### PR TITLE
ENYO-6274: Remove background color in Panels

### DIFF
--- a/Panels/Panels.module.less
+++ b/Panels/Panels.module.less
@@ -23,11 +23,11 @@
 			.position(0, auto, auto, 0);
 			z-index: 10;
 			overflow: hidden;
-	
+
 			.breadcrumb {
 				position: absolute;
 				display: table;
-	
+
 				.breadcrumbContent {
 					display: table-cell;
 					vertical-align: middle;
@@ -54,8 +54,6 @@
 	}
 
 	.applySkins({
-		background-color: @agate-panels-bg-color;
-
 		.controls {
 			top: @agate-panels-controls-top;
 			.position-start-end(auto, @agate-panel-h-padding);
@@ -67,7 +65,7 @@
 				background-color: @agate-panels-breadcrumb-bg-color;
 				height: @agate-panels-breadcrumb-height;
 				width: @agate-panels-breadcrumb-width;
-				
+
 				.breadcrumb {
 					height: @agate-panels-breadcrumb-height;
 					width: @agate-panels-breadcrumb-width;


### PR DESCRIPTION
Background image was applied to AgateDecorator.
To show it under a panels properly, the panels's background color style should be removed.

I don't know the full history why the background color was added at the first time in https://github.com/enactjs/agate/pull/115. But it seems to me that we need to remove it now.

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)