### PR TITLE
PLAT-80257: Durable Skins

### DIFF
--- a/styles/skin.less
+++ b/styles/skin.less
@@ -2,10 +2,18 @@
 //
 
 .applySkins(@componentRules) when (isruleset(@componentRules)) {
+	// Establish a base set of colors and variables that other skins can optionally override.
+	@import "./colors-carbon.less";
+	@import "./variables-carbon.less";
+
+
+	//
+	// Start assigning skin values
+	//
 	&:global(.carbon) {
 		// Load the Carbon agate rules into this scope
 		@import "./colors-carbon.less";
-		@import "./variables-carbon.less";
+		@import (multiple) "./variables-carbon.less";
 
 		@componentRules();
 	}
@@ -17,7 +25,6 @@
 
 		@componentRules();
 	}
-
 
 	&:global(.cobalt-day) {
 		// Load the Copper agate rules into this scope


### PR DESCRIPTION
Skins should now be able to ignore newly created variables for components

This change, looking seemly simple, allows components to specify one initial set of colors/variables in one pair of files, allowing the others to simply ignore or override those variables, without breaking the whole system due to a variable missing or not being defined.

This can be viewed as a first step, albeit the most important step. Future steps to refine this could include:
* removing repetitive or already defined variables/values in each of the skin files which don't differ from the established base skin.
* establishing a true "base" skin which has extremely generic colors and variables, rather than one that's a little opinionated