### PR TITLE
PLAT-85937: Add deep-freeze in dev mode

### DIFF
--- a/data/ProviderDecorator/ProviderDecorator.js
+++ b/data/ProviderDecorator/ProviderDecorator.js
@@ -1,3 +1,4 @@
+import freeze from 'deep-freeze';
 import hoc from '@enact/core/hoc';
 import {produce} from 'immer';
 import React, {Component} from 'react';
@@ -21,9 +22,17 @@ const ProviderDecorator = hoc({state: {}}, (config, Wrapped) => {
 			this.setState(produce(cb));
 		};
 
+		getState () {
+			if (__DEV__) {
+				return freeze(this.state);
+			}
+
+			return this.state;
+		}
+
 		render () {
 			const context = {
-				state: this.state,
+				state: this.getState(this.state),
 				updateAppState: this.updateAppState
 			};
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@enact/ui": "^3.1.2",
     "classnames": "^2.2.6",
     "color-convert": "^1.9.3",
+    "deep-freeze": "0.0.1",
     "eases": "^1.0.8",
     "immer": "^3.2.0",
     "prop-types": "^15.6.2",


### PR DESCRIPTION
Prior implementations (#134, #135) were naive and should have used `hasOwnProperty()`. Instead of adding that, added the small `deep-freeze` module which handles this correctly.

Signed-off-by: Ryan Duffy <ryan.duffy@lge.com>