### PR TITLE
Added some panel optimization

### DIFF
--- a/Panels/Panels.js
+++ b/Panels/Panels.js
@@ -42,6 +42,12 @@ VerticalArranger.leave = arrange.ease(
 	arrange.compose(slideOut, VerticalArranger.leave)
 );
 
+const mapChildren = (childs) => React.Children.map(childs, (child, index) => {
+	return child ? React.cloneElement(child, {
+		'data-index': index
+	}) : null;
+})
+
 const PanelsBase = kind({
 	name: 'Panels',
 	propTypes: {
@@ -65,13 +71,18 @@ const PanelsBase = kind({
 			if (arranger) return arranger;
 			if (orientation === 'vertical') return VerticalArranger;
 			else return HorizontalArranger;
-		}
+		},
+		enteringProp: ({noAnimation}) => noAnimation ? null : 'hideChildren'
 	},
-	render: (props) => {
+	render: ({children, ...props}) => {
+		const mappedChildren = mapChildren(children);
+
 		return (
 			<ViewManager
 				{...props}
-			/>
+			>
+				{mappedChildren}
+			</ViewManager>
 		);
 	}
 });

--- a/Panels/TabbedPanels.js
+++ b/Panels/TabbedPanels.js
@@ -22,12 +22,18 @@ const TabBase = kind({
 		css: componentCss,
 		className: 'tab'
 	},
-	render: ({children, css, icon = 'star', labelPosition, onClick, ...rest}) => {
+	render: ({children, css, icon = 'star', labelPosition, onClick, orientation, style = {}, ...rest}) => {
+		let inline;
+		if (orientation === 'horizontal') {
+			style.textAlign = 'center';
+			inline = true;
+		}
 		return (
-			<Cell {...rest} onClick={onClick}>
+			<Cell {...rest} style={style} onClick={onClick}>
 				<LabeledIcon
 					className={css.labeledIcon}
 					icon={icon}
+					inline={inline}
 					labelPosition={labelPosition}
 				>
 					{children}
@@ -82,6 +88,7 @@ const TabGroupBase = kind({
 						component={Group}
 						itemProps={{
 							labelPosition,
+							orientation,
 							shrink: (orientation === 'vertical')
 						}}
 						orientation={orientation}


### PR DESCRIPTION
Moving in some tricks we used for moonstone. Adding data-index, to prevent re-renders. Also adding in `hideChildren` to fade in. This will make the transitions quicker.  