### PR TITLE
PLAT-71634: Cleanup SwitchItem and Switch

### DIFF
--- a/Switch/Switch.js
+++ b/Switch/Switch.js
@@ -14,7 +14,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Icon from '../Icon';
 
-import ToggleIcon from '@enact/ui/ToggleIcon';
+import Toggleable from '@enact/ui/Toggleable';
+import {ToggleIconBase} from '@enact/ui/ToggleIcon';
 import Skinnable from '../Skinnable';
 
 import compose from 'ramda/src/compose';
@@ -66,20 +67,21 @@ const SwitchBase = kind({
 		delete rest.noAnimation;
 
 		return (
-			<ToggleIcon
+			<ToggleIconBase
 				{...rest}
 				css={css}
 				iconComponent={Icon}
 			>
 				{children}
-			</ToggleIcon>
+			</ToggleIconBase>
 		);
 	}
 });
 
 const SwitchDecorator = compose(
+	Toggleable({toggleProp: 'onClick'}),
 	Skinnable
-)
+);
 
 const Switch = SwitchDecorator(SwitchBase);
 

--- a/Switch/Switch.less
+++ b/Switch/Switch.less
@@ -88,7 +88,6 @@
 				&.selected .icon {
 					color: @agate-sliderbutton-focus-color;
 				}
-
 			}
 		})
 	});

--- a/SwitchItem/SwitchItem.js
+++ b/SwitchItem/SwitchItem.js
@@ -7,18 +7,20 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-
-import kind from '@enact/core/kind';
-import AgateSwitch from '../Switch';
-import Icon from '../Icon';
-import Skinnable from '../Skinnable';
-
-import Spottable from '@enact/spotlight/Spottable';
-import Toggleable from '@enact/ui/Toggleable';
-import Touchable from '@enact/ui/Touchable';
 import compose from 'ramda/src/compose';
 
+import kind from '@enact/core/kind';
+import Spottable from '@enact/spotlight/Spottable';
+import {Row, Cell} from '@enact/ui/Layout';
+import Toggleable from '@enact/ui/Toggleable';
+
+import Icon from '../Icon';
+import Skinnable from '../Skinnable';
+import {SwitchBase} from '../Switch';
+
 import componentCss from './SwitchItem.less';
+
+const Switch = Skinnable(SwitchBase);
 
 /**
  * Renders an `Item` with a radio-dot component. Useful to show a selected state on an Item.
@@ -29,8 +31,6 @@ import componentCss from './SwitchItem.less';
  * @ui
  * @public
  */
-
-
 const SwitchItemBase = kind({
 	name: 'SwitchItemBase',
 
@@ -100,32 +100,29 @@ const SwitchItemBase = kind({
 	},
 
 	computed: {
-		icon: ({css, icon}) => (icon ? <Icon small className={css.icon}>{icon}</Icon> : null)
+		icon: ({css, icon}) => (icon ? <Cell shrink component={Icon} small className={css.icon}>{icon}</Cell> : null)
 	},
 
 	render: ({children, css, icon, offText, onText, selected, ...rest}) => {
 
 		return (
-			<div {...rest} css={css}>
+			<Row align="center" {...rest}>
 				{icon}
-				<div
-					className={css.text}
-				>
+				<Cell className={css.text}>
 					{children}
-				</div>
-				<div className={css.label}>
+				</Cell>
+				<Cell shrink className={css.label}>
 					{selected ? onText : offText}
-				</div>
-				<AgateSwitch selected={selected} className={css.switchIcon} />
-			</div>
+				</Cell>
+				<Cell shrink component={Switch} selected={selected} className={css.switchIcon} />
+			</Row>
 		);
 	}
 });
 
-
 const SwitchItemDecorator = compose(
-	Toggleable({toggleProp: 'onTap'}),
-	Touchable,
+	Toggleable({toggleProp: 'onClick'}),
+	// Touchable,
 	Spottable,
 	Skinnable
 );
@@ -134,5 +131,7 @@ const SwitchItem = SwitchItemDecorator(SwitchItemBase);
 
 export default SwitchItem;
 export {
-	SwitchItem
+	SwitchItem,
+	SwitchItemBase,
+	SwitchItemDecorator
 };

--- a/SwitchItem/SwitchItem.less
+++ b/SwitchItem/SwitchItem.less
@@ -1,22 +1,16 @@
 // SwitchItem.less
 //
 @import "../styles/mixins.less";
-@import "../styles/variables.less";
 @import "../styles/skin.less";
 
-// Public
 .switchItem {
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-
 	.label {
 		vertical-align: middle;
 	}
 
-
 	.switchIcon {
 		margin-left: 10px;
+		pointer-events: none;
 	}
 
 	.applySkins({
@@ -25,13 +19,11 @@
 
 		.text {
 			color: @agate-item-color;
-			flex: 1;
 		}
 
 		.label {
 			.margin-start-end(0, @agate-component-spacing);
 			font-weight: 500;	// Covert to var
-
 			color: @agate-switch-label-color;
 
 			.disabled({
@@ -41,6 +33,7 @@
 		}
 		.focus({
 			color: @agate-switch-focus-color;
+
 			.text {
 				color: @agate-switch-focus-color;
 			}


### PR DESCRIPTION
Converted custom layout to Layout component for better reliability, ignore taps on the Switch when inside SwitchItem, convert onTaps to onClicks to avoid quirk in Tappable, general cleanup.