### PR TITLE
Feature/expandable color picker

### DIFF
--- a/ColorPicker/ColorPicker.js
+++ b/ColorPicker/ColorPicker.js
@@ -41,13 +41,15 @@ const ColorPickerBase = kind({
 	name: 'ColorPicker',
 
 	propTypes: /** @lends agate/ColorPicker.ColorPickerBase.prototype */ {
+		children: PropTypes.array,
+
 		/**
 		 * Customizes the component by mapping the supplied collection of CSS class names to the
 		 * corresponding internal Elements and states of this component.
 		 *
 		 * The following classes are supported:
 		 *
-		 * * `expandableColorPicker` - The root class name
+		 * * `colorPicker` - The root class name
 		 * * `swatchDrawer` - The drawer that displays all the available options for color.
 		 *
 		 * @type {Object}
@@ -113,7 +115,7 @@ const ColorPickerBase = kind({
 	},
 
 	computed: {
-		transitionContainerClassname: ({css, open}) => open ? `${css.transitionContainer} ${css.openTransitionContainer}` : css.transitionContainer,
+		transitionContainerClassname: ({css, open, styler}) => styler.join(css.transitionContainer, (open ? css.openTransitionContainer : null)),
 		transitionDirection: ({direction}) => {
 			switch (direction) {
 				case 'left':
@@ -139,10 +141,11 @@ const ColorPickerBase = kind({
 				>
 					<div className={css.swatchDrawer}>
 						<Group
+							className={css.group}
 							childComponent={SwatchButton}
 							itemProps={{small: true}}
 							onSelect={onChange}
-						>{children}</Group>
+						>{children || []}</Group>
 					</div>
 				</Transition>
 			</div>

--- a/ColorPicker/ColorPicker.less
+++ b/ColorPicker/ColorPicker.less
@@ -1,4 +1,4 @@
-// ExpandableColorPicker.less
+// ColorPicker.less
 //;
 @import "../styles/mixins.less";
 @import "../styles/skin.less";
@@ -21,7 +21,7 @@
 
 	.applySkins({
 		.swatchDrawer {
-			background-color: rgba(0, 0, 0, 0.5);
+			background-color: @agate-colorpicker-bg-color;
 			border-radius: @agate-colorpicker-swatch-border-radius;
 		}
 	});

--- a/ColorPicker/ColorPicker.less
+++ b/ColorPicker/ColorPicker.less
@@ -19,10 +19,14 @@
 		}
 	}
 
+	.group {
+		display: block;
+	}
+
 	.applySkins({
 		.swatchDrawer {
 			background-color: @agate-colorpicker-bg-color;
-			border-radius: @agate-colorpicker-swatch-border-radius;
+			border-radius: @agate-colorpicker-swatchdrawer-border-radius;
 		}
 	});
 }

--- a/ColorPicker/ColorPicker.less
+++ b/ColorPicker/ColorPicker.less
@@ -1,37 +1,28 @@
-// Divider.less
+// ExpandableColorPicker.less
 //;
 @import "../styles/mixins.less";
 @import "../styles/skin.less";
 
 .colorPicker {
+	// position: relative;
+	display: inline-block;
+	vertical-align: inherit;
+
+	.transitionContainer {
+		position: absolute;
+		display: inline-block;
+		z-index: 1;
+		pointer-events: none;
+
+		&.openTransitionContainer {
+			pointer-events: inherit;
+		}
+	}
+
 	.applySkins({
-		&,
-		&.small {
-			padding: 0;
-		}
-
-		// ColorPicker's Button bg style reset
-		.bg {
+		.swatchDrawer {
+			background-color: rgba(0, 0, 0, 0.5);
 			border-radius: @agate-colorpicker-swatch-border-radius;
-			transform: @agate-colorpicker-bg-transform;
-		}
-
-		.colorSwatch,
-		.colorInput {
-			position: absolute;
-			.position(0);
-			border-radius: @agate-colorpicker-swatch-border-radius;
-		}
-
-		.colorSwatch {
-			margin: @agate-colorpicker-swatch-spacing;
-		}
-
-		.colorInput {
-			padding: 0;
-			width: 100%;
-			height: 100%;
-			opacity: 0;
 		}
 	});
 }

--- a/ColorPicker/SwatchButton.js
+++ b/ColorPicker/SwatchButton.js
@@ -38,6 +38,16 @@ const SwatchButtonBase = kind({
 
 	propTypes: /** @lends agate/SwatchButton.SwatchButtonBase.prototype */ {
 		/**
+		 * The color of the swatch. If the `color` prop is not set.
+		 *
+		 * The value should take the format of a HEX color. Ex: `#ffcc00` or `#3467af`
+		 *
+		 * @type {String}
+		 * @public
+		 */
+		children: PropTypes.string,
+
+		/**
 		 * The color of the swatch.
 		 *
 		 * The value should take the format of a HEX color. Ex: `#ffcc00` or `#3467af`
@@ -80,7 +90,7 @@ const SwatchButtonBase = kind({
 	handlers: {
 		onClick: (ev, {children, color, onClick}) => {
 			if (onClick) {
-				onClick({color: color ? color : children});
+				onClick({color: color || children});
 			}
 		}
 	},

--- a/ColorPicker/SwatchButton.js
+++ b/ColorPicker/SwatchButton.js
@@ -1,0 +1,134 @@
+/**
+ * Agate component to allow the user to choose a color.
+ *
+ * @example
+ * <SwatchButton color="#ffcc00" onClick={handleClick} />
+ *
+ * @module agate/SwatchButton
+ * @exports SwatchButton
+ * @exports SwatchButtonBase
+ * @exports SwatchButtonDecorator
+ */
+
+import kind from '@enact/core/kind';
+
+import PropTypes from 'prop-types';
+import compose from 'ramda/src/compose';
+import React from 'react';
+
+import {ButtonBase, ButtonDecorator} from '../Button';
+import Skinnable from '../Skinnable';
+
+import componentCss from './SwatchButton.less';
+
+
+/**
+ * The color picker base component which sets-up the component's structure.
+ *
+ * This component is most often not used directly but may be composed within another component as it
+ * is within [SwatchButton]{@link agate/SwatchButton.SwatchButton}.
+ *
+ * @class SwatchButtonBase
+ * @memberof agate/SwatchButton
+ * @ui
+ * @public
+ */
+const SwatchButtonBase = kind({
+	name: 'SwatchButton',
+
+	propTypes: /** @lends agate/SwatchButton.SwatchButtonBase.prototype */ {
+		/**
+		 * The color of the swatch.
+		 *
+		 * The value should take the format of a HEX color. Ex: `#ffcc00` or `#3467af`
+		 *
+		 * @type {String}
+		 * @public
+		 */
+		color: PropTypes.string,
+
+		/**
+		 * Customizes the component by mapping the supplied collection of CSS class names to the
+		 * corresponding internal Elements and states of this component.
+		 *
+		 * The following classes are supported:
+		 *
+		 * * `colorPicker` - The root class name
+		 * * `colorSwatch` - The node that displays the chosen color. The current value is applied
+		 * 		as a background-color to this element.
+		 *
+		 * @type {Object}
+		 * @public
+		 */
+		css: PropTypes.object,
+
+		/**
+		 * Callback method with a payload containing the `value` that was just selected.
+		 *
+		 * @type {Function}
+		 * @public
+		 */
+		onClick: PropTypes.func
+	},
+
+	styles: {
+		css: componentCss,
+		className: 'swatchButton',
+		publicClassNames: ['swatchButton', 'colorSwatch']
+	},
+
+	handlers: {
+		onClick: (ev, {children, color, onClick}) => {
+			if (onClick) {
+				onClick({color: color ? color : children});
+			}
+		}
+	},
+
+	computed: {
+		colorSwatchStyle: ({children, color}) => ({backgroundColor: color ? color : children})
+	},
+
+	render: ({colorSwatchStyle, css, ...rest}) => {
+		return (
+			<ButtonBase {...rest} css={css} minWidth={false}>
+				<div className={css.colorSwatch} style={colorSwatchStyle} />
+			</ButtonBase>
+		);
+	}
+});
+
+/**
+ * Applies Agate specific behaviors to [SwatchButtonBase]{@link agate/SwatchButton.SwatchButtonBase}.
+ *
+ * @hoc
+ * @memberof agate/SwatchButton
+ * @mixes agate/Skinnable.Skinnable
+ * @public
+ */
+
+const SwatchButtonDecorator = compose(
+	ButtonDecorator,
+	Skinnable
+);
+
+/**
+ * A color picker component, ready to use in Agate applications.
+ *
+ * @class SwatchButton
+ * @memberof agate/SwatchButton
+ * @extends agate/SwatchButton.SwatchButtonBase
+ * @mixes agate/Button.ButtonDecorator
+ * @mixes ui/Changeable.Changeable
+ * @mixes agate/Skinnable.Skinnable
+ * @ui
+ * @public
+ */
+const SwatchButton = SwatchButtonDecorator(SwatchButtonBase);
+
+export default SwatchButton;
+export {
+	SwatchButton,
+	SwatchButtonBase,
+	SwatchButtonDecorator
+};

--- a/ColorPicker/SwatchButton.less
+++ b/ColorPicker/SwatchButton.less
@@ -22,7 +22,8 @@
 		.colorSwatch {
 			position: absolute;
 			.position(0);
-			border-radius: @agate-colorpicker-swatch-border-radius;
+			border-radius: @agate-colorpicker-swatchcolor-border-radius;
+			transform: @agate-colorpicker-bg-transform;
 		}
 
 		.colorSwatch {

--- a/ColorPicker/SwatchButton.less
+++ b/ColorPicker/SwatchButton.less
@@ -1,0 +1,32 @@
+// SwatchButton.less
+//;
+@import "../styles/mixins.less";
+@import "../styles/skin.less";
+
+.swatchButton {
+	.applySkins({
+		margin: 10px;
+		vertical-align: inherit;
+
+		&,
+		&.small {
+			padding: 0;
+		}
+
+		// ColorPicker's Button bg style reset
+		.bg {
+			border-radius: @agate-colorpicker-swatch-border-radius;
+			transform: @agate-colorpicker-bg-transform;
+		}
+
+		.colorSwatch {
+			position: absolute;
+			.position(0);
+			border-radius: @agate-colorpicker-swatch-border-radius;
+		}
+
+		.colorSwatch {
+			margin: @agate-colorpicker-swatch-spacing;
+		}
+	});
+}

--- a/ColorPicker/SwatchButton.less
+++ b/ColorPicker/SwatchButton.less
@@ -5,7 +5,7 @@
 
 .swatchButton {
 	.applySkins({
-		margin: 10px;
+		margin: @agate-colorpicker-swatch-margin;
 		vertical-align: inherit;
 
 		&,
@@ -26,7 +26,7 @@
 		}
 
 		.colorSwatch {
-			margin: @agate-colorpicker-swatch-spacing;
+			margin: (@agate-colorpicker-swatch-margin / 2);
 		}
 	});
 }

--- a/styles/colors-carbon.less
+++ b/styles/colors-carbon.less
@@ -50,6 +50,10 @@
 @agate-button-highlighted-bg-color: @agate-background-focus;
 @agate-button-highlighted-bg-image: @agate-gradient;
 
+// ColorPicker
+// ---------------------------------------
+@agate-colorpicker-bg-color: rgba(0, 0, 0, 0.5);
+
 // Divider
 // ---------------------------------------
 @agate-divider-color:        @agate-text-color;

--- a/styles/colors-electro.less
+++ b/styles/colors-electro.less
@@ -62,6 +62,10 @@
 @agate-button-highlighted-bg-color: @agate-highlight;
 @agate-button-highlighted-bg-image: @electro-highlight-gradient;
 
+// ColorPicker
+// ---------------------------------------
+@agate-colorpicker-bg-color: rgba(0, 0, 0, 0.5);
+
 // Divider
 // ---------------------------------------
 @agate-divider-color:        @agate-text-color;

--- a/styles/colors-titanium.less
+++ b/styles/colors-titanium.less
@@ -49,6 +49,10 @@
 @agate-button-highlighted-bg-color: @agate-background-focus;
 @agate-button-highlighted-bg-image: none;
 
+// ColorPicker
+// ---------------------------------------
+@agate-colorpicker-bg-color: rgba(0, 0, 0, 0.5);
+
 // Divider
 // ---------------------------------------
 @agate-divider-color:        @agate-text-color;

--- a/styles/variables-carbon.less
+++ b/styles/variables-carbon.less
@@ -32,6 +32,8 @@
 // ColorPicker
 // ---------------------------------------
 @agate-colorpicker-swatch-border-radius: 999px;
+@agate-colorpicker-swatchcolor-border-radius: @agate-colorpicker-swatch-border-radius;
+@agate-colorpicker-swatchdrawer-border-radius: @agate-button-height;
 @agate-colorpicker-swatch-margin: 12px;
 @agate-colorpicker-bg-transform: none;
 

--- a/styles/variables-carbon.less
+++ b/styles/variables-carbon.less
@@ -32,7 +32,7 @@
 // ColorPicker
 // ---------------------------------------
 @agate-colorpicker-swatch-border-radius: 999px;
-@agate-colorpicker-swatch-spacing: 6px;
+@agate-colorpicker-swatch-margin: 12px;
 @agate-colorpicker-bg-transform: none;
 
 // DateTimePicker

--- a/styles/variables-electro.less
+++ b/styles/variables-electro.less
@@ -37,7 +37,7 @@
 // ColorPicker
 // ---------------------------------------
 @agate-colorpicker-swatch-border-radius: 999px;
-@agate-colorpicker-swatch-spacing: 6px;
+@agate-colorpicker-swatch-margin: 12px;
 @agate-colorpicker-bg-transform: skewX(0);
 
 // DateTimePicker

--- a/styles/variables-electro.less
+++ b/styles/variables-electro.less
@@ -36,9 +36,11 @@
 
 // ColorPicker
 // ---------------------------------------
-@agate-colorpicker-swatch-border-radius: 999px;
+@agate-colorpicker-swatch-border-radius: @electro-border-radius;
+@agate-colorpicker-swatchcolor-border-radius: 12px;
+@agate-colorpicker-swatchdrawer-border-radius: @electro-border-radius;
 @agate-colorpicker-swatch-margin: 12px;
-@agate-colorpicker-bg-transform: skewX(0);
+@agate-colorpicker-bg-transform: skewX(@electro-skew);
 
 // DateTimePicker
 // ---------------------------------------

--- a/styles/variables-titanium.less
+++ b/styles/variables-titanium.less
@@ -32,6 +32,8 @@
 // ColorPicker
 // ---------------------------------------
 @agate-colorpicker-swatch-border-radius: 999px;
+@agate-colorpicker-swatchcolor-border-radius: @agate-colorpicker-swatch-border-radius;
+@agate-colorpicker-swatchdrawer-border-radius: @agate-button-height;
 @agate-colorpicker-swatch-margin: 12px;
 @agate-colorpicker-bg-transform: none;
 

--- a/styles/variables-titanium.less
+++ b/styles/variables-titanium.less
@@ -32,7 +32,7 @@
 // ColorPicker
 // ---------------------------------------
 @agate-colorpicker-swatch-border-radius: 999px;
-@agate-colorpicker-swatch-spacing: 6px;
+@agate-colorpicker-swatch-margin: 12px;
 @agate-colorpicker-bg-transform: none;
 
 // DateTimePicker


### PR DESCRIPTION
ColorPicker with an expandable drawer.
Usage example:
```
<ColorPicker defaultValue="#ffcc00" onChange={handleChange}>
  {['#fff', '#999', '#000', 'red', 'blue', 'green']}
</ColorPicker>
```

Consideration:
It is possible to implement the drawer like `Tooltip` for better positioning configurations, but it adds another level of complexity so it can be added later when needed. For now, `swatchDrawer` can be customized through `css` prop.

![colopickerdemo](https://user-images.githubusercontent.com/8940009/47939530-e737d980-dea4-11e8-97b6-807c9a814604.gif)
Resolves https://github.com/enactjs/agate/issues/67