### PR TITLE
Fix ColorPicker's sticky stubborn sliders

### DIFF
--- a/ColorPicker/ColorPicker.js
+++ b/ColorPicker/ColorPicker.js
@@ -215,6 +215,12 @@ const ColorPickerExtended = hoc((config, Wrapped) => {
 			};
 		}
 
+		componentDidUpdate (prevProps) {
+			if (prevProps.value !== this.props.value) {
+				this.hsl = convert.hex.hsl(this.props.value);
+			}
+		}
+
 		buildValue = ({h = this.hsl[0], s = this.hsl[1], l = this.hsl[2]} = {}) => (
 			'#' + convert.hsl.hex(h, s, l)
 		)


### PR DESCRIPTION
ColorPicker maintains an instance variable for fast color conversions. This wasn't being updated when the value prop was updated, so it was hard for a user to simply update the chosen color rather than start over each time because the picker wasn't factoring the other values into account correctly.