### PR TITLE
Refactor agate/Picker

### DIFF
--- a/Picker/Picker.less
+++ b/Picker/Picker.less
@@ -18,7 +18,7 @@
 		width: 100%;
 		text-align: center;
 
-		&.currentIndex {
+		&.active {
 			font-size: 36px;
 		}
 	}
@@ -28,8 +28,12 @@
 			height: @agate-button-height;
 			line-height: @agate-button-height;
 
-			&.currentIndex {
+			&.active {
 				background-color: @agate-sliderbutton-bg-color;
+			}
+
+			&[disabled] {
+				.vendor-opacity(0.6);
 			}
 		}
 	});


### PR DESCRIPTION
Fixes #49 

## Issue
> When trying to use Picker with outside services it didn't update easily. Now we adjusted it to be able to getDerivedStateFromProps. This allows us to still use the Picker logic and allow outside apps to handle it easily. This works fine so far, but there could be some better ways to implement this logic.
>
> We may want to come up with a breakdown between PickerBase and Picker that we see in Moonstone. Maybe what we have now is a good middle ground, but I'm sure other components with trickier states may run into similar problems so we should come up with a more standard solution.

## Resolution
* Refactor into a kind and use `ui/Changeable` to manage the state
* Change "value" prop from `index` to `value` for better intra-framework consistency

## Additional Considerations
I removed the manual spotlight handling and updated the `.item` elements to support the `disabled` state when focused. I think this is reasonable particularly in touch environments where the focused state is only temporary. We should make a broader decision about how we want to handle focused + disabled in `agate` even if that decision is the same as `moonstone`.
