### PR TITLE
PLAT-95484: Update Slider

### DIFF
--- a/styles/colors-gallium-day.less
+++ b/styles/colors-gallium-day.less
@@ -178,21 +178,10 @@
 // Slider
 // ---------------------------------------
 @agate-slider-color:          @agate-accent;
-@agate-slider-bg-color:       transparent;
-@agate-slider-bg-image:       none;
-@agate-slider-track-bg-color: fade(#666, 50%);
-@agate-slider-track-bg-image: linear-gradient(to top, transparent, fade(black, 3%));
-@agate-slider-track-focus-bg-color: @agate-slider-track-bg-color;
-@agate-slider-track-focus-bg-image: @agate-gradient;
-@agate-slider-fill-bg-color:  @agate-background-active;
-@agate-slider-fill-bg-image:  none;
-@agate-slider-focus-color:    black;
-@agate-slider-focus-bg-color: @agate-slider-bg-color;
-@agate-slider-focus-bg-image: none;
-@agate-slider-knob-bg-color:  @agate-accent;
-@agate-slider-knob-bg-image:  linear-gradient(to bottom, transparent, fade(#333, 50%));
-@agate-slider-knob-focus-bg-color: @agate-slider-knob-bg-color;
-@agate-slider-knob-focus-bg-image: @agate-slider-knob-bg-image;
+@agate-slider-track-bg-color: fade(black, 10%);
+@agate-slider-fill-bg-color:  black;
+@agate-slider-knob-bg-color:  @agate-dark-gray;
+@agate-slider-knob-focus-bg-color: @agate-accent;
 @agate-slider-knob-shadow:    0 3px 9px 3px fade(black, 30%);
 @agate-slider-knob-focus-shadow: @agate-slider-knob-shadow;
 

--- a/styles/colors-gallium-night.less
+++ b/styles/colors-gallium-night.less
@@ -181,21 +181,10 @@
 // Slider
 // ---------------------------------------
 @agate-slider-color:          @agate-accent;
-@agate-slider-bg-color:       transparent;
-@agate-slider-bg-image:       none;
-@agate-slider-track-bg-color: fade(#666, 50%);
-@agate-slider-track-bg-image: linear-gradient(to top, transparent, fade(black, 3%));
-@agate-slider-track-focus-bg-color: @agate-slider-track-bg-color;
-@agate-slider-track-focus-bg-image: @agate-gradient;
-@agate-slider-fill-bg-color:  @agate-background-active;
-@agate-slider-fill-bg-image:  none;
-@agate-slider-focus-color:    black;
-@agate-slider-focus-bg-color: @agate-slider-bg-color;
-@agate-slider-focus-bg-image: none;
-@agate-slider-knob-bg-color:  @agate-accent;
-@agate-slider-knob-bg-image:  linear-gradient(to bottom, transparent, fade(#333, 50%));
-@agate-slider-knob-focus-bg-color: @agate-slider-knob-bg-color;
-@agate-slider-knob-focus-bg-image: @agate-slider-knob-bg-image;
+@agate-slider-track-bg-color: @agate-darker-gray;
+@agate-slider-fill-bg-color:  @agate-white;
+@agate-slider-knob-bg-color:  @agate-dark-gray;
+@agate-slider-knob-focus-bg-color: @agate-accent;
 @agate-slider-knob-shadow:    0 3px 9px 3px fade(black, 30%);
 @agate-slider-knob-focus-shadow: @agate-slider-knob-shadow;
 

--- a/styles/variables-base.less
+++ b/styles/variables-base.less
@@ -325,6 +325,7 @@
 
 // Slider
 // ---------------------------------------
+@agate-slider-knob-height: @agate-slider-height;
 @agate-slider-knob-active-transform: @agate-slider-knob-transform;
 @agate-slider-knob-border-radius: @agate-slider-knob-height;
 @agate-slider-knob-border-width: 0;

--- a/styles/variables-gallium.less
+++ b/styles/variables-gallium.less
@@ -110,9 +110,9 @@
 @agate-slider-knob-border-radius: (@agate-slider-knob-height / 2);
 @agate-slider-knob-resting-state-scale: 0.77;
 // Additional offset (-12% at min position, 0% halfway, and +12% at max position) is needed when scaled down to 0.77 so that the knob stays within the progressbar
-@agate-slider-knob-transform: translate(calc((var(--ui-slider-proportion-end-knob) * -100%) + (-12% + ((var(--ui-slider-proportion-end-knob) * 0.24) * 100%))), -50%) scale(0.77);
+@agate-slider-knob-transform: translate(calc((var(--ui-slider-proportion-end-knob) * -100%) + (-12% + (var(--ui-slider-proportion-end-knob) * 24%))), -50%) scale(@agate-slider-knob-resting-state-scale);
 // Additional offset (-5px at min position, 0px halfway, and +5px at max position) is needed when focused and scaled back to 1
-@agate-slider-knob-active-transform: translate(calc((var(--ui-slider-proportion-end-knob) * -100%) + (-5px + ((var(--ui-slider-proportion-end-knob) * 0.1) * 100px))), -50%) scale(1);
+@agate-slider-knob-active-transform: translate(calc((var(--ui-slider-proportion-end-knob) * -100%) + (-5px + (var(--ui-slider-proportion-end-knob) * 10px))), -50%) scale(1);
 @agate-slider-border-radius: 3px;
 @agate-slider-horizontal-padding: ((@agate-slider-knob-height - @agate-slider-track-height) / 2) (@agate-slider-knob-height / 2);
 @agate-slider-vertical-margin: 0;

--- a/styles/variables-gallium.less
+++ b/styles/variables-gallium.less
@@ -106,10 +106,14 @@
 
 // Slider
 // ---------------------------------------
+@agate-slider-knob-height: 45px;
 @agate-slider-knob-border-radius: (@agate-slider-knob-height / 2);
-@agate-slider-knob-resting-state-scale: 0.8;
-@agate-slider-knob-transform: @agate-translate-center scale(0.8);
-@agate-slider-border-radius: 0;
+@agate-slider-knob-resting-state-scale: 0.77;
+// Additional offset (-12% at min position, 0% halfway, and +12% at max position) is needed when scaled down to 0.77 so that the knob stays within the progressbar
+@agate-slider-knob-transform: translate(calc((var(--ui-slider-proportion-end-knob) * -100%) + (-12% + ((var(--ui-slider-proportion-end-knob) * 0.24) * 100%))), -50%) scale(0.77);
+// Additional offset (-5px at min position, 0px halfway, and +5px at max position) is needed when focused and scaled back to 1
+@agate-slider-knob-active-transform: translate(calc((var(--ui-slider-proportion-end-knob) * -100%) + (-5px + ((var(--ui-slider-proportion-end-knob) * 0.1) * 100px))), -50%) scale(1);
+@agate-slider-border-radius: 3px;
 @agate-slider-horizontal-padding: ((@agate-slider-knob-height - @agate-slider-track-height) / 2) (@agate-slider-knob-height / 2);
 @agate-slider-vertical-margin: 0;
 @agate-slider-vertical-padding: (@agate-slider-knob-height / 2) ((@agate-slider-knob-height - @agate-slider-track-height) / 2);


### PR DESCRIPTION
Updated `Slider` colors and knob position.

<img width="712" alt="slider-day-focus" src="https://user-images.githubusercontent.com/8940009/70952521-5629b080-201b-11ea-8d6e-fe6da8922c92.png">
<img width="684" alt="slider-day" src="https://user-images.githubusercontent.com/8940009/70952522-5629b080-201b-11ea-9ab9-b7c934298a9a.png">
<img width="714" alt="slider-night-focus" src="https://user-images.githubusercontent.com/8940009/70952523-5629b080-201b-11ea-9360-953d63c21664.png">
<img width="703" alt="slider-night" src="https://user-images.githubusercontent.com/8940009/70952524-56c24700-201b-11ea-9ab9-39ea27bd67fd.png">

When focused, knob grows from 35px to 45px in height, and 5px over the edge of the progressbar:
<img width="96" alt="knob-focus-edge" src="https://user-images.githubusercontent.com/8940009/70952525-56c24700-201b-11ea-80dd-d4c5662196f4.png">
Normal knob at the edge of the progressbar:
<img width="72" alt="knob-edge" src="https://user-images.githubusercontent.com/8940009/70952526-575add80-201b-11ea-9893-6a3003c2297d.png">
