### PR TITLE
ENYO-6273: Define letter-spacing and text-index in Icon instead of being inherited from Button

### DIFF
--- a/Icon/Icon.module.less
+++ b/Icon/Icon.module.less
@@ -18,6 +18,8 @@
 		text-align: center;
 		position: relative;
 		color: inherit;
+		letter-spacing: @agate-icon-letter-spacing;
+		text-indent: @agate-icon-letter-spacing;
 
 		&.huge {
 			background-position: center -((@agate-icon-sprite-huge-size - @agate-icon-huge-size) / 2);

--- a/Icon/Icon.module.less
+++ b/Icon/Icon.module.less
@@ -19,7 +19,7 @@
 		position: relative;
 		color: inherit;
 		letter-spacing: @agate-icon-letter-spacing;
-		text-indent: @agate-icon-letter-spacing;
+		text-indent: @agate-icon-text-indent;
 
 		&.huge {
 			background-position: center -((@agate-icon-sprite-huge-size - @agate-icon-huge-size) / 2);

--- a/styles/variables-gallium.less
+++ b/styles/variables-gallium.less
@@ -139,6 +139,8 @@
 @agate-icon-sprite-small-size: (@agate-icon-button-small-size - (@agate-button-border-width * 2));
 @agate-icon-sprite-huge-size: 250px;
 @agate-icon-margin: @agate-component-spacing;
+@agate-icon-letter-spacing: normal;
+@agate-icon-text-indent: initial;
 
 // IconButton
 // ---------------------------------------

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -4,5 +4,3 @@
 // App
 // ---------------------------------------
 @agate-app-keepout: 18px;
-@agate-icon-letter-spacing: normal;
-@agate-icon-text-indent: initial;

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -4,3 +4,4 @@
 // App
 // ---------------------------------------
 @agate-app-keepout: 18px;
+@agate-icon-letter-spacing: initial;

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -4,4 +4,5 @@
 // App
 // ---------------------------------------
 @agate-app-keepout: 18px;
-@agate-icon-letter-spacing: initial;
+@agate-icon-letter-spacing: normal;
+@agate-icon-text-indent: initial;


### PR DESCRIPTION
### Issue Resolved / Feature Added

The Icon position in only `Copper` and `Cobalt` skins shifted to the right in Icon Button.

### Resolution

The Icon `letter-spacing` and `text-index` styles were inherited from Button with `normal` value.
But the those styles of Button in the `Copper` and `Cobalt` skins were updated with `9x` in https://github.com/enactjs/agate/pull/97 and https://github.com/enactjs/agate/pull/101.
So we needed to define those styles in Icon separately.
Browser did not recognize `normal` value for them. So I defined those styles in Icon as `initial` to override the those styles in Button.

### Links
ENYO-6273

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)