### PR TITLE
PLAT-86660: agate/Popup should forward to `onClose` when the close button is tapped/clicked

### DIFF
--- a/Popup/Popup.js
+++ b/Popup/Popup.js
@@ -1,5 +1,4 @@
 import compose from 'ramda/src/compose';
-import {forward, handle} from '@enact/core/handle';
 import kind from '@enact/core/kind';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -21,7 +20,7 @@ const PopupBase = kind({
 		closeButton: PropTypes.bool,
 		css: PropTypes.object,
 		noAnimation: PropTypes.bool,
-		onCloseButtonClick: PropTypes.func,
+		onClose: PropTypes.func,
 		onHide: PropTypes.func,
 		open: PropTypes.bool,
 		title: PropTypes.string
@@ -35,16 +34,10 @@ const PopupBase = kind({
 		css: componentCss,
 		className: 'popup'
 	},
-	handlers: {
-		onCloseButtonClick: handle(
-			forward('onCloseButtonClick'),
-			forward('onClose')
-		)
-	},
 	computed: {
 		className: ({closeButton, title, styler}) => styler.append({withCloseButton: closeButton, withTitle: title})
 	},
-	render: ({buttons, children, closeButton, css, noAnimation, onCloseButtonClick, onHide, open, skin, title, ...rest}) => {
+	render: ({buttons, children, closeButton, css, noAnimation, onClose, onHide, open, skin, title, ...rest}) => {
 		const wideLayout = (skin === 'carbon');
 
 		return (
@@ -63,7 +56,7 @@ const PopupBase = kind({
 				>
 					{closeButton ? <Button
 						icon="closex"
-						onTap={onCloseButtonClick}
+						onTap={onClose}
 						className={componentCss.closeButton}
 						size="small"
 					/> : null}

--- a/Popup/Popup.js
+++ b/Popup/Popup.js
@@ -17,12 +17,17 @@ import componentCss from './Popup.module.less';
 const PopupBase = kind({
 	name: 'Popup',
 	propTypes: {
+		buttons: PropTypes.oneOfType([
+			PropTypes.element,
+			PropTypes.arrayOf(PropTypes.element)
+		]),
 		closeButton: PropTypes.bool,
 		css: PropTypes.object,
 		noAnimation: PropTypes.bool,
 		onClose: PropTypes.func,
 		onHide: PropTypes.func,
 		open: PropTypes.bool,
+		skin: PropTypes.string,
 		title: PropTypes.string
 	},
 	defaultProps: {

--- a/Popup/Popup.js
+++ b/Popup/Popup.js
@@ -1,4 +1,5 @@
 import compose from 'ramda/src/compose';
+import {forward, handle} from '@enact/core/handle';
 import kind from '@enact/core/kind';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -33,6 +34,12 @@ const PopupBase = kind({
 	styles: {
 		css: componentCss,
 		className: 'popup'
+	},
+	handlers: {
+		onCloseButtonClick: handle(
+			forward('onCloseButtonClick'),
+			forward('onClose')
+		)
 	},
 	computed: {
 		className: ({closeButton, title, styler}) => styler.append({withCloseButton: closeButton, withTitle: title})

--- a/Popup/PopupState.js
+++ b/Popup/PopupState.js
@@ -10,7 +10,6 @@ const OpenState = {
 	OPEN: 2
 };
 
-const forwardClose = forward('onClose');
 const forwardHide = forward('onHide');
 
 const PopupState = hoc((config, Wrapped) => {	// eslint-disable-line no-unused-vars
@@ -69,7 +68,6 @@ const PopupState = hoc((config, Wrapped) => {	// eslint-disable-line no-unused-v
 		}
 
 		handlePopupHide = () => {
-			forwardClose(null, this.props);
 			forwardHide(null, this.props);
 
 			this.setState({

--- a/Popup/PopupState.js
+++ b/Popup/PopupState.js
@@ -10,6 +10,7 @@ const OpenState = {
 	OPEN: 2
 };
 
+const forwardClose = forward('onClose');
 const forwardHide = forward('onHide');
 
 const PopupState = hoc((config, Wrapped) => {	// eslint-disable-line no-unused-vars
@@ -68,6 +69,7 @@ const PopupState = hoc((config, Wrapped) => {	// eslint-disable-line no-unused-v
 		}
 
 		handlePopupHide = () => {
+			forwardClose(null, this.props);
 			forwardHide(null, this.props);
 
 			this.setState({

--- a/PopupMenu/PopupMenu.js
+++ b/PopupMenu/PopupMenu.js
@@ -20,7 +20,7 @@ const PopupMenuBase = kind({
 		closeButton: PropTypes.bool,
 		css: PropTypes.object,
 		noAnimation: PropTypes.bool,
-		onCloseButtonClick: PropTypes.func,
+		onClose: PropTypes.func,
 		onHide: PropTypes.func,
 		open: PropTypes.bool,
 		title: PropTypes.string
@@ -37,7 +37,7 @@ const PopupMenuBase = kind({
 		className: 'popupMenu'
 	},
 
-	render: ({children, closeButton, css, noAnimation, onCloseButtonClick, onHide, open, title, ...rest}) => {
+	render: ({children, closeButton, css, noAnimation, onClose, onHide, open, title, ...rest}) => {
 		return (
 			<Transition
 				noAnimation={noAnimation}
@@ -58,7 +58,7 @@ const PopupMenuBase = kind({
 						{closeButton ? <IconButton
 							icon="cancel"
 							backgroundOpacity="lightOpaque"
-							onClick={onCloseButtonClick}
+							onClick={onClose}
 							className={css.closeButton}
 							size="huge"
 						>cancel</IconButton> : null}


### PR DESCRIPTION
We want to make sure that `onClose` is called when the popup is closed via the close button.