### PR TITLE
PLAT-70504: Fixed TabbedPanels Tabs layout being squished together

### DIFF
--- a/Panels/TabbedPanels.js
+++ b/Panels/TabbedPanels.js
@@ -16,29 +16,27 @@ import Panels from './Panels';
 
 import componentCss from './TabbedPanels.less';
 
-const SpottableLabeledIcon = Spottable(LabeledIcon);
-
 const TabBase = kind({
 	name: 'Tab',
 	styles: {
 		css: componentCss,
 		className: 'tab'
 	},
-	render: ({children, icon = 'star', labelPosition, onClick, ...rest}) => {
+	render: ({children, css, icon = 'star', labelPosition, onClick, ...rest}) => {
 		return (
-			<Cell
-				{...rest}
-				icon={icon}
-				component={SpottableLabeledIcon}
-				labelPosition={labelPosition}
-				onClick={onClick}
-			>
-				{children}
+			<Cell {...rest} onClick={onClick}>
+				<LabeledIcon
+					className={css.labeledIcon}
+					icon={icon}
+					labelPosition={labelPosition}
+				>
+					{children}
+				</LabeledIcon>
 			</Cell>
 		);
 	}
 });
-const Tab = Skinnable(TabBase);
+const Tab = Skinnable(Spottable(TabBase));
 
 const TabGroupBase = kind({
 	name: 'TabGroup',

--- a/Panels/TabbedPanels.less
+++ b/Panels/TabbedPanels.less
@@ -34,9 +34,6 @@
 			transform: @agate-panels-tab-group-transform;
 
 			.tab {
-				margin: @agate-panels-tab-margin;
-				padding: @agate-panels-tab-padding;
-
 				color: @agate-panels-tab-color;
 				// background-color: @agate-panels-tab-bg-color;
 				// background-image: @agate-panels-tab-bg-image;
@@ -62,6 +59,11 @@
 
 				&:first-child {
 					border-left-width: 0;
+				}
+
+				.labeledIcon {
+					margin: @agate-panels-tab-margin;
+					padding: @agate-panels-tab-padding;
 				}
 
 				.focus({


### PR DESCRIPTION
TabbedPanels Tabs get all smushed together on Chrome 53, rather than being properly spaced (as expected). This was due to the fact that Cell was being assigned Layout rules when the inner component should have just been a child, rather than leveraging the `component` prop of `Cell`.

Generally, `Cell` and `Layout` should not be the same DOM node since early support for flex-box *does NOT* handle this case well. Newer browsers don't appear to exhibit this quirky behavior, but the older ones do. `<table>` and `<td>` cannot be the same DOM node; `<frame>` and `<frameset>` cannot either; `Layout` and `Cell` have a similar relationship.