### PR TITLE
ENYO-6276: Forward onClose via clicking on close button if onCloseButtonClick prop is not passed

### DIFF
--- a/Popup/PopupState.js
+++ b/Popup/PopupState.js
@@ -10,6 +10,8 @@ const OpenState = {
 	OPEN: 2
 };
 
+const forwardClose = forward('onClose');
+const forwardCloseButtonClick = forward('onCloseButtonClick');
 const forwardHide = forward('onHide');
 
 const PopupState = hoc((config, Wrapped) => {	// eslint-disable-line no-unused-vars
@@ -20,6 +22,7 @@ const PopupState = hoc((config, Wrapped) => {	// eslint-disable-line no-unused-v
 			noAnimation: PropTypes.bool,
 			noAutoDismiss: PropTypes.bool,
 			onClose: PropTypes.func,
+			onCloseButtonClick: PropTypes.func,
 			open: PropTypes.bool,
 			scrimType: PropTypes.oneOf(['transparent', 'translucent', 'none'])
 		}
@@ -67,6 +70,14 @@ const PopupState = hoc((config, Wrapped) => {	// eslint-disable-line no-unused-v
 			}
 		}
 
+		handleCloseButtonClick = () => {
+			if (!this.props.onCloseButtonClick) {
+				forwardClose(null, this.props);
+			} else {
+				forwardCloseButtonClick(null, this.props);
+			}
+		}
+
 		handlePopupHide = () => {
 			forwardHide(null, this.props);
 
@@ -78,6 +89,7 @@ const PopupState = hoc((config, Wrapped) => {	// eslint-disable-line no-unused-v
 
 		render () {
 			const {noAutoDismiss, onClose, scrimType, ...rest} = this.props;
+			delete rest.onCloseButtonClick;
 			delete rest.spotlightRestrict;
 
 			return (
@@ -92,6 +104,7 @@ const PopupState = hoc((config, Wrapped) => {	// eslint-disable-line no-unused-v
 						{...rest}
 						open={this.state.popupOpen >= OpenState.OPENING}
 						onClose={onClose}
+						onCloseButtonClick={this.handleCloseButtonClick}
 						onHide={this.handlePopupHide}
 					/>
 				</FloatingLayer>


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)

It seems to me that we don't have to forward `onCloseButtonClick` via clicking out of a popup if `onClose` prop is not passed. I supposed that `onClose`is the main event handler and the `onClose` will be called if the sub event handler is missing like `onCloseButtonClick`.