### PR TITLE
PLAT-86435: Enable Scroller container after wheeling

### DIFF
--- a/Scrollable/Scrollable.js
+++ b/Scrollable/Scrollable.js
@@ -715,7 +715,7 @@ class ScrollableBase extends Component {
 	stop = () => {
 		if (this.isDragging && !this.isFlicked) return;
 
-		if (this.props['data-spotlight-container-disabled'] || this.isFlicked) {
+		if (this.props['data-spotlight-container-disabled'] || this.isFlicked || this.isWheeling) {
 			this.childRef.current.setContainerDisabled(false);
 		}
 		this.focusOnItem();


### PR DESCRIPTION
### Issue
The `Scroller` component disables its container when a wheel event starts, but does not enable the container again after the scroll stops.

### Fix
We explicitly enable the `Scroller` after a `scrollStop` event, we just need to also check if the scroll was caused by a wheel event.