### PR TITLE
PLAT-87047: Connect Button on the wifi password window is not able to be tapped but must be clicked with mouse device

### DIFF
--- a/Input/pointer.js
+++ b/Input/pointer.js
@@ -21,11 +21,23 @@ const handlePointerUp = handle(
 	stop						// (and stop propagation to support touch)
 );
 
-const handlePointerClick = handle(
+// This is attached to both click and touchend. On some systems (e.g. Chrome), click events are
+// fired when you touch anything but other systems (e.g. iOS) will only emit click events when you
+// touch a clickable component (something with a tabindex). By attaching the same handler to both,
+// we ensure that we do not leave this module in an unstable state where it thinks capturing is
+// active but focus is not on the input.
+const handleTap = handle(
 	isCapturing,				// if a down event was captured
 	stop,						// prevent the click event from propagating
+	preventDefault,				// prevent touchend from triggering a click after releasing lock
 	setCapturing(false),		// clear the capturing flag
 	() => active.blur()			// and blur the active node
+);
+
+const handleTouchStart = handle(
+	shouldCapture,                // If we should capture the click
+	stop,                         // prevent other components from handling this event
+	setCapturing(true)            // and flag that we've started capturing a down event
 );
 
 // Lock the pointer from emitting click events until released
@@ -33,9 +45,9 @@ const lockPointer = (target) => {
 	active = target;
 	document.addEventListener('mousedown', handlePointerDown, {capture: true});
 	document.addEventListener('mouseup', handlePointerUp, {capture: true});
-	document.addEventListener('touchstart', handlePointerDown, {capture: true});
-	document.addEventListener('touchend', handlePointerUp, {capture: true});
-	document.addEventListener('click', handlePointerClick, {capture: true});
+	document.addEventListener('touchstart', handleTouchStart, {capture: true});
+	document.addEventListener('touchend', handleTap, {capture: true});
+	document.addEventListener('click', handleTap, {capture: true});
 };
 
 // Release the pointer and allow subsequent click events
@@ -44,9 +56,9 @@ const releasePointer = (target) => {
 		active = null;
 		document.removeEventListener('mousedown', handlePointerDown, {capture: true});
 		document.removeEventListener('mouseup', handlePointerUp, {capture: true});
-		document.removeEventListener('touchstart', handlePointerDown, {capture: true});
-		document.removeEventListener('touchend', handlePointerUp, {capture: true});
-		document.removeEventListener('click', handlePointerClick, {capture: true});
+		document.removeEventListener('touchstart', handleTouchStart, {capture: true});
+		document.removeEventListener('touchend', handleTap, {capture: true});
+		document.removeEventListener('click', handleTap, {capture: true});
 	}
 };
 


### PR DESCRIPTION
Advances in our touch event handling for `moonstone` have left `agate` behind.  This patch ensures consistent handling of touch and pointer events for `agate/Input`.