### PR TITLE
Added drag and drop rearrangeable support with 2 new hocs

### DIFF
--- a/DropManager/DropManager.js
+++ b/DropManager/DropManager.js
@@ -1,0 +1,175 @@
+import hoc from '@enact/core/hoc';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import {compose, setDisplayName} from 'recompose';
+import React from 'react';
+import Changeable from '@enact/ui/Changeable';
+
+import css from './DropManager.less';
+
+// https://stackoverflow.com/questions/9907419/how-to-get-a-key-in-a-javascript-object-by-its-value
+// By: ZER0 - Mar 28 '12 at 12:51
+const getKeyByValue = (obj, value) =>
+	Object.keys(obj).find(key => obj[key] === value);
+
+const DropManagerBase = hoc((configHoc, Wrapped) => {
+	return class extends React.Component {
+		static displayName = 'DropManager';
+
+		static propTypes = {
+			arrangement: PropTypes.object,
+			onArrange: PropTypes.func
+		};
+
+		state = {
+			arrangement: this.props.arrangement || {},
+			dragging: false
+		};
+
+		addDropTarget = (target) => {
+			target.classList.add('dropTarget');
+		};
+
+		removeDropTarget = (target) => {
+			target.classList.remove('dropTarget');
+		};
+
+
+		handleDragStart = (ev) => {
+			// ev.dataTransfer.setData('text/plain', ev.target.dataset.slot);
+			ev.dataTransfer.effectAllowed = 'move';
+			this.dragOriginNode = ev.target;
+			this.setState({dragging: true});
+		};
+
+		handleDragEnter = (ev) => {
+			this.addDropTarget(ev.target);
+		};
+
+		handleDragLeave = (ev) => {
+			this.removeDropTarget(ev.target);
+		};
+
+		handleDragOver = (ev) => {
+			ev.preventDefault();
+			// Set the dropEffect to move
+			ev.dataTransfer.dropEffect = 'move';
+		};
+
+		handleDrop = (ev) => {
+			ev.preventDefault();
+
+			// Bail early if the drag started from some unknown location.
+			if (!this.dragOriginNode) {
+				this.setState({dragging: false});
+				return;
+			}
+
+			// Get the id of the target and add the moved element to the target's DOM
+			// const dragOrigin = ev.dataTransfer.getData('text/plain');
+			const dragOrigin = this.dragOriginNode.dataset.slot;
+
+			let dragDropNode;
+			// If we dropped directly on an element with a slot defined, just use that directly
+			if (ev.target.dataset.slot) {
+				dragDropNode = ev.target;
+			} else {
+				// If we dropped on a child of a slotted element (like an icon or a div or other
+				// nested component), find the closest ancestor with a slot and use that as the drop element.
+				const closestSlot = ev.target.closest('[data-slot]');
+				if (closestSlot && closestSlot.dataset.slot) {
+					dragDropNode = closestSlot;
+				} else {
+					// We didn't actually find anything, just bail out. The component was dropped in
+					// a place that is unknown.
+					this.setState({dragging: false});
+					return;
+				}
+			}
+
+			this.removeDropTarget(dragDropNode);
+
+			// Get the destination element's slot value, or find its ancestor that has one (in case we drop this on a child or grandchild of the slotted item).
+			// const dragDestination = ev.target.dataset.slot || (ev.target.closest('[data-slot]') && ev.target.closest('[data-slot]').dataset.slot);
+			const dragDestination = dragDropNode.dataset.slot;
+
+			// If the dragged element was dropped back on itself, do nothing and exit.
+			if (dragDestination === dragOrigin) {
+				this.setState({dragging: false});
+				return;
+			}
+
+			// ev.dataTransfer.clearData();
+
+			this.dragOriginNode.dataset.slot = dragDestination;
+			dragDropNode.dataset.slot = dragOrigin;
+
+			// console.log('from:', dragOrigin, 'to:', dragDestination);
+
+			// We successfully completed the drag, blank-out the node.
+			this.dragOriginNode = null;
+
+			this.setState(({arrangement}) => {
+				const oldD = getKeyByValue(arrangement, dragDestination);
+				const oldO = getKeyByValue(arrangement, dragOrigin);
+
+				arrangement[oldD || dragDestination] = dragOrigin;
+				arrangement[oldO || dragOrigin] = dragDestination;
+
+				return {dragging: false, arrangement};
+			});
+		};
+
+		handleDragEnd = () => {
+			if (this.props.onArrange) {
+				this.props.onArrange({arrangement: this.state.arrangement});
+			}
+		};
+
+		render () {
+			const {className, ...rest} = {...this.props};
+			delete rest.onArrange;
+			// console.log('slots:', rest);
+
+			return (
+				<Wrapped
+					{...rest}
+					className={classnames(className, css.dropManager, {dragging: this.state.dragging})}
+					arrangement={this.state.arrangement}
+					arranging={this.state.dragging}
+					// draggable="true"
+					onDragStart={this.handleDragStart}
+					onDragEnter={this.handleDragEnter}
+					onDragLeave={this.handleDragLeave}
+					onDragOver={this.handleDragOver}
+					onDrop={this.handleDrop}
+					onDragEnd={this.handleDragEnd}
+				/>
+			);
+		}
+	};
+});
+
+const DropManager = compose(
+	Changeable({prop: 'arrangement'}),
+	DropManagerBase
+);
+
+const Draggable = (Wrapped) => setDisplayName('Draggable')(
+	// ({arrangement, name, ...rest}) => <Wrapped {...rest} data-slot={arrangement && arrangement[name] || name} draggable="true" />
+	// If something is marked explicitly as *not* draggable (everything using this is normally)
+	// don't assign it a data-slot, so it can't be dragged(A) or dropped on(B).
+	({arrangement, draggable = true, name, slot, ...rest}) =>
+		<Wrapped
+			{...rest}
+			draggable={draggable}
+			data-slot={draggable ? (arrangement && (arrangement[name] || arrangement[slot]) || (name || slot)) : null}
+			data-slot-name={slot}
+		/>
+);
+
+export default DropManager;
+export {
+	DropManager,
+	Draggable
+};

--- a/DropManager/DropManager.js
+++ b/DropManager/DropManager.js
@@ -12,7 +12,19 @@ import css from './DropManager.less';
 const getKeyByValue = (obj, value) =>
 	Object.keys(obj).find(key => obj[key] === value);
 
-const DropManagerBase = hoc((configHoc, Wrapped) => {
+
+const defaultConfig = {
+	// The prop name for the boolean send to the Wrapped component that indicates whether we are
+	// currently arranging things. Useful in case we need to show some boxes on the screen or
+	// something. The default/common value for this is "arranging".
+	arrangingProp: null,
+
+	// The prop name for the object sent to the Wrapped component containing the arrangement object.
+	// This will typically directly feed into Rearrangeable.
+	arrangementProp: 'arrangement'
+};
+
+const DropManagerBase = hoc(defaultConfig, (configHoc, Wrapped) => {
 	return class extends React.Component {
 		static displayName = 'DropManager';
 
@@ -129,14 +141,15 @@ const DropManagerBase = hoc((configHoc, Wrapped) => {
 		render () {
 			const {className, ...rest} = {...this.props};
 			delete rest.onArrange;
+
+			if (configHoc.arrangingProp) rest[configHoc.arrangingProp] = this.state.dragging;
+			if (configHoc.arrangementProp) rest[configHoc.arrangementProp] = this.state.arrangement;
 			// console.log('slots:', rest);
 
 			return (
 				<Wrapped
 					{...rest}
 					className={classnames(className, css.dropManager, {dragging: this.state.dragging})}
-					arrangement={this.state.arrangement}
-					arranging={this.state.dragging}
 					// draggable="true"
 					onDragStart={this.handleDragStart}
 					onDragEnter={this.handleDragEnter}

--- a/DropManager/DropManager.less
+++ b/DropManager/DropManager.less
@@ -1,0 +1,55 @@
+// DropManager.less
+//
+
+@import "~@enact/agate/styles/mixins.less";
+
+.dropManager {
+	*[draggable=true] {
+		overflow: hidden;
+	}
+
+	*[data-slot] {
+
+		&::after {
+			content: "";
+			display: none;
+			position: absolute;
+			.position(6px);
+			border: 1px dashed fade(gray, 50%);
+			border-radius: 12px;
+			background-color: fade(white, 10%);
+		}
+	}
+
+	&:global(.dragging) *[data-slot] {
+		min-height: 30px;
+		min-width: 30px;
+
+		&::after {
+			display: block;
+		}
+
+		&:global(.dropTarget) {
+			&::after {
+				display: block;
+				border-width: 6px;
+			}
+		}
+	}
+
+
+	&:global(.debug.drag) {
+		*[data-slot]::before {
+			content: "slot=" attr(data-slot);
+			display: block;
+			// position: absolute;
+			border: 1px solid lime;
+			color: lime;
+			padding: 0 0.3em;
+			margin: 0.3em;
+			line-height: 1.5em;
+			font-size: 60%;
+			background-color: fade(black, 30%);
+		}
+	}
+}

--- a/DropManager/package.json
+++ b/DropManager/package.json
@@ -1,0 +1,3 @@
+{
+	"main": "DropManager.js"
+}

--- a/Rearrangeable/Rearrangeable.js
+++ b/Rearrangeable/Rearrangeable.js
@@ -1,0 +1,69 @@
+import kind from '@enact/core/kind';
+import hoc from '@enact/core/hoc';
+import React from 'react';
+
+const propRemapper = (slotNames, props) => {
+	if (!props.arrangement) return props;
+
+	const origRest = {...props};
+
+	slotNames.forEach(prop => {
+		if (props.arrangement[prop] && props.arrangement[prop] !== prop) {
+			// If there is a new destination for a prop, assign it there... sourceProp -> destinationProp
+			props[prop] = origRest[props.arrangement[prop]];
+		}
+	});
+	return props;
+};
+
+/**
+ * A hoc to remap props to different props. Provide an `arrangement` prop which is a map of keys
+ * relating to destination prop names and values related to the props to send to the key.
+ *
+ * In the `config` for this HOC, provide a `slots` key which is set to an array listing any prop
+ * names you intend to be remappable. For example, if your component has the following props:
+ * `dayOne`, `dayTwo`, and `dayThree`, and you only want `dayOne` and `dayTwo` to have the
+ * capability to be swapped or reassigned, the config and array should look like the following:
+ *
+ * ```
+ * {slots: [`dayOne`, `dayTwo`]}
+ * ```
+ *
+ * Now the this HOC is configured, it can act on the `arrangement` prop supplied at runtime.
+ * Any slots provided in the config can be reassigned in the arrangement mapping. To extend our
+ * above example, the incoming props being the following:
+ *
+ * ```
+ * const RearrangeableComponent = Rearrangeable({slots: [`dayOne`, `dayTwo`]}, Component);
+ *
+ * <RearrangeableComponent dayOne="swimming" dayTwo="hiking" />
+ * // The generated output from the above would be:
+ * // <Component dayOne="swimming" dayTwo="hiking" />
+ *
+ * // Now with an arragement prop filled-in,
+ * <RearrangeableComponent dayOne="swimming" dayTwo="hiking" arrangement={{dayOne: 'dayTwo', dayTwo: 'dayOne'}} />
+ *
+ * // The generated output from the above would be:
+ * // <Component dayOne="hiking" dayTwo="swimming" />
+ * ```
+ *
+ * @param  {Object} (config, Wrapped)      accepts a single key (`slots`)
+ *
+ * @return {Component}
+ */
+const Rearrangeable = hoc((config, Wrapped) => kind({
+	name: 'Rearrangeable',
+	render: (props) => {
+		props = propRemapper(config.slots, props);
+		// delete rest.arrangement;
+		return (
+			<Wrapped {...props} />
+		);
+	}
+}));
+
+export default Rearrangeable;
+export {
+	Rearrangeable,
+	propRemapper
+};

--- a/Rearrangeable/package.json
+++ b/Rearrangeable/package.json
@@ -1,0 +1,3 @@
+{
+	"main": "Rearrangeable.js"
+}


### PR DESCRIPTION
These two components enable dragging and dropping of rearrangeable interfaces.

Below is an example of the usage:
```
const allSlotNames = ['bottom', 'children', 'top', 'left', 'right'];

const CustomLayout = DropManager(
	// Don't provide the "children" slot to Slottable
	Slottable({slots: allSlotNames.filter(slot => slot !== 'children')},
		Rearrangeable({slots: allSlotNames},
			CustomLayoutBase
		)
	)
);
```
Here, `DropManager` facilitates the movement of the slots and informs `Rearrangeable` of the new structure. `Rearrangeable` takes the slot prop values from `Slottable` and remaps them to their new destinations (provided by `DropManager`, via the `arrangement` prop) and supplies those to the wrapped component (`CustomLayout` in this case), which needs no special knowledge of dragging or being rearranged.