### PR TITLE
PLAT-69809: Add GridListImageItem component

### DIFF
--- a/GridListImageItem/GridListImageItem.js
+++ b/GridListImageItem/GridListImageItem.js
@@ -1,0 +1,101 @@
+/**
+ * @module agate/GridListImageItem
+ * @exports GridListImageItem
+ */
+
+import kind from '@enact/core/kind';
+import {GridListImageItem as UiGridListImageItem} from '@enact/ui/GridListImageItem';
+import {ImageBase as Image} from '@enact/ui/Image';
+import PropTypes from 'prop-types';
+import compose from 'ramda/src/compose';
+import React from 'react';
+
+import Skinnable from '../Skinnable';
+
+import componentCss from './GridListImageItem.less';
+
+/**
+ * @class GridListImageItemBase
+ * @extends ui/GridListImageItem.GridListImageItem
+ * @memberof agate/GridListImageItem
+ * @ui
+ * @public
+ */
+const GridListImageItemBase = kind({
+	name: 'GridListImageItem',
+
+	propTypes: /** @lends moonstone/GridListImageItem.GridListImageItemBase.prototype */ {
+		aspectRatio: PropTypes.oneOf(['1:1', '4:3', '16:9']),
+
+		/**
+		 * Customizes the component by mapping the supplied collection of CSS class names to the
+		 * corresponding internal Elements and states of this component.
+		 *
+		 * The following classes are supported:
+		 *
+		 * * `image` - The image component class
+		 * * `caption` - The caption component class
+		 * * `subCaption` - The subCaption component class
+		 *
+		 * @type {Object}
+		 * @public
+		 */
+		css: PropTypes.object
+	},
+
+	defaultProps: {
+		aspectRatio: '1:1'
+	},
+
+	styles: {
+		css: componentCss,
+		publicClassNames: ['gridListImageItem', 'image', 'caption', 'subCaption']
+	},
+
+	computed: {
+		className: ({aspectRatio, styler}) => styler.append({
+			fourThree: aspectRatio === '4:3',
+			sixteenNine: aspectRatio === '16:9'
+		})
+	},
+
+	render: ({css, ...rest}) => {
+		delete rest.aspectRatio;
+
+		return (
+			<UiGridListImageItem
+				{...rest}
+				css={css}
+				imageComponent={Image}
+			/>
+		);
+	}
+});
+
+/**
+ * @hoc
+ * @memberof agate/GridListImageItem
+ * @mixes agate/Skinnable.Skinnable
+ * @public
+ */
+const GridListImageItemDecorator = compose(
+	Skinnable
+);
+
+/**
+ * @class GridListImageItem
+ * @memberof agate/GridListImageItem
+ * @extends agate/GridListIamgeItem.GridListImageItemBase
+ * @mixes agate/GridListImageItem.GridListImageItemDecorator
+ * @see agate/GridListImageItem.GridListImageItemBase
+ * @ui
+ * @public
+ */
+const GridListImageItem = GridListImageItemDecorator(GridListImageItemBase);
+
+export default GridListImageItem;
+export {
+	GridListImageItem,
+	GridListImageItemBase,
+	GridListImageItemDecorator
+};

--- a/GridListImageItem/GridListImageItem.less
+++ b/GridListImageItem/GridListImageItem.less
@@ -1,29 +1,39 @@
 @import '../styles/skin.less';
 
 .gridListImageItem {
+    --agate-aspect-ratio: 1;
+
     .applySkins({
         .image {
+            position: relative;
             height: 0px;
+
+            // with margins around image
+            // margin: calc(50% - 50% * var(--agate-aspect-ratio)) 0;
+
+            // without margins
+            padding: calc(50% * var(--agate-aspect-ratio, 1)) 0;
+            flex: 0 1 0%;
         }
 
-        &.fourThree .image {
-            height: 0px;
-            margin: 6.25% 0;
-        }
-
-        &.sixteenNine .image {
-            height: 0px;
-            margin: 22% 0;
+        .overlayContainer {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            height: auto;
         }
 
         .caption {
-            height: 48px;
-            line-height: 48px;
+            font-weight: @agate-gridlistimageitem-caption-weight;
+            height: @agate-gridlistimageitem-caption-height;
+            line-height: @agate-gridlistimageitem-caption-height;
             text-align: center;
         }
 
         .subCaption {
-            line-height: 48px;
+            height: @agate-gridlistimageitem-subcaption-height;
+            line-height: @agate-gridlistimageitem-subcaption-height;
             text-align: center;
         }
     });

--- a/GridListImageItem/GridListImageItem.less
+++ b/GridListImageItem/GridListImageItem.less
@@ -1,0 +1,30 @@
+@import '../styles/skin.less';
+
+.gridListImageItem {
+    .applySkins({
+        .image {
+            height: 0px;
+        }
+
+        &.fourThree .image {
+            height: 0px;
+            margin: 6.25% 0;
+        }
+
+        &.sixteenNine .image {
+            height: 0px;
+            margin: 22% 0;
+        }
+
+        .caption {
+            height: 48px;
+            line-height: 48px;
+            text-align: center;
+        }
+
+        .subCaption {
+            line-height: 48px;
+            text-align: center;
+        }
+    });
+}

--- a/GridListImageItem/package.json
+++ b/GridListImageItem/package.json
@@ -1,0 +1,3 @@
+{
+    "main": "GridListImageItem.js"
+}

--- a/styles/variables-carbon.less
+++ b/styles/variables-carbon.less
@@ -62,6 +62,12 @@
 // ---------------------------------------
 @agate-fullscreenpopup-padding: 72px;
 
+// GridListImageItem
+// ---------------------------------------
+@agate-gridlistimageitem-caption-weight: 400;
+@agate-gridlistimageitem-caption-height: 48px;
+@agate-gridlistimageitem-subcaption-height: 48px;
+
 // Icon Sizes
 // ---------------------------------------
 @agate-icon-size: 48px;

--- a/styles/variables-electro.less
+++ b/styles/variables-electro.less
@@ -67,6 +67,12 @@
 // ---------------------------------------
 @agate-fullscreenpopup-padding: 72px;
 
+// GridListImageItem
+// ---------------------------------------
+@agate-gridlistimageitem-caption-weight: 400;
+@agate-gridlistimageitem-caption-height: 48px;
+@agate-gridlistimageitem-subcaption-height: 48px;
+
 // Icon Sizes
 // ---------------------------------------
 @agate-icon-size: 48px;

--- a/styles/variables-titanium.less
+++ b/styles/variables-titanium.less
@@ -62,6 +62,12 @@
 // ---------------------------------------
 @agate-fullscreenpopup-padding: 72px;
 
+// GridListImageItem
+// ---------------------------------------
+@agate-gridlistimageitem-caption-weight: 400;
+@agate-gridlistimageitem-caption-height: 48px;
+@agate-gridlistimageitem-subcaption-height: 48px;
+
 // Icon Sizes
 // ---------------------------------------
 @agate-icon-size: 48px;


### PR DESCRIPTION
Extends `ui/GridListImageItem` with agate-styled `Icon` component. We don't have any agate-specific requirements for `Image` yet so `ui/Image` is used for now.

In order to support both the Album art and video thumbnail requirement, I added an `aspectRatio` prop which sizes the height of the image relative to the width. The sizing using a CSS variable, `--agate-aspect-ratio` along with a `padding` and `calc()` to size the image node.

```
<GridListImageItem aspectRatio="16:9" ... />
```

It's possible to add space around the image using `margin` instead of `padding` and maintain the same aspect ratio but I thought i more likely we'd want to keep the thumbnail close to the caption so I've used `padding`. The `margin` core remains commented out for future consideration.
