### PR TITLE
PLAT-86438: Conditionally apply shrink prop based on the presence of label

### DIFF
--- a/Item/Item.js
+++ b/Item/Item.js
@@ -58,12 +58,12 @@ const ItemContent = kind({
 		// specified, all of the cells should be set to `shrink` so their height is summed to define
 		// the height of the entire Layout. Without this, a cell will collapse, causing unwanted overlap.
 		const contentElement = (
-			<Cell component={Marquee} className={css.content} shrink={(orientation === 'vertical')}>
+			<Cell component={Marquee} className={css.content} shrink={(label != null && orientation === 'vertical')}>
 				{content}
 			</Cell>
 		);
 
-		if (!label) return contentElement;
+		if (label == null) return contentElement;
 
 		return (
 			<Cell {...rest}>


### PR DESCRIPTION

Conditionally apply shrink prop based on the presence of label.

The item field will now display, even if empty-string to preserve layout, in case that's your intent. Undefined or null will remove it entirely (for the case of you having not set it).
