### PR TITLE
the smallest buttons!

### DIFF
--- a/Button/Button.js
+++ b/Button/Button.js
@@ -53,6 +53,8 @@ const ButtonBase = kind({
 		 * * `bg` - The background node of the button
 		 * * `selected` - Applied to a `selected` button
 		 * * `small` - Applied to a `small` button
+		 * * `smaller` - Applied to a `smaller` button
+		 * * `smallest - Applied to the `smallest` button
 		 *
 		 * @type {Object}
 		 * @public
@@ -104,7 +106,7 @@ const ButtonBase = kind({
 
 	styles: {
 		css: componentCss,
-		publicClassNames: ['button', 'bg', 'client', 'selected', 'small']
+		publicClassNames: ['button', 'bg', 'client', 'selected', 'small', 'smallest']
 	},
 
 	computed: {

--- a/Button/Button.less
+++ b/Button/Button.less
@@ -83,6 +83,24 @@
 			}
 		}
 
+		&.smallest {
+			height: @agate-button-smallest-height;
+			min-width: @agate-button-smallest-height;
+			font-size: @agate-button-smallest-font-size;
+			line-height: (@agate-button-smallest-height - (2 * @agate-button-border-width));
+			padding: 0 @agate-button-smallest-h-padding;
+
+			&.minWidth {
+				padding: 0;
+			}
+
+			.client::before {
+				bottom: 6px;
+				left: 9px;
+				right: 9px;
+			}
+		}
+
 		&.grid {
 			.bg {
 				border-radius: @agate-button-grid-border-radius;

--- a/Icon/Icon.less
+++ b/Icon/Icon.less
@@ -28,6 +28,15 @@
 			line-height: @agate-icon-small-size;
 		}
 
+		&.smallest {
+			background-position: center -((@agate-icon-sprite-smallest-size - @agate-icon-smallest-size) / 2);
+			background-size: @agate-icon-sprite-smallest-size (@agate-icon-sprite-smallest-size * 2);
+			width: @agate-icon-smallest-size;
+			height: @agate-icon-smallest-size;
+			font-size: @agate-icon-smallest-font-size;
+			line-height: @agate-icon-smallest-size;
+		}
+
 		&.dingbat {
 			font-family: "LG Display_Dingbat";
 			font-size: @agate-icon-size;

--- a/styles/variables-carbon.less
+++ b/styles/variables-carbon.less
@@ -16,14 +16,18 @@
 // ---------------------------------------
 @agate-button-height: 84px;
 @agate-button-small-height: 60px;
+@agate-button-smallest-height: 45px;
 @agate-button-font-size: 36px;
 @agate-button-small-font-size: 24px;
+@agate-button-smallest-font-size: 18px;
 @agate-button-border-width: 1px;
 @agate-button-border-radius: 9999px;
 @agate-button-text-size: 30px;
 @agate-button-small-text-size: 24px;
+@agate-button-smallest-text-size: 18px;
 @agate-button-h-padding: 27px;
 @agate-button-small-h-padding: 18px;
+@agate-button-smallest-h-padding: 12px;
 @agate-button-highlighted-opacity: 1;
 @agate-button-skew: 0;
 @agate-button-grid-border-radius: 0;
@@ -66,12 +70,16 @@
 // ---------------------------------------
 @agate-icon-size: 48px;
 @agate-icon-small-size: 36px;
+@agate-icon-smallest-size: 24px;
 @agate-icon-font-size: (@agate-icon-size * 2);
 @agate-icon-small-font-size: (@agate-icon-small-size * 2);
+@agate-icon-smallest-font-size: (@agate-icon-smallest-size * 2);
 @agate-icon-button-size: @agate-button-height;
 @agate-icon-button-small-size: @agate-button-small-height;
+@agate-icon-button-smallest-size: @agate-button-smallest-height;
 @agate-icon-sprite-size: (@agate-icon-button-size - (@agate-button-border-width * 2));
 @agate-icon-sprite-small-size: (@agate-icon-button-small-size - (@agate-button-border-width * 2));
+@agate-icon-sprite-smallest-size: (@agate-icon-button-smallest-size - (@agate-button-border-width * 2));
 @agate-icon-margin: @agate-component-spacing;
 
 // Input

--- a/styles/variables-electro.less
+++ b/styles/variables-electro.less
@@ -21,14 +21,18 @@
 // ---------------------------------------
 @agate-button-height: 84px;
 @agate-button-small-height: 60px;
+@agate-button-smallest-height: 45px;
 @agate-button-font-size: 36px;
 @agate-button-small-font-size: 24px;
+@agate-button-smallest-font-size: 18px;
 @agate-button-border-width: 0;
 @agate-button-border-radius: @electro-border-radius;
 @agate-button-text-size: 30px;
 @agate-button-small-text-size: 24px;
+@agate-button-smallest-text-size: 218px;
 @agate-button-h-padding: 27px;
 @agate-button-small-h-padding: 18px;
+@agate-button-smallest-h-padding: 12px;
 @agate-button-highlighted-opacity: 1;
 @agate-button-skew: @electro-skew;
 @agate-button-grid-border-radius: @electro-border-radius;
@@ -71,12 +75,16 @@
 // ---------------------------------------
 @agate-icon-size: 48px;
 @agate-icon-small-size: 36px;
+@agate-icon-smallest-size: 24px;
 @agate-icon-font-size: (@agate-icon-size * 2);
 @agate-icon-small-font-size: (@agate-icon-small-size * 2);
+@agate-icon-smallest-font-size: (@agate-icon-smallest-size * 2);
 @agate-icon-button-size: @agate-button-height;
 @agate-icon-button-small-size: @agate-button-small-height;
+@agate-icon-button-smallest-size: @agate-button-smallest-height;
 @agate-icon-sprite-size: (@agate-icon-button-size - (@agate-button-border-width * 2));
 @agate-icon-sprite-small-size: (@agate-icon-button-small-size - (@agate-button-border-width * 2));
+@agate-icon-sprite-smallest-size: (@agate-icon-button-smallest-size - (@agate-button-border-width * 2));
 @agate-icon-margin: @agate-component-spacing;
 
 // Input

--- a/styles/variables-titanium.less
+++ b/styles/variables-titanium.less
@@ -16,14 +16,18 @@
 // ---------------------------------------
 @agate-button-height: 84px;
 @agate-button-small-height: 60px;
+@agate-button-smallest-height: 45px;
 @agate-button-font-size: 36px;
 @agate-button-small-font-size: 24px;
+@agate-button-smallest-font-size: 18px;
 @agate-button-border-width: 3px;
 @agate-button-border-radius: 9999px;
 @agate-button-text-size: 30px;
 @agate-button-small-text-size: 24px;
+@agate-button-smallest-text-size: 18px;
 @agate-button-h-padding: 27px;
 @agate-button-small-h-padding: 18px;
+@agate-button-smallest-h-padding: 112px;
 @agate-button-highlighted-opacity: 1;
 @agate-button-skew: 0;
 @agate-button-grid-border-radius: 0;
@@ -66,12 +70,16 @@
 // ---------------------------------------
 @agate-icon-size: 48px;
 @agate-icon-small-size: 36px;
+@agate-icon-smallest-size: 24px;
 @agate-icon-font-size: (@agate-icon-size * 2);
 @agate-icon-small-font-size: (@agate-icon-small-size * 2);
+@agate-icon-smallest-font-size: (@agate-icon-smallest-size * 2);
 @agate-icon-button-size: @agate-button-height;
 @agate-icon-button-small-size: @agate-button-small-height;
+@agate-icon-button-smallest-size: @agate-button-smallest-height;
 @agate-icon-sprite-size: (@agate-icon-button-size - (@agate-button-border-width * 2));
 @agate-icon-sprite-small-size: (@agate-icon-button-small-size - (@agate-button-border-width * 2));
+@agate-icon-sprite-smallest-size: (@agate-icon-button-smallest-size - (@agate-button-border-width * 2));
 @agate-icon-margin: @agate-component-spacing;
 
 // Input


### PR DESCRIPTION
This patch relies on https://github.com/enactjs/enact/pull/2024 being merged.

This adds the `smallest` rules for `Button` and `Icon` to the existing skins.