### PR TITLE
ENYO-6245: agate/Heading: styles for spacing prop are not applied

### DIFF
--- a/Heading/Heading.js
+++ b/Heading/Heading.js
@@ -87,7 +87,7 @@ const HeadingBase = kind({
 	},
 
 	computed: {
-		className: ({showLine, styler}) => styler.append({showLine}),
+		className: ({showLine, spacing, styler}) => styler.append({showLine}, spacing),
 		style: ({color, style}) => ({
 			...style,
 			'--agate-heading-accent': color


### PR DESCRIPTION
Spacing styles now get added to `className`