### PR TITLE
PLAT-68524: Add FullScreenPopup component

### DIFF
--- a/FullscreenPopup/FullscreenPopup.js
+++ b/FullscreenPopup/FullscreenPopup.js
@@ -1,0 +1,62 @@
+import compose from 'ramda/src/compose';
+import kind from '@enact/core/kind';
+import PropTypes from 'prop-types';
+import React from 'react';
+import Transition from '@enact/ui/Transition';
+
+import PopupState from '../Popup/PopupState';
+import Skinnable from '../Skinnable';
+
+import componentCss from './FullscreenPopup.less';
+
+const FullscreenPopupBase = kind({
+	name: 'FullscreenPopup',
+	propTypes: {
+		css: PropTypes.object,
+		noAnimation: PropTypes.bool,
+		onHide: PropTypes.func,
+		open: PropTypes.bool
+	},
+	defaultProps: {
+		noAnimation: false,
+		open: false
+	},
+	styles: {
+		css: componentCss,
+		className: 'fullscreenPopup'
+	},
+	computed: {
+		className: ({styler}) => styler.append('enact-fit')
+	},
+	render: ({children, className, css, noAnimation, onHide, open, ...rest}) => {
+
+		return (
+			<Transition
+				noAnimation={noAnimation}
+				visible={open}
+				direction="down"
+				duration="short"
+				type="slide"
+				className={className}
+				onHide={onHide}
+				css={css}
+			>
+				<div
+					{...rest}
+				>
+					{children}
+				</div>
+			</Transition>
+		);
+	}
+});
+
+const FullscreenPopupDecorator = compose(
+	Skinnable({prop: 'skin'}),
+	PopupState
+);
+
+const FullscreenPopup = FullscreenPopupDecorator(FullscreenPopupBase);
+
+export default FullscreenPopup;
+export {FullscreenPopup, FullscreenPopupBase};

--- a/FullscreenPopup/FullscreenPopup.js
+++ b/FullscreenPopup/FullscreenPopup.js
@@ -13,33 +13,43 @@ const FullscreenPopupBase = kind({
 	name: 'FullscreenPopup',
 	propTypes: {
 		css: PropTypes.object,
+		direction: PropTypes.string,
+		duration: PropTypes.string,
 		noAnimation: PropTypes.bool,
 		onHide: PropTypes.func,
-		open: PropTypes.bool
+		open: PropTypes.bool,
+		type: PropTypes.string
 	},
+
 	defaultProps: {
+		direction: 'down',
+		duration: 'short',
 		noAnimation: false,
-		open: false
+		open: false,
+		type: 'slide'
 	},
+
 	styles: {
 		css: componentCss,
 		className: 'fullscreenPopup'
 	},
+
 	computed: {
 		className: ({styler}) => styler.append('enact-fit')
 	},
-	render: ({children, className, css, noAnimation, onHide, open, ...rest}) => {
+
+	render: ({children, className, css, direction, duration, noAnimation, onHide, open, type, ...rest}) => {
 
 		return (
 			<Transition
-				noAnimation={noAnimation}
-				visible={open}
-				direction="down"
-				duration="short"
-				type="slide"
 				className={className}
-				onHide={onHide}
 				css={css}
+				direction={direction}
+				duration={duration}
+				noAnimation={noAnimation}
+				onHide={onHide}
+				type={type}
+				visible={open}
 			>
 				<div
 					{...rest}

--- a/FullscreenPopup/FullscreenPopup.less
+++ b/FullscreenPopup/FullscreenPopup.less
@@ -1,0 +1,14 @@
+// FullscreenPopup.less
+//
+@import "../styles/skin.less";
+
+.fullscreenPopup {
+	.inner {
+		height: 100%;
+		width: 100%;
+	}
+
+	.applySkins({
+		background-color: @agate-popup-bg-color;
+	});
+}

--- a/FullscreenPopup/FullscreenPopup.less
+++ b/FullscreenPopup/FullscreenPopup.less
@@ -9,6 +9,7 @@
 	}
 
 	.applySkins({
-		background-color: @agate-popup-bg-color;
+		background-color: @agate-fullscreenpopup-bg-color;
+		padding: @agate-fullscreenpopup-padding;
 	});
 }

--- a/FullscreenPopup/package.json
+++ b/FullscreenPopup/package.json
@@ -1,0 +1,3 @@
+{
+	"main": "FullscreenPopup.js"
+}

--- a/Popup/Popup.js
+++ b/Popup/Popup.js
@@ -1,6 +1,4 @@
 import compose from 'ramda/src/compose';
-import FloatingLayer from '@enact/ui/FloatingLayer';
-import {forward} from '@enact/core/handle';
 import kind from '@enact/core/kind';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -12,9 +10,9 @@ import Skinnable from '../Skinnable';
 import Divider from '../Divider';
 import Button from '../Button';
 
-import componentCss from './Popup.less';
+import PopupState from './PopupState';
 
-const forwardHide = forward('onHide');
+import componentCss from './Popup.less';
 
 const PopupBase = kind({
 	name: 'Popup',
@@ -39,7 +37,7 @@ const PopupBase = kind({
 	computed: {
 		className: ({closeButton, title, styler}) => styler.append({withCloseButton: closeButton, withTitle: title})
 	},
-	render: ({buttons, children, closeButton, css, noAnimation, onCloseButtonClick, onHide, open, skin, title, ...rest}) => {
+	render: ({buttons, children, closeButton, css, noAnimation, onClose, onHide, open, skin, title, ...rest}) => {
 		const wideLayout = (skin === 'carbon');
 
 		return (
@@ -59,7 +57,7 @@ const PopupBase = kind({
 					{closeButton ? <Button
 						icon="closex"
 						small
-						onTap={onCloseButtonClick}
+						onTap={onClose}
 						className={componentCss.closeButton}
 					/> : null}
 					{title ? <Divider className={css.title}>{title}</Divider> : null}
@@ -88,89 +86,11 @@ const PopupBase = kind({
 
 const PopupDecorator = compose(
 	Slottable({slots: ['closeButton', 'title', 'buttons']}),
-	Skinnable({prop: 'skin'})
+	Skinnable({prop: 'skin'}),
+	PopupState
 );
 
-class PopupState extends React.Component {
-	static propTypes = {
-		noAnimation: PropTypes.bool,
-		noAutoDismiss: PropTypes.bool,
-		onClose: PropTypes.func,
-		open: PropTypes.bool,
-		scrimType: PropTypes.oneOf(['transparent', 'translucent', 'none'])
-	}
-
-	static defaultProps = {
-		noAnimation: false,
-		noAutoDismiss: false,
-		open: false,
-		scrimType: 'translucent'
-	}
-
-	constructor (props) {
-		super(props);
-		this.state = {
-			floatLayerOpen: this.props.open,
-			popupOpen: this.props.noAnimation
-		};
-	}
-
-	componentWillReceiveProps (nextProps) {
-		if (!this.props.open && nextProps.open) {
-			this.setState({
-				popupOpen: nextProps.noAnimation,
-				floatLayerOpen: true
-			});
-		} else if (this.props.open && !nextProps.open) {
-			this.setState({
-				popupOpen: nextProps.noAnimation,
-				floatLayerOpen: !nextProps.noAnimation
-			});
-		}
-	}
-
-	handleFloatingLayerOpen = () => {
-		if (!this.props.noAnimation) {
-			this.setState({
-				popupOpen: true
-			});
-		}
-	}
-
-
-	handlePopupHide = () => {
-		forwardHide(null, this.props);
-
-		this.setState({
-			floatLayerOpen: false,
-			activator: null
-		});
-	}
-
-	render () {
-		const {noAutoDismiss, onClose, scrimType, ...rest} = this.props;
-		delete rest.spotlightRestrict;
-
-		return (
-			<FloatingLayer
-				noAutoDismiss={noAutoDismiss}
-				open={this.state.floatLayerOpen}
-				onOpen={this.handleFloatingLayerOpen}
-				onDismiss={onClose}
-				scrimType={scrimType}
-			>
-				<PopupBase
-					{...rest}
-					onCloseButtonClick={onClose}
-					open={this.state.popupOpen}
-					onHide={this.handlePopupHide}
-				/>
-			</FloatingLayer>
-		);
-	}
-}
-
-const Popup = PopupDecorator(PopupState);
+const Popup = PopupDecorator(PopupBase);
 
 export default Popup;
 export {Popup, PopupBase};

--- a/Popup/PopupState.js
+++ b/Popup/PopupState.js
@@ -1,0 +1,92 @@
+import FloatingLayer from '@enact/ui/FloatingLayer';
+import {forward} from '@enact/core/handle';
+import hoc from '@enact/core/hoc';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const forwardHide = forward('onHide');
+
+const PopupState = hoc((config, Wrapped) => {	// eslint-disable-line no-unused-vars
+	return class extends React.Component {
+		static displayName = 'PopupState'
+
+		static propTypes = {
+			noAnimation: PropTypes.bool,
+			noAutoDismiss: PropTypes.bool,
+			onClose: PropTypes.func,
+			open: PropTypes.bool,
+			scrimType: PropTypes.oneOf(['transparent', 'translucent', 'none'])
+		}
+
+		static defaultProps = {
+			noAnimation: false,
+			noAutoDismiss: false,
+			open: false,
+			scrimType: 'translucent'
+		}
+
+		constructor (props) {
+			super(props);
+			this.state = {
+				floatLayerOpen: this.props.open,
+				popupOpen: this.props.noAnimation
+			};
+		}
+
+		componentWillReceiveProps (nextProps) {
+			if (!this.props.open && nextProps.open) {
+				this.setState({
+					popupOpen: nextProps.noAnimation,
+					floatLayerOpen: true
+				});
+			} else if (this.props.open && !nextProps.open) {
+				this.setState({
+					popupOpen: nextProps.noAnimation,
+					floatLayerOpen: !nextProps.noAnimation
+				});
+			}
+		}
+
+		handleFloatingLayerOpen = () => {
+			if (!this.props.noAnimation) {
+				this.setState({
+					popupOpen: true
+				});
+			}
+		}
+
+		handlePopupHide = () => {
+			forwardHide(null, this.props);
+
+			this.setState({
+				floatLayerOpen: false,
+				activator: null
+			});
+		}
+
+		render () {
+			const {noAutoDismiss, onClose, scrimType, ...rest} = this.props;
+			delete rest.spotlightRestrict;
+
+			return (
+				<FloatingLayer
+					noAutoDismiss={noAutoDismiss}
+					open={this.state.floatLayerOpen}
+					onOpen={this.handleFloatingLayerOpen}
+					onDismiss={onClose}
+					scrimType={scrimType}
+				>
+					<Wrapped
+						{...rest}
+						open={this.state.popupOpen}
+						onClose={onClose}
+						onHide={this.handlePopupHide}
+					/>
+				</FloatingLayer>
+			);
+		}
+	};
+});
+
+export default PopupState;
+export {PopupState};

--- a/styles/colors-carbon.less
+++ b/styles/colors-carbon.less
@@ -36,7 +36,6 @@
 @agate-spotlight-disabled-text-color:  fade(@agate-spotlight-color, 40%);
 @agate-spotlight-focus-bg-image: @agate-gradient;
 
-
 // Button
 // ---------------------------------------
 @agate-button-color:          @agate-foreground;
@@ -54,6 +53,10 @@
 // ---------------------------------------
 @agate-divider-color:        @agate-text-color;
 @agate-divider-border-color: fadeout(@agate-divider-color, 30%);
+
+// FullscreenPopup
+// ---------------------------------------
+@agate-fullscreenpopup-bg-color: @agate-popup-bg-color;
 
 // Icon
 // ---------------------------------------

--- a/styles/colors-electro.less
+++ b/styles/colors-electro.less
@@ -48,7 +48,6 @@
 @agate-spotlight-disabled-text-color:  fade(@agate-spotlight-color, 40%);
 @agate-spotlight-focus-bg-image: @agate-gradient;
 
-
 // Button
 // ---------------------------------------
 @agate-button-color:          white;
@@ -66,6 +65,10 @@
 // ---------------------------------------
 @agate-divider-color:        @agate-text-color;
 @agate-divider-border-color: fadeout(@agate-divider-color, 30%);
+
+// FullscreenPopup
+// ---------------------------------------
+@agate-fullscreenpopup-bg-color: @agate-bg-color;
 
 // Icon
 // ---------------------------------------

--- a/styles/colors-titanium.less
+++ b/styles/colors-titanium.less
@@ -54,6 +54,10 @@
 @agate-divider-color:        @agate-text-color;
 @agate-divider-border-color: @agate-accent;
 
+// FullscreenPopup
+// ---------------------------------------
+@agate-fullscreenpopup-bg-color: @agate-popup-bg-color;
+
 // Icon
 // ---------------------------------------
 @agate-icon-color:       @agate-text-color;

--- a/styles/variables-carbon.less
+++ b/styles/variables-carbon.less
@@ -53,6 +53,10 @@
 @agate-divider-text-transform: uppercase;
 @agate-divider-icon-alignment: top;
 
+// FullscreenPopup
+// ---------------------------------------
+@agate-fullscreenpopup-padding: 72px;
+
 // Icon Sizes
 // ---------------------------------------
 @agate-icon-size: 48px;

--- a/styles/variables-electro.less
+++ b/styles/variables-electro.less
@@ -58,6 +58,10 @@
 @agate-divider-text-transform: uppercase;
 @agate-divider-icon-alignment: top;
 
+// FullscreenPopup
+// ---------------------------------------
+@agate-fullscreenpopup-padding: 72px;
+
 // Icon Sizes
 // ---------------------------------------
 @agate-icon-size: 48px;

--- a/styles/variables-titanium.less
+++ b/styles/variables-titanium.less
@@ -53,6 +53,10 @@
 @agate-divider-text-transform: none;
 @agate-divider-icon-alignment: text-top;
 
+// FullscreenPopup
+// ---------------------------------------
+@agate-fullscreenpopup-padding: 72px;
+
 // Icon Sizes
 // ---------------------------------------
 @agate-icon-size: 48px;


### PR DESCRIPTION
Adding the `FullscreenPopup` component.
Usage:
```
<FullscreenPopup
	onClose={this.handleClose}
	open={open}
>
	This is an example of a fullscreen popup.
</FullscreenPopup>
```
So far details are light-to-nonexistent regarding how the popup should be styled. It should ultimately respect theme styling (colors/padding). We can start a discussion to grow the needed styling rules and apply them in this PR.

Additional Considerations:
I've changed the `PopupState` component (used in `Popup`) into a `hoc` and moved into its own module, since it could/should also be used with `FullscreenPopup`. There are shared behaviors within popups in general that would be best served with centralized management.