### PR TITLE
PLAT-84598: Fix react lifecycle  deprecation warnings

### DIFF
--- a/IncrementSlider/IncrementSlider.js
+++ b/IncrementSlider/IncrementSlider.js
@@ -379,18 +379,18 @@ const IncrementSliderBase = kind({
 		onDecrement: emitChange(-1),
 		onIncrement: emitChange(1),
 		onKeyDown: (ev, props) => {
-			const {css, orientation} = props;
+			const {orientation} = props;
 
 			forward('onKeyDown', ev, props);
 
 			// if the source of the event is the slider, forward it along
-			if (ev.target.classList.contains(css.slider)) {
+			if (ev.target.classList.contains(componentCss.slider)) {
 				forward('onSpotlightDirection', ev, props);
 				return;
 			}
 
-			const isIncrement = ev.target.classList.contains(css.incrementButton);
-			const isDecrement = ev.target.classList.contains(css.decrementButton);
+			const isIncrement = ev.target.classList.contains(componentCss.incrementButton);
+			const isDecrement = ev.target.classList.contains(componentCss.decrementButton);
 
 			if (isRight(ev.keyCode) && (isIncrement || orientation === 'vertical')) {
 				forwardWithType('onSpotlightRight', props);

--- a/Popup/Popup.js
+++ b/Popup/Popup.js
@@ -37,7 +37,7 @@ const PopupBase = kind({
 	computed: {
 		className: ({closeButton, title, styler}) => styler.append({withCloseButton: closeButton, withTitle: title})
 	},
-	render: ({buttons, children, closeButton, css, noAnimation, onClose, onHide, open, skin, title, ...rest}) => {
+	render: ({buttons, children, closeButton, css, noAnimation, onCloseButtonClick, onHide, open, skin, title, ...rest}) => {
 		const wideLayout = (skin === 'carbon');
 
 		return (
@@ -57,7 +57,7 @@ const PopupBase = kind({
 					{closeButton ? <Button
 						icon="closex"
 						small
-						onTap={onClose}
+						onTap={onCloseButtonClick}
 						className={componentCss.closeButton}
 					/> : null}
 					{title ? <Divider className={css.title}>{title}</Divider> : null}

--- a/Slider/SliderBehaviorDecorator.js
+++ b/Slider/SliderBehaviorDecorator.js
@@ -59,8 +59,8 @@ const SliderBehaviorDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			orientation: 'horizontal'
 		}
 
-		constructor () {
-			super();
+		constructor (props) {
+			super(props);
 
 			this.paused = new Pause();
 			this.handleActivate = this.handleActivate.bind(this);
@@ -75,14 +75,19 @@ const SliderBehaviorDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				active: false,
 				dragging: false,
 				focused: false,
-				useHintText: false
+				useHintText: false,
+				prevValue: props.value
 			};
 		}
 
-		componentWillReceiveProps (nextProps) {
-			if (this.props.value !== nextProps.value) {
-				this.setState({useHintText: false});
+		static getDerivedStateFromProps (props, state) {
+			if (props.value !== state.prevValue) {
+				return {
+					useHintText: false,
+					prevValue: props.value
+				};
 			}
+			return null;
 		}
 
 		componentWillUnmount () {


### PR DESCRIPTION
This fixes the react life-cycle deprecation warnings in the following components:
- `PopupState`
- `SliderBehaviorDecorator`

I have also fixed a couple of associated errors which made testing this lifecycle change difficult or impossible.