### PR TITLE
PLAT-98292: Adds skin-based partial-coverage Panels customization

### DIFF
--- a/Panels/Panels.js
+++ b/Panels/Panels.js
@@ -91,6 +91,15 @@ const PanelsBase = kind({
 		]),
 
 		/**
+		 * The portion of the screen that this `Panels` instance should cover.
+		 *
+		 * @type {('full'|'partial')}
+		 * @default 'full'
+		 * @public
+		 */
+		cover: PropTypes.oneOf(['full', 'partial']),
+
+		/**
 		 * Duration of the animation (in ms) when transitioning between `Panel` components.
 		 *
 		 * @type {Number}
@@ -190,6 +199,7 @@ const PanelsBase = kind({
 	},
 
 	defaultProps: {
+		cover: 'full',
 		duration: 500,
 		index: 0,
 		noAnimation: false,
@@ -222,7 +232,7 @@ const PanelsBase = kind({
 			return updatedChildProps;
 		},
 
-		className: ({controls, noCloseButton, styler}) => styler.append({
+		className: ({controls, cover, noCloseButton, styler}) => styler.append(cover, {
 			'agate-panels-hasControls': (!noCloseButton || !!controls) // If there is a close button or controls were specified
 		}),
 
@@ -254,6 +264,7 @@ const PanelsBase = kind({
 		...rest
 	}) => {
 		delete rest.controlsMeasurements;
+		delete rest.cover;
 		delete rest.onBack;
 
 		const controlsId = getControlsId(id);

--- a/Panels/Panels.module.less
+++ b/Panels/Panels.module.less
@@ -23,11 +23,11 @@
 			.position(0, auto, auto, 0);
 			z-index: 10;
 			overflow: hidden;
-	
+
 			.breadcrumb {
 				position: absolute;
 				display: table;
-	
+
 				.breadcrumbContent {
 					display: table-cell;
 					vertical-align: middle;
@@ -62,12 +62,20 @@
 			.padding-start-end(@agate-panels-controls-padding-start, initial);
 		}
 
+		.partial {
+			background-color: @agate-panels-partial-bg-color;
+			background-image: @agate-panels-partial-bg-image;
+			height: @agate-panels-partial-height;
+			width: @agate-panels-partial-width;
+		}
+
 		&.breadcrumbPanels {
 			.breadcrumbs {
 				background-color: @agate-panels-breadcrumb-bg-color;
+				background-image: @agate-panels-breadcrumb-bg-image;
 				height: @agate-panels-breadcrumb-height;
 				width: @agate-panels-breadcrumb-width;
-				
+
 				.breadcrumb {
 					height: @agate-panels-breadcrumb-height;
 					width: @agate-panels-breadcrumb-width;

--- a/styles/colors-base.less
+++ b/styles/colors-base.less
@@ -164,7 +164,10 @@
 // Panels
 // ---------------------------------------
 @agate-panels-bg-color:               inherit;
+@agate-panels-partial-bg-color:       inherit;
+@agate-panels-partial-bg-image:       inherit;
 @agate-panels-breadcrumb-bg-color:    inherit;
+@agate-panels-breadcrumb-bg-image:    inherit;
 @agate-panels-tab-separator-border-color: inherit;
 @agate-panels-tab-color:              @agate-text-color;
 @agate-panels-tab-bg-color:           inherit;

--- a/styles/colors-carbon.less
+++ b/styles/colors-carbon.less
@@ -104,6 +104,7 @@
 
 // Panels
 // ---------------------------------------
+@agate-panels-partial-bg-color:       fade(@agate-bg-color, 50%);
 @agate-panels-tab-separator-border-color: #333;
 @agate-panels-tab-color:              @agate-foreground;
 @agate-panels-tab-bg-color:           transparent;

--- a/styles/colors-cobalt-day.less
+++ b/styles/colors-cobalt-day.less
@@ -114,6 +114,7 @@
 
 // Panels
 // ---------------------------------------
+@agate-panels-partial-bg-color:       @agate-bg-color;
 @agate-panels-tab-separator-border-color: transparent;
 @agate-panels-tab-color:              @agate-accent;
 @agate-panels-tab-bg-color:           fade(black, 5%);

--- a/styles/colors-copper-day.less
+++ b/styles/colors-copper-day.less
@@ -114,6 +114,8 @@
 
 // Panels
 // ---------------------------------------
+@agate-panels-partial-bg-color:       @agate-drawer-bg-color;
+@agate-panels-partial-bg-image:       @agate-drawer-bg-image;
 @agate-panels-tab-separator-border-color: transparent;
 @agate-panels-tab-color:              @agate-accent;
 @agate-panels-tab-bg-color:           fade(black, 5%);

--- a/styles/colors-copper.less
+++ b/styles/colors-copper.less
@@ -118,6 +118,8 @@
 
 // Panels
 // ---------------------------------------
+@agate-panels-partial-bg-color:       @agate-drawer-bg-color;
+@agate-panels-partial-bg-image:       @agate-drawer-bg-image;
 @agate-panels-tab-separator-border-color: transparent;
 @agate-panels-tab-color:              @agate-text-color;
 @agate-panels-tab-bg-color:           fade(white, 5%);

--- a/styles/colors-electro.less
+++ b/styles/colors-electro.less
@@ -118,6 +118,7 @@
 
 // Panels
 // ---------------------------------------
+@agate-panels-partial-bg-color:       @agate-bg-color;
 @agate-panels-tab-separator-border-color: transparent;
 @agate-panels-tab-color:              @agate-text-color;
 @agate-panels-tab-bg-color:           transparent;

--- a/styles/colors-gallium-night.less
+++ b/styles/colors-gallium-night.less
@@ -118,6 +118,7 @@
 // Panels
 // ---------------------------------------
 @agate-panels-bg-color:               @agate-background;
+@agate-panels-partial-bg-color:       @agate-background;
 @agate-panels-breadcrumb-bg-color:    @agate-bg-color;
 @agate-panels-tab-separator-border-color: #333;
 @agate-panels-tab-color:              @agate-foreground;

--- a/styles/colors-titanium.less
+++ b/styles/colors-titanium.less
@@ -105,6 +105,7 @@
 
 // Panels
 // ---------------------------------------
+@agate-panels-partial-bg-color:       @agate-bg-color;
 @agate-panels-tab-separator-border-color: transparent;
 @agate-panels-tab-color:              fade(black, 50%);
 @agate-panels-tab-bg-color:           lighten(@agate-bg-color, 5%);

--- a/styles/variables-base.less
+++ b/styles/variables-base.less
@@ -255,6 +255,8 @@
 // ---------------------------------------
 @agate-panel-v-padding: @agate-app-keepout;
 @agate-panel-h-padding: inherit;
+@agate-panels-partial-height: auto;
+@agate-panels-partial-width: 50%;
 @agate-panels-breadcrumb-height: 100%;
 @agate-panels-breadcrumb-width: 100px;
 @agate-panels-controls-top: inherit;

--- a/styles/variables-carbon.less
+++ b/styles/variables-carbon.less
@@ -43,6 +43,8 @@
 
 // Panels
 // ---------------------------------------
+@agate-panels-partial-height: 50%;
+@agate-panels-partial-width: auto;
 @agate-panels-tab-margin: 0;
 @agate-panels-tab-padding: 18px 0;
 @agate-panels-tab-separator-border-width: 1px;

--- a/styles/variables-gallium.less
+++ b/styles/variables-gallium.less
@@ -64,6 +64,7 @@
 @agate-panel-v-padding: @agate-app-keepout;
 // @agate-panel-h-padding: (@agate-app-keepout - @agate-spotlight-outset);
 @agate-panel-h-padding: extract(@agate-panels-panel-padding, 2);
+@agate-panels-partial-width: 890px;
 @agate-panels-breadcrumb-height: 100%;
 @agate-panels-breadcrumb-width: 105px;
 @agate-panels-controls-top: (extract(@agate-panels-panel-padding, 1) + 41px);


### PR DESCRIPTION
Added a `cover` prop to Panels which is now responsible for determining several states of screen coverage, definable by a skin. Initially supported states are "full" and "partial". "full" is expected to fully cover the screen, in any skin (at the moment), while "partial" covers some proportion of the screen, defined by the preferred layout of the skin.

This also includes the ability for a skin to choose a different background color/image for a partial panels instance that differs from a full-screen scenario, since one may need to be a basic translucency while others may want an opaque occluding background. Skins are updated to include an appropriate background and size for this feature.

Other possible `cover` values in the future could be values like "pip", "floater", "partial-reversed", "partial-rtl", etc.