### PR TITLE
PLAT-80254: Update Agate components to expose public class names

### DIFF
--- a/Button/Button.js
+++ b/Button/Button.js
@@ -104,7 +104,7 @@ const ButtonBase = kind({
 
 	styles: {
 		css: componentCss,
-		publicClassNames: ['button', 'bg', 'client', 'selected', 'small']
+		publicClassNames: true
 	},
 
 	computed: {

--- a/IconButton/IconButton.js
+++ b/IconButton/IconButton.js
@@ -27,6 +27,7 @@ import componentCss from './IconButton.module.less';
 const Icon = kind({
 	name: 'Icon',
 	propTypes: {
+		css: PropTypes.object,
 		size: PropTypes.oneOf(['small', 'smallest'])
 	},
 	styles: {
@@ -34,16 +35,11 @@ const Icon = kind({
 		className: 'icon'
 	},
 	computed: {
-		className: ({size, styler}) => styler.append(size),
-		small: ({size}) => size === 'small'
+		className: ({size, styler}) => styler.append(size)
 	},
-	render: (props) => {
-		delete props.size;
-
-		return (
-			<AgateIcon {...props} />
-		);
-	}
+	render: (props) => (
+		<AgateIcon {...props} />
+	)
 });
 
 /**

--- a/LabeledIcon/LabeledIcon.js
+++ b/LabeledIcon/LabeledIcon.js
@@ -29,9 +29,14 @@ const LabeledIconBase = kind({
 		children: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired
 	},
 
+	styles: {
+		css: componentCss,
+		className: 'labeledIcon',
+		publicClassNames: true
+	},
+
 	render: (props) => UiLabeledIcon.inline({
 		...props,
-		css: componentCss,
 		iconComponent: Icon
 	})
 });

--- a/LabeledIcon/LabeledIcon.js
+++ b/LabeledIcon/LabeledIcon.js
@@ -37,6 +37,7 @@ const LabeledIconBase = kind({
 
 	render: (props) => UiLabeledIcon.inline({
 		...props,
+		css: props.css,
 		iconComponent: Icon
 	})
 });

--- a/LabeledIconButton/LabeledIconButton.js
+++ b/LabeledIconButton/LabeledIconButton.js
@@ -65,7 +65,7 @@ const LabeledIconButtonBase = kind({
 	styles: {
 		css: componentCss,
 		className: 'labeledIconButton',
-		publicClassNames: ['labeledIconButton', 'icon', 'label', 'selected', 'small']
+		publicClassNames: true
 	},
 
 	render: ({css, icon, pressed, selected, ...rest}) => {

--- a/Picker/Picker.js
+++ b/Picker/Picker.js
@@ -39,7 +39,9 @@ const PickerBase = kind({
 
 	styles: {
 		css,
-		className: 'picker'
+		className: 'picker',
+		publicClassNames: ['picker', 'active', 'label', 'item', 'itemTop', 'itemBottom']
+
 	},
 
 	handlers: {

--- a/Picker/Picker.js
+++ b/Picker/Picker.js
@@ -40,8 +40,7 @@ const PickerBase = kind({
 	styles: {
 		css,
 		className: 'picker',
-		publicClassNames: ['picker', 'active', 'label', 'item', 'itemTop', 'itemBottom']
-
+		publicClassNames: true
 	},
 
 	handlers: {

--- a/ProgressBar/ProgressBar.js
+++ b/ProgressBar/ProgressBar.js
@@ -81,7 +81,8 @@ const ProgressBarBase = kind({
 	},
 
 	styles: {
-		css: componentCss
+		css: componentCss,
+		publicClassNames: true
 	},
 
 	computed: {

--- a/SliderButton/SliderButton.js
+++ b/SliderButton/SliderButton.js
@@ -71,7 +71,8 @@ const SliderButtonBase = kind({
 	},
 	styles: {
 		css: componentCss,
-		className: 'sliderButton'
+		className: 'sliderButton',
+		publicClassNames: true
 	},
 	computed: {
 		max: ({children}) => (children && children.length ? children.length - 1 : 0),

--- a/ToggleButton/ToggleButton.js
+++ b/ToggleButton/ToggleButton.js
@@ -138,7 +138,8 @@ const ToggleButtonBase = kind({
 
 	styles: {
 		css,
-		className: 'toggleButton'
+		className: 'toggleButton',
+		publicClassNames: true
 	},
 
 	computed: {


### PR DESCRIPTION
Update `publicClassNames` for `LabeledIcon`, `LabeledIconButton`, `Picker`, `ProgressBar`, `SliderButton`, and `ToggleButton`.