### PR TITLE
Adopt Skinnable prop

### DIFF
--- a/Popup/Popup.js
+++ b/Popup/Popup.js
@@ -8,14 +8,13 @@ import Layout, {Cell} from '@enact/ui/Layout';
 import Slottable from '@enact/ui/Slottable';
 import Transition from '@enact/ui/Transition';
 
-import Skinnable, {SkinContext} from '../Skinnable';
+import Skinnable from '../Skinnable';
 import Divider from '../Divider';
 import Button from '../Button';
 
 import componentCss from './Popup.less';
 
 const forwardHide = forward('onHide');
-// const SkinContext = React.createContext(null);
 
 const PopupBase = kind({
 	name: 'Popup',
@@ -40,51 +39,39 @@ const PopupBase = kind({
 	computed: {
 		className: ({closeButton, title, styler}) => styler.append({withCloseButton: closeButton, withTitle: title})
 	},
-	render: ({buttons, children, closeButton, css, noAnimation, onCloseButtonClick, onHide, open, title, ...rest}) => {
-		// delete rest.onCloseButtonClick;
+	render: ({buttons, children, closeButton, css, noAnimation, onCloseButtonClick, onHide, open, skin, title, ...rest}) => {
+		const wideLayout = (skin === 'carbon');
+
 		return (
-			<SkinContext.Consumer>
-				{(skin) => {
-					// const effectiveSkin = determineSkin(skin, parentSkin);
-					// console.log('popup context:', skin);
-
-					const wideLayout = (skin === 'carbon');
-
-					// <SkinContext.Provider value={skin}>
-					return (
-						<Transition
-							noAnimation={noAnimation}
-							visible={open}
-							direction="down"
-							duration="short"
-							type="fade"
-							className={css.popupTransitionContainer}
-							onHide={onHide}
-						>
-							<div
-								{...rest}
-							>
-								{closeButton ? <Button
-									icon="closex"
-									small
-									onTap={onCloseButtonClick}
-									className={componentCss.closeButton}
-								/> : null}
-								{title ? <Divider className={css.title}>{title}</Divider> : null}
-								<Layout orientation={wideLayout ? 'horizontal' : 'vertical'} className={css.body}>
-									<Cell shrink={!wideLayout} className={css.content}>
-										{children}
-									</Cell>
-									{buttons ? <Cell shrink className={css.buttons}>
-										{buttons}
-									</Cell> : null}
-								</Layout>
-							</div>
-						</Transition>
-					);
-					// </SkinContext.Provider>
-				}}
-			</SkinContext.Consumer>
+			<Transition
+				noAnimation={noAnimation}
+				visible={open}
+				direction="down"
+				duration="short"
+				type="fade"
+				className={css.popupTransitionContainer}
+				onHide={onHide}
+			>
+				<div
+					{...rest}
+				>
+					{closeButton ? <Button
+						icon="closex"
+						small
+						onTap={onCloseButtonClick}
+						className={componentCss.closeButton}
+					/> : null}
+					{title ? <Divider className={css.title}>{title}</Divider> : null}
+					<Layout orientation={wideLayout ? 'horizontal' : 'vertical'} className={css.body}>
+						<Cell shrink={!wideLayout} className={css.content}>
+							{children}
+						</Cell>
+						{buttons ? <Cell shrink className={css.buttons}>
+							{buttons}
+						</Cell> : null}
+					</Layout>
+				</div>
+			</Transition>
 		);
 	}
 });
@@ -100,7 +87,7 @@ const PopupBase = kind({
 
 const PopupDecorator = compose(
 	Slottable({slots: ['closeButton', 'title', 'buttons']}),
-	Skinnable
+	Skinnable({prop: 'skin'})
 );
 
 class PopupState extends React.Component {

--- a/Skinnable/Skinnable.js
+++ b/Skinnable/Skinnable.js
@@ -6,7 +6,7 @@
  */
 
 import hoc from '@enact/core/hoc';
-import SkinnableBase, {SkinContext} from '@enact/ui/Skinnable';
+import UiSkinnable from '@enact/ui/Skinnable';
 
 const defaultConfig = {
 	skins: {
@@ -26,7 +26,7 @@ const defaultConfig = {
  * @hoc
  * @public
  */
-const Skinnable = hoc(defaultConfig, SkinnableBase);
+const Skinnable = hoc(defaultConfig, UiSkinnable);
 
 /**
  * Select a skin by name by specifying this property. This may be changed at runtime. All components
@@ -48,6 +48,5 @@ const Skinnable = hoc(defaultConfig, SkinnableBase);
 
 export default Skinnable;
 export {
-	Skinnable,
-	SkinContext
+	Skinnable
 };


### PR DESCRIPTION
I added a config option to `ui/Skinnable` to allow it to pass the skin down to its Wrapped component rather than using `SkinContext` which is more complicated.

This PR adopts that prop for `agate/Popup`

Signed-off-by: Ryan Duffy <ryan.duffy@lge.com>