### PR TITLE
ENYO- 6274: Define default panels bg color

### DIFF
--- a/styles/colors-carbon.less
+++ b/styles/colors-carbon.less
@@ -135,6 +135,7 @@
 @agate-panels-tab-focus-color:        white;
 @agate-panels-tab-focus-bg-color:     ~"hsla(var(--agate-accent-h, 0), var(--agate-accent-s, 0), var(--agate-accent-l, 0), 0.2)"; // @agate-accent; // fade(@agate-accent, 20%);
 @agate-panels-tab-focus-bg-image:     linear-gradient(to bottom, ~"hsla(var(--agate-accent-h, 0), var(--agate-accent-s, 0), var(--agate-accent-l, 0), 0.1)", @agate-accent 98%, @agate-accent);
+@agate-panels-bg-color:               transparent;
 
 // Picker
 // ---------------------------------------

--- a/styles/colors-cobalt-day.less
+++ b/styles/colors-cobalt-day.less
@@ -145,6 +145,7 @@
 @agate-panels-tab-focus-color:        @agate-foreground-focus;
 @agate-panels-tab-focus-bg-color:     transparent;
 @agate-panels-tab-focus-bg-image:     none;
+@agate-panels-bg-color:               transparent;
 
 // Picker
 // ---------------------------------------

--- a/styles/colors-cobalt.less
+++ b/styles/colors-cobalt.less
@@ -151,6 +151,7 @@
 @agate-panels-tab-focus-color:        @agate-accent;
 @agate-panels-tab-focus-bg-color:     transparent;
 @agate-panels-tab-focus-bg-image:     transparent;
+@agate-panels-bg-color:               transparent;
 
 // Picker
 // ---------------------------------------

--- a/styles/colors-copper-day.less
+++ b/styles/colors-copper-day.less
@@ -145,6 +145,7 @@
 @agate-panels-tab-focus-color:        @agate-foreground-focus;
 @agate-panels-tab-focus-bg-color:     transparent;
 @agate-panels-tab-focus-bg-image:     none;
+@agate-panels-bg-color:               transparent;
 
 // Picker
 // ---------------------------------------

--- a/styles/colors-copper.less
+++ b/styles/colors-copper.less
@@ -148,6 +148,7 @@
 @agate-panels-tab-focus-color:        @agate-text-color;
 @agate-panels-tab-focus-bg-color:     transparent;
 @agate-panels-tab-focus-bg-image:     transparent;
+@agate-panels-bg-color:               transparent;
 
 // Picker
 // ---------------------------------------

--- a/styles/colors-electro.less
+++ b/styles/colors-electro.less
@@ -148,6 +148,7 @@
 @agate-panels-tab-focus-color:        white;
 @agate-panels-tab-focus-bg-color:     ~"hsla(var(--agate-accent-h, 0), var(--agate-accent-s, 0), var(--agate-accent-l, 0), 0.2)";
 @agate-panels-tab-focus-bg-image:     @agate-gradient;
+@agate-panels-bg-color:               transparent;
 
 // Picker
 // ---------------------------------------

--- a/styles/colors-titanium.less
+++ b/styles/colors-titanium.less
@@ -135,6 +135,7 @@
 @agate-panels-tab-focus-color:        @agate-text-color;
 @agate-panels-tab-focus-bg-color:     transparent;
 @agate-panels-tab-focus-bg-image:     @agate-panels-tab-bg-image;
+@agate-panels-bg-color:               transparent;
 
 // Picker
 // ---------------------------------------

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -4,5 +4,3 @@
 // App
 // ---------------------------------------
 @agate-app-keepout: 18px;
-
-@agate-panels-bg-color: transparent;

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -4,3 +4,5 @@
 // App
 // ---------------------------------------
 @agate-app-keepout: 18px;
+
+@agate-panels-bg-color: transparent;


### PR DESCRIPTION
### Issue Resolved / Feature Added

The background color of panels in `Copper` skin is white. It should be transparent.

### Resolution

The background color of panels in `gallium day` skin color was defined in https://github.com/enactjs/agate/pull/126/files#diff-09f4b42163b21125118257a2164d1ed5R142
But the `gallium day` skin color was the default color for all skins. So that color was also applied to `Copper` skin. We needed to define it as default background color for all skins separately.

### Links
ENYO-6274

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)