### PR TITLE
ENYO-6393: Fix up SliderButton

### DIFF
--- a/SliderButton/SliderButton.js
+++ b/SliderButton/SliderButton.js
@@ -45,6 +45,7 @@ const SliderKnob = kind({
 	},
 	render: ({...rest}) => {
 		delete rest.value;
+		delete rest.tooltipComponent;
 		return (
 			<div
 				{...rest}
@@ -57,14 +58,15 @@ const SliderProgress = kind({
 	name: 'SliderProgress',
 	propTypes: {
 		css: PropTypes.object,
-		values: PropTypes.arrayOf(PropTypes.number)
+		values: PropTypes.arrayOf(PropTypes.string)
 	},
 	styles: {
 		css: componentCss,
 		className: 'track'
 	},
 	render: ({children, css, values, ...rest}) => {
-
+		delete rest.progressAnchor;
+		delete rest.backgroundProgress;
 		return (
 			<Row {...rest} align="center">
 				{children}

--- a/SliderButton/SliderButton.js
+++ b/SliderButton/SliderButton.js
@@ -45,6 +45,7 @@ const SliderKnob = kind({
 	},
 	render: ({...rest}) => {
 		delete rest.value;
+		// eslint-disable-next-line enact/prop-types
 		delete rest.tooltipComponent;
 		return (
 			<div
@@ -65,7 +66,9 @@ const SliderProgress = kind({
 		className: 'track'
 	},
 	render: ({children, css, values, ...rest}) => {
+		// eslint-disable-next-line enact/prop-types
 		delete rest.progressAnchor;
+		// eslint-disable-next-line enact/prop-types
 		delete rest.backgroundProgress;
 		return (
 			<Row {...rest} align="center">

--- a/SliderButton/SliderButton.module.less
+++ b/SliderButton/SliderButton.module.less
@@ -10,6 +10,7 @@
 
 	// shrink the slider's available space by the width of one item, distributed to both ends (padding);
 	padding: 0 ~"calc(var(--sliderbutton-item-size) / 2)";
+	box-sizing: border-box;
 
 	&::before {
 		content: "";
@@ -31,6 +32,7 @@
 		left: ~"calc(var(--knob-value) * var(--sliderbutton-item-size))";
 		will-change: left;
 		transition: left 200ms ease-in-out;
+		box-sizing: border-box;
 	}
 
 	.track {
@@ -50,9 +52,11 @@
 	.applySkins({
 		margin: @agate-sliderbutton-margin;
 		height: @agate-button-height;
+		border: @agate-sliderbutton-border-width solid @agate-sliderbutton-border-color;
 		border-radius: @agate-sliderbutton-border-radius;
 		background-color: @agate-sliderbutton-bg-color;
 		background-image: @agate-sliderbutton-bg-image;
+		background-clip: @agate-sliderbutton-bg-clip;
 		cursor: pointer;
 		transform: @agate-sliderbutton-bg-transform;
 
@@ -65,7 +69,9 @@
 			background-color: @agate-sliderbutton-knob-bg-color;
 			background-image: @agate-sliderbutton-knob-bg-image;
 			box-shadow: @agate-sliderbutton-knob-shadow;
-			border-radius: @agate-sliderbutton-border-radius;
+			border: @agate-sliderbutton-knob-border-width solid @agate-sliderbutton-knob-border-color;
+			border-radius: @agate-sliderbutton-knob-border-radius;
+			transform: @agate-sliderbutton-knob-transform;
 		}
 
 		.focus({

--- a/styles/colors-base.less
+++ b/styles/colors-base.less
@@ -293,11 +293,13 @@
 @agate-sliderbutton-color:          inherit;
 @agate-sliderbutton-bg-color:       @agate-slider-bg-color;
 @agate-sliderbutton-bg-image:       @agate-slider-bg-image;
+@agate-sliderbutton-border-color:   transparent;
 @agate-sliderbutton-focus-color:    @agate-slider-focus-color;
 @agate-sliderbutton-focus-bg-color: @agate-sliderbutton-bg-color;
 @agate-sliderbutton-focus-bg-image: @agate-sliderbutton-bg-image;
 @agate-sliderbutton-knob-bg-color:  @agate-slider-knob-bg-color;
 @agate-sliderbutton-knob-bg-image:  @agate-slider-knob-bg-image;
+@agate-sliderbutton-knob-border-color: transparent;
 @agate-sliderbutton-knob-shadow:    @agate-slider-knob-shadow;
 @agate-sliderbutton-knob-focus-shadow: @agate-slider-knob-focus-shadow;
 

--- a/styles/colors-gallium-day.less
+++ b/styles/colors-gallium-day.less
@@ -227,14 +227,16 @@
 
 // SliderButton
 // ---------------------------------------
-@agate-sliderbutton-color:          @agate-accent;
+@agate-sliderbutton-color:          @agate-white;
 @agate-sliderbutton-bg-color:       @agate-slider-track-bg-color;
 @agate-sliderbutton-bg-image:       @agate-slider-track-bg-image;
+@agate-sliderbutton-border-color:   transparent;
 @agate-sliderbutton-focus-color:    @agate-slider-focus-color;
 @agate-sliderbutton-focus-bg-color: @agate-slider-track-focus-bg-color;
 @agate-sliderbutton-focus-bg-image: @agate-slider-track-focus-bg-image;
-@agate-sliderbutton-knob-bg-color:  @agate-slider-knob-bg-color;
-@agate-sliderbutton-knob-bg-image:  @agate-slider-knob-bg-image;
+@agate-sliderbutton-knob-bg-color:  transparent;
+@agate-sliderbutton-knob-bg-image:  none;
+@agate-sliderbutton-knob-border-color: @agate-accent;
 @agate-sliderbutton-knob-shadow:    @agate-slider-knob-shadow;
 @agate-sliderbutton-knob-focus-shadow: @agate-slider-knob-focus-shadow;
 

--- a/styles/colors-gallium-day.less
+++ b/styles/colors-gallium-day.less
@@ -227,7 +227,7 @@
 
 // SliderButton
 // ---------------------------------------
-@agate-sliderbutton-color:          @agate-white;
+@agate-sliderbutton-color:          @agate-text-color;
 @agate-sliderbutton-bg-color:       @agate-slider-track-bg-color;
 @agate-sliderbutton-bg-image:       @agate-slider-track-bg-image;
 @agate-sliderbutton-border-color:   transparent;

--- a/styles/colors-gallium-day.less
+++ b/styles/colors-gallium-day.less
@@ -26,11 +26,11 @@
 @agate-white:       #fff;
 
 // Component color assignments
-@agate-bg-color: black;
+@agate-bg-color: @agate-background;
 @agate-bg-image: none;
 @agate-bg-image2: none;
 @agate-text-color: @agate-foreground;
-@agate-title-text-color: white;
+@agate-title-text-color: @agate-foreground;
 
 // Disabled Opacity
 // ---------------------------------------

--- a/styles/colors-gallium-night.less
+++ b/styles/colors-gallium-night.less
@@ -231,7 +231,7 @@
 
 // SliderButton
 // ---------------------------------------
-@agate-sliderbutton-color:          @agate-white;
+@agate-sliderbutton-color:          @agate-text-color;
 @agate-sliderbutton-bg-color:       @agate-slider-track-bg-color;
 @agate-sliderbutton-bg-image:       @agate-slider-track-bg-image;
 @agate-sliderbutton-border-color:   transparent;

--- a/styles/colors-gallium-night.less
+++ b/styles/colors-gallium-night.less
@@ -231,14 +231,16 @@
 
 // SliderButton
 // ---------------------------------------
-@agate-sliderbutton-color:          @agate-accent;
+@agate-sliderbutton-color:          @agate-white;
 @agate-sliderbutton-bg-color:       @agate-slider-track-bg-color;
 @agate-sliderbutton-bg-image:       @agate-slider-track-bg-image;
+@agate-sliderbutton-border-color:   transparent;
 @agate-sliderbutton-focus-color:    @agate-slider-focus-color;
 @agate-sliderbutton-focus-bg-color: @agate-slider-track-focus-bg-color;
 @agate-sliderbutton-focus-bg-image: @agate-slider-track-focus-bg-image;
-@agate-sliderbutton-knob-bg-color:  @agate-slider-knob-bg-color;
-@agate-sliderbutton-knob-bg-image:  @agate-slider-knob-bg-image;
+@agate-sliderbutton-knob-bg-color:  transparent;
+@agate-sliderbutton-knob-bg-image:  none;
+@agate-sliderbutton-knob-border-color: @agate-accent;
 @agate-sliderbutton-knob-shadow:    @agate-slider-knob-shadow;
 @agate-sliderbutton-knob-focus-shadow: @agate-slider-knob-focus-shadow;
 

--- a/styles/variables-base.less
+++ b/styles/variables-base.less
@@ -388,8 +388,13 @@
 // SliderButton
 // ---------------------------------------
 @agate-sliderbutton-border-radius: @agate-border-radius;
+@agate-sliderbutton-border-width: 0;
 @agate-sliderbutton-bg-transform: @agate-slider-bg-transform;
+@agate-sliderbutton-bg-clip: initial;
 @agate-sliderbutton-client-transform: @agate-slider-track-transform;
+@agate-sliderbutton-knob-border-radius: @agate-sliderbutton-border-radius;
+@agate-sliderbutton-knob-border-width: 0;
+@agate-sliderbutton-knob-transform: none;
 @agate-sliderbutton-margin: 3px 24px;
 
 // Spinner

--- a/styles/variables-gallium.less
+++ b/styles/variables-gallium.less
@@ -156,7 +156,7 @@
 @agate-sliderbutton-knob-border-radius: 6px;
 @agate-sliderbutton-knob-border-width: 3px;
 @agate-sliderbutton-knob-transform: scale(1.07, 1.4);
-@agate-sliderbutton-margin: 0 @agate-component-spacing;
+@agate-sliderbutton-margin: 6px 12px 18px 12px;
 
 // Spinner
 // ---------------------------------------

--- a/styles/variables-gallium.less
+++ b/styles/variables-gallium.less
@@ -150,6 +150,12 @@
 
 // SliderButton
 // ---------------------------------------
+@agate-sliderbutton-border-radius: 3px;
+@agate-sliderbutton-border-width: 12px;
+@agate-sliderbutton-bg-clip: padding-box;
+@agate-sliderbutton-knob-border-radius: 6px;
+@agate-sliderbutton-knob-border-width: 3px;
+@agate-sliderbutton-knob-transform: scale(1.07, 1.4);
 @agate-sliderbutton-margin: 0 @agate-component-spacing;
 
 // Spinner


### PR DESCRIPTION
SliderButton was largely ignored after its initial creation. This PR aims to improve its customizability by a skin, and leverages that customizability to make the SliderButton component, when used in the Gallium skin, look like it matches the target visual style.

<img width="356" alt="SliderButton-BeforeAfter" src="https://user-images.githubusercontent.com/386529/71758485-0a696a80-2e55-11ea-833b-30308dc599f3.png">
