### PR TITLE
PLAT-70638: Fix DropManager to only apply updated arrangements while arranging

### DIFF
--- a/DropManager/DropManager.js
+++ b/DropManager/DropManager.js
@@ -233,11 +233,13 @@ const DropManager = hoc(defaultConfig, (configHoc, Wrapped) => {
 
 			if (configHoc.arrangeableProp) rest[configHoc.arrangeableProp] = arrangeable;
 			if (configHoc.arrangingProp) rest[configHoc.arrangingProp] = this.state.dragging;
-			if (arrangeable) {
-				rest[configHoc.arrangementProp || fallbackArrangementProp] = this.state.arrangement;
-			}
 
 			if (arrangeable) {
+				// Respect the incoming prop from the parent, unless we're in arranging mode.
+				// During arranging mode, we're handling our own arrangement, then will emit the
+				// finalized arrangement back to the parent when we're done.
+				rest[configHoc.arrangementProp || fallbackArrangementProp] = this.state.arrangement;
+
 				// Add all of the necessary events, but only if we're in edit mode
 				rest.onDragStart = this.handleDragStart;
 				rest.onDragEnter = this.handleDragEnter;

--- a/DropManager/DropManager.js
+++ b/DropManager/DropManager.js
@@ -233,8 +233,9 @@ const DropManager = hoc(defaultConfig, (configHoc, Wrapped) => {
 
 			if (configHoc.arrangeableProp) rest[configHoc.arrangeableProp] = arrangeable;
 			if (configHoc.arrangingProp) rest[configHoc.arrangingProp] = this.state.dragging;
-			// Always apply arrangement, so Rearrangeable can receive it.
-			rest[configHoc.arrangementProp || fallbackArrangementProp] = this.state.arrangement;
+			if (arrangeable) {
+				rest[configHoc.arrangementProp || fallbackArrangementProp] = this.state.arrangement;
+			}
 
 			if (arrangeable) {
 				// Add all of the necessary events, but only if we're in edit mode


### PR DESCRIPTION
If `arrangement` prop is updated by the parent, `DropManager` fails to respect the value. It only needs to use the arrangement state while it's in an arrangeable state.

Enact-DCO-1.0-Signed-off-by: Stephen Choi <stephen.choi@lge.com>