### PR TITLE
PLAT-97799: Add Skin Variants for night mode

### DIFF
--- a/AgateDecorator/AgateDecorator.js
+++ b/AgateDecorator/AgateDecorator.js
@@ -217,7 +217,7 @@ const AgateDecorator = hoc(defaultConfig, (config, Wrapped) => {
 	if (ri) App = ResolutionDecorator(ri, App);
 	if (i18n) App = I18nDecorator(App);
 	if (spotlight) App = SpotlightRootDecorator({noAutoFocus}, App);
-	if (skin) App = Skinnable({defaultSkin: 'gallium-day'}, App);
+	if (skin) App = Skinnable({defaultSkin: 'gallium'}, App);
 
 	// add webOS-specific key maps
 	addAll({

--- a/AgateDecorator/tests/AgateDecorator-specs.js
+++ b/AgateDecorator/tests/AgateDecorator-specs.js
@@ -9,7 +9,7 @@ describe('AgateDecorator', () => {
 
 	const AppRoot = (props) => <div id="app" {...props} />;
 
-	test('should add base gallium-day classes to wrapped component', function () {
+	test('should add base gallium classes to wrapped component', function () {
 		const config = {ri: false, i18n: false, spotlight: false, float: false, overlay: false};
 		const App = AgateDecorator(config, AppRoot);
 		const subject = mount(
@@ -21,7 +21,7 @@ describe('AgateDecorator', () => {
 		const appRoot = subject.find('#app');
 
 		const expected = true;
-		const actual = appRoot.hasClass('gallium-day');
+		const actual = appRoot.hasClass('gallium');
 
 		expect(actual).toBe(expected);
 	});

--- a/Skinnable/Skinnable.js
+++ b/Skinnable/Skinnable.js
@@ -13,14 +13,13 @@ const defaultConfig = {
 	skins: {
 		carbon: 'carbon',
 		cobalt: 'cobalt',
-		'cobalt-day': 'cobalt-day',
 		copper: 'copper',
-		'copper-day': 'copper-day',
 		electro: 'electro',
-		'gallium-day': 'gallium-day',
-		'gallium-night': 'gallium-night',
+		gallium: 'gallium',
 		titanium: 'titanium'
-	}
+	},
+	allowedVariants: ['night', 'highContrast'],
+	defaultVariants: null
 };
 
 /**

--- a/styles/skin.less
+++ b/styles/skin.less
@@ -24,39 +24,48 @@
 		@componentRules();
 	});
 	.buildSkinRules(cobalt; {
-		@import (multiple) "./colors-cobalt.less";
 		@import (multiple) "./variables-cobalt.less";
-		@componentRules();
-	});
-	.buildSkinRules(cobalt-day; {
-		@import (multiple) "./colors-cobalt-day.less";
-		@import (multiple) "./variables-cobalt.less";
-		@componentRules();
+
+		// .buildSkinRules(day; {
+			@import (multiple) "./colors-cobalt-day.less";
+			@componentRules();
+		// });
+
+		.buildSkinRules(night; {
+			@import (multiple) "./colors-cobalt.less";
+			@componentRules();
+		});
 	});
 	.buildSkinRules(copper; {
-		@import (multiple) "./colors-copper.less";
 		@import (multiple) "./variables-copper.less";
-		@componentRules();
-	});
-	.buildSkinRules(copper-day; {
-		@import (multiple) "./colors-copper-day.less";
-		@import (multiple) "./variables-copper.less";
-		@componentRules();
+
+		// .buildSkinRules(day; {
+			@import (multiple) "./colors-copper-day.less";
+			@componentRules();
+		// });
+
+		.buildSkinRules(night; {
+			@import (multiple) "./colors-copper.less";
+			@componentRules();
+		});
 	});
 	.buildSkinRules(electro; {
 		@import (multiple) "./colors-electro.less";
 		@import (multiple) "./variables-electro.less";
 		@componentRules();
 	});
-	.buildSkinRules(gallium-day; {
-		@import (multiple) "./colors-gallium-day.less";
+	.buildSkinRules(gallium; {
 		@import (multiple) "./variables-gallium.less";
-		@componentRules();
-	});
-	.buildSkinRules(gallium-night; {
-		@import (multiple) "./colors-gallium-night.less";
-		@import (multiple) "./variables-gallium.less";
-		@componentRules();
+
+		// .buildSkinRules(day; {
+			@import (multiple) "./colors-gallium-day.less";
+			@componentRules();
+		// });
+
+		.buildSkinRules(night; {
+			@import (multiple) "./colors-gallium-night.less";
+			@componentRules();
+		});
 	});
 	.buildSkinRules(titanium; {
 		@import (multiple) "./colors-titanium.less";

--- a/styles/skin.less
+++ b/styles/skin.less
@@ -26,10 +26,8 @@
 	.buildSkinRules(cobalt; {
 		@import (multiple) "./variables-cobalt.less";
 
-		// .buildSkinRules(day; {
-			@import (multiple) "./colors-cobalt-day.less";
-			@componentRules();
-		// });
+		@import (multiple) "./colors-cobalt-day.less";
+		@componentRules();
 
 		.buildSkinRules(night; {
 			@import (multiple) "./colors-cobalt.less";
@@ -39,10 +37,8 @@
 	.buildSkinRules(copper; {
 		@import (multiple) "./variables-copper.less";
 
-		// .buildSkinRules(day; {
-			@import (multiple) "./colors-copper-day.less";
-			@componentRules();
-		// });
+		@import (multiple) "./colors-copper-day.less";
+		@componentRules();
 
 		.buildSkinRules(night; {
 			@import (multiple) "./colors-copper.less";
@@ -57,10 +53,8 @@
 	.buildSkinRules(gallium; {
 		@import (multiple) "./variables-gallium.less";
 
-		// .buildSkinRules(day; {
-			@import (multiple) "./colors-gallium-day.less";
-			@componentRules();
-		// });
+		@import (multiple) "./colors-gallium-day.less";
+		@componentRules();
 
 		.buildSkinRules(night; {
 			@import (multiple) "./colors-gallium-night.less";


### PR DESCRIPTION
Converted existing skins to use `skinVariants` to capture day vs night mode. All skins can be easily switched between and their appropriate day or night skin will switch along with the main one.

A companion branch of the same name is available in the https://github.com/enyojs/webos-auto-settings repo.