### PR TITLE
Fix 5-way selection support for LabeledIconButton

### DIFF
--- a/Button/Button.less
+++ b/Button/Button.less
@@ -92,8 +92,12 @@
 				color: @agate-button-focus-color;
 			}
 		}
+	});
 
-		.focus({
+	// .focus({}), and .focus({}, parent) ...
+	&:global(.spottable):focus,
+	:global(.spottable):focus & {
+		.applySkins({
 			background-color: transparent;
 			background-image: none;
 
@@ -113,5 +117,5 @@
 				}
 			}
 		});
-	});
+	}
 }

--- a/Button/Button.less
+++ b/Button/Button.less
@@ -94,7 +94,8 @@
 		}
 	});
 
-	// .focus({}), and .focus({}, parent) ...
+	// TODO: Replace with an updated .focus() mixin that can apply rules both when focused and
+	// within a focused node
 	&:global(.spottable):focus,
 	:global(.spottable):focus & {
 		.applySkins({

--- a/LabeledIconButton/LabeledIconButton.js
+++ b/LabeledIconButton/LabeledIconButton.js
@@ -68,7 +68,7 @@ const LabeledIconButtonBase = kind({
 		return UiLabeledIcon.inline({
 			...rest,
 			icon: (
-				<Button selected={selected} icon={icon} className={css.button} />
+				<Button selected={selected} icon={icon} />
 			),
 			css
 		});

--- a/LabeledIconButton/LabeledIconButton.js
+++ b/LabeledIconButton/LabeledIconButton.js
@@ -1,22 +1,14 @@
 import kind from '@enact/core/kind';
-import Spottable from '@enact/spotlight/Spottable';
-import {ButtonDecorator as UiButtonDecorator} from '@enact/ui/Button';
 import UiLabeledIcon from '@enact/ui/LabeledIcon';
-import Pure from '@enact/ui/internal/Pure';
 import PropTypes from 'prop-types';
-import compose from 'ramda/src/compose';
 import React from 'react';
 
-import {ButtonBase} from '../Button';
+import {ButtonBase, ButtonDecorator} from '../Button';
 import Skinnable from '../Skinnable';
 
 import componentCss from './LabeledIconButton.less';
 
-const Button = compose(
-	UiButtonDecorator,
-	Spottable,
-	Skinnable
-)(ButtonBase);
+const Button = Skinnable(ButtonBase);
 
 /**
  * An icon button component with a label.
@@ -76,7 +68,7 @@ const LabeledIconButtonBase = kind({
 		return UiLabeledIcon.inline({
 			...rest,
 			icon: (
-				<Button selected={selected} icon={icon} />
+				<Button selected={selected} icon={icon} className={css.button} />
 			),
 			css
 		});
@@ -91,10 +83,7 @@ const LabeledIconButtonBase = kind({
  * @mixes agate/Skinnable.Skinnable
  * @public
  */
-const LabeledIconButtonDecorator = compose(
-	Pure,
-	Skinnable
-);
+const LabeledIconButtonDecorator = ButtonDecorator;
 
 /**
  * A Agate-styled icon button component with a label.

--- a/LabeledIconButton/LabeledIconButton.less
+++ b/LabeledIconButton/LabeledIconButton.less
@@ -10,8 +10,8 @@
 .labeledIconButton {
     .icon,
     .label,
-    &.selected,
-    &.small {
+    .selected,
+    .small {
         /* Public Class Names */
     }
 

--- a/LabeledIconButton/LabeledIconButton.less
+++ b/LabeledIconButton/LabeledIconButton.less
@@ -8,10 +8,10 @@
 @import '../LabeledIcon/LabeledIcon.less';
 
 .labeledIconButton {
-    .icon,
-    .label,
-    .selected,
-    .small {
+    &.icon,
+    &.label,
+    &.selected,
+    &.small {
         /* Public Class Names */
     }
 

--- a/LabeledIconButton/LabeledIconButton.less
+++ b/LabeledIconButton/LabeledIconButton.less
@@ -1,14 +1,27 @@
 // LabeledIconButton.less
 //
 
+@import "../styles/mixins.less";
+@import '../styles/skin.less';
+
 // This refers to the LabeledIcon styling, since they're the same.
 @import '../LabeledIcon/LabeledIcon.less';
 
 .labeledIconButton {
-    &.icon,
-    &.label,
+    .icon,
+    .label,
     &.selected,
     &.small {
         /* Public Class Names */
     }
+
+    .applySkins({
+        .focus({
+            background: transparent;
+
+            .label {
+                color: @agate-accent;
+            }
+        });
+    });
 }


### PR DESCRIPTION
## Issue
`onClick` handlers attached to `<LabeledIconButton>` do not fire when 5-way selected

## Resolution
* Move Spottable up to the root so it can correctly emulate `onClick` for Enter
* Also move the `agate/Button.ButtonDecorator` to the top so Touchable events can be attached
* Broaden the styling rules for `agate/Button` to show its focus rules when spotted or when within a spotted node.

## Additional Considerations
Will need to fix up the Button ruleset when we land an improve mixin in `@enact/spotlight`

Fixes enactjs/agate-apps#30
Supercedes #52 and enactjs/agate-apps#37