### PR TITLE
ColorPicker: Set default value

### DIFF
--- a/ColorPicker/ColorPicker.js
+++ b/ColorPicker/ColorPicker.js
@@ -111,7 +111,8 @@ const ColorPickerBase = kind({
 
 	defaultProps: {
 		direction: 'right',
-		open: false
+		open: false,
+		value: '#fff'
 	},
 
 	styles: {

--- a/ColorPicker/ColorPicker.js
+++ b/ColorPicker/ColorPicker.js
@@ -112,7 +112,7 @@ const ColorPickerBase = kind({
 	defaultProps: {
 		direction: 'right',
 		open: false,
-		value: '#fff'
+		value: '#cccccc'
 	},
 
 	styles: {


### PR DESCRIPTION
`ColorPicker` needs a value to set the HSL values for the sliders in order to fix this error when there is no default value:
<img width="891" alt="colorpicker-error" src="https://user-images.githubusercontent.com/8940009/48231794-434aa400-e364-11e8-8135-005bdd34154b.png">
