### PR TITLE
PLAT-85937: Freeze state in dev mode to prevent direct mutation

### DIFF
--- a/data/ProviderDecorator/ProviderDecorator.js
+++ b/data/ProviderDecorator/ProviderDecorator.js
@@ -21,9 +21,27 @@ const ProviderDecorator = hoc({state: {}}, (config, Wrapped) => {
 			this.setState(produce(cb));
 		};
 
+		getState (state) {
+			if (__DEV__) {
+				return Object.freeze(
+					Object.keys(state).reduce((acc, key) => {
+						if (typeof state[key] === 'object') {
+							acc[key] = this.getState(state[key]);
+						} else {
+							acc[key] = state[key];
+						}
+
+						return acc;
+					}, {})
+				);
+			}
+
+			return state;
+		}
+
 		render () {
 			const context = {
-				state: this.state,
+				state: this.getState(this.state),
 				updateAppState: this.updateAppState
 			};
 


### PR DESCRIPTION
We had some code that was directly mutating state to cache service requests. We've discussed other ways to handle that particular concern but this PR freezes the state object in dev-mode to prevent that mutation.

Signed-off-by: Ryan Duffy <ryan.duffy@lge.com>