### PR TITLE
Background image didn't show on Chrome 53

### DIFF
--- a/AgateDecorator/AgateDecorator.less
+++ b/AgateDecorator/AgateDecorator.less
@@ -26,5 +26,13 @@
 		color: @agate-text-color;
 		background-color: @agate-bg-color;
 		background-image: @agate-bg-image;
+
+		&::before {
+			content: "";
+			display: block;
+			background-image: @agate-bg-image2;
+			position: absolute;
+			.position(0);
+		}
 	});
 }

--- a/styles/colors-carbon.less
+++ b/styles/colors-carbon.less
@@ -21,6 +21,7 @@
 // Component color assignments
 @agate-bg-color: black;
 @agate-bg-image: none;
+@agate-bg-image2: none;
 @agate-text-color: @agate-foreground;
 @agate-title-text-color: white;
 

--- a/styles/colors-copper-day.less
+++ b/styles/colors-copper-day.less
@@ -23,8 +23,8 @@
 
 // Component color assignments
 @agate-bg-color: @agate-light-gray;
-@agate-bg-image: url(../assets/noise-black.png), radial-gradient(~"hsla(var(--agate-accent-h, 0), var(--agate-accent-s, 0), var(--agate-accent-l, 0), 0.2)", transparent 60%), linear-gradient(to bottom, @agate-bg-color 43%, @agate-white 90%);
-// @agate-bg-image: url(../assets/noise-white.png), linear-gradient(to bottom, #121b22 43%, #040213 80%);
+@agate-bg-image: radial-gradient(~"hsla(var(--agate-accent-h, 0), var(--agate-accent-s, 0), var(--agate-accent-l, 0), 0.2)", transparent 60%), linear-gradient(to bottom, @agate-bg-color 43%, @agate-white 90%);
+@agate-bg-image2: url(../assets/noise-black.png);
 @agate-text-color: @agate-darker-gray;
 @agate-title-text-color: @agate-dark-gray;
 

--- a/styles/colors-copper.less
+++ b/styles/colors-copper.less
@@ -23,8 +23,8 @@
 
 // Component color assignments
 @agate-bg-color: @agate-darker-gray;
-@agate-bg-image: url(../assets/noise-white.png), radial-gradient(~"hsla(var(--agate-accent-h, 0), var(--agate-accent-s, 0), var(--agate-accent-l, 0), 0.2)", transparent 60%), linear-gradient(to bottom, #14191d 43%, #040213 90%);
-// @agate-bg-image: url(../assets/noise-white.png), linear-gradient(to bottom, #121b22 43%, #040213 80%);
+@agate-bg-image: radial-gradient(~"hsla(var(--agate-accent-h, 0), var(--agate-accent-s, 0), var(--agate-accent-l, 0), 0.2)", transparent 60%), linear-gradient(to bottom, #14191d 43%, #040213 90%);
+@agate-bg-image2: url(../assets/noise-white.png);
 @agate-text-color: @agate-accent;
 @agate-title-text-color: @agate-white;
 

--- a/styles/colors-electro.less
+++ b/styles/colors-electro.less
@@ -24,6 +24,7 @@
 // Component color assignments
 @agate-bg-color: #1c0d3f;
 @agate-bg-image: none;
+@agate-bg-image2: none;
 @agate-text-color: white;
 @agate-title-text-color: white;
 

--- a/styles/colors-titanium.less
+++ b/styles/colors-titanium.less
@@ -21,6 +21,7 @@
 // Component color assignments
 @agate-bg-color: #ddd;
 @agate-bg-image: none;
+@agate-bg-image2: none;
 @agate-text-color: @agate-foreground;
 @agate-title-text-color: white;
 


### PR DESCRIPTION
In old Chrome 53, it didn't know how to render a background image URL + a CSS-variable-based HSLA color value in a radial-gradient on one DOM node and would just show 2 of the 3 backgrounds being applied. This moves the URL to a separate variable and applies that to a new background layer (pseudo-class).
Bonus, now the URL background can be used in other places too.

This bug only appears in the one place that matters (in the build). For true integration diligence, you'll need to test this on our build, however, I can verify it does work.