### PR TITLE
ENYO-6275: Fixed `noCloseButton` prop to pass TabbedPanels to panels

### DIFF
--- a/Panels/TabbedPanels.js
+++ b/Panels/TabbedPanels.js
@@ -16,11 +16,13 @@ const TabbedPanelsBase = kind({
 	name: 'TabbedPanels',
 	propTypes: {
 		index: PropTypes.number,
+		noCloseButton: PropTypes.bool,
 		tabPosition: PropTypes.string
 		// tabs: PropTypes.oneOfType([TabGroup])
 	},
 	defaultProps: {
 		index: 0,
+		noCloseButton: false,
 		tabPosition: 'before'
 	},
 	styles: {

--- a/Panels/TabbedPanels.js
+++ b/Panels/TabbedPanels.js
@@ -49,7 +49,7 @@ const TabbedPanelsBase = kind({
 		className: ({css, orientation, styler, tabPosition}) => styler.append(tabPosition == 'after' ? css.reverse : '', orientation == 'vertical' ? css.column : ''),
 		tabOrientation: ({orientation}) => orientation === 'vertical' ? 'horizontal' : 'vertical'
 	},
-	render: ({afterTabs, beforeTabs, children, css, index, onSelect, tabOrientation, tabPosition, tabs, ...rest}) => {
+	render: ({afterTabs, beforeTabs, children, css, index, noCloseButton, onSelect, tabOrientation, tabPosition, tabs, ...rest}) => {
 		return (
 			<Layout {...rest}>
 				<Cell shrink>
@@ -67,6 +67,7 @@ const TabbedPanelsBase = kind({
 				<Cell
 					className={css.panels}
 					component={Panels}
+					noCloseButton={noCloseButton}
 					orientation={tabOrientation}
 					index={index}
 				>


### PR DESCRIPTION
There is no way to remove the close button of a TabbedPanels from app.
When this PR is merged, we can use `noCloseButton` prop to hide the close button on the TabbedPanels.

Enact-DCO-1.0-Signed-off-by: Baekwoo Jung (baekwoo.jung@lge.com)