### PR TITLE
PLAT-95484: Additional Slider knob offset fix

### DIFF
--- a/Slider/Slider.module.less
+++ b/Slider/Slider.module.less
@@ -83,7 +83,8 @@
 			}
 
 			.knob {
-				left: ~"calc(var(--ui-slider-proportion-end-knob) * 100%)";
+				left: calc((var(--ui-slider-proportion-end-knob) * 100%) + @agate-slider-knob-left-offset);
+				// calc((var(--ui-slider-proportion-end-knob) * 100%) + (15px - (var(--ui-slider-proportion-end-knob) * 30px)))
 			}
 		}
 

--- a/Slider/Slider.module.less
+++ b/Slider/Slider.module.less
@@ -18,7 +18,6 @@
 
 		.progressBar {
 			position: relative;
-			margin: @agate-slider-track-margin;
 			background-color: @agate-slider-track-bg-color;
 			background-image: @agate-slider-track-bg-image;
 			border-radius: @agate-slider-border-radius;
@@ -82,11 +81,12 @@
 			}
 
 			.progressBar{
+				margin: @agate-slider-track-horizontal-margin;
 				width: @agate-slider-track-horizontal-width;
 			}
 
 			.knob {
-				left: calc((var(--ui-slider-proportion-end-knob) * 100%) + @agate-slider-knob-left-offset);
+				left: calc((var(--ui-slider-proportion-end-knob) * 100%) + @agate-slider-knob-position-offset);
 			}
 		}
 
@@ -104,11 +104,12 @@
 			}
 
 			.progressBar{
+				margin: @agate-slider-track-vertical-margin;
 				height: @agate-slider-track-vertical-height;
 			}
 
 			.knob {
-				bottom: ~"calc(var(--ui-slider-proportion-end-knob) * 100%)";
+				bottom: calc((var(--ui-slider-proportion-end-knob) * 100%) + @agate-slider-knob-position-offset);
 				top: auto;
 			}
 		}

--- a/Slider/Slider.module.less
+++ b/Slider/Slider.module.less
@@ -18,8 +18,7 @@
 
 		.progressBar {
 			position: relative;
-			height: 100%;
-			width: 100%;
+			margin: @agate-slider-track-margin;
 			background-color: @agate-slider-track-bg-color;
 			background-image: @agate-slider-track-bg-image;
 			border-radius: @agate-slider-border-radius;
@@ -79,12 +78,15 @@
 			.progressBar,
 			.fill,
 			.load {
-				height: @agate-slider-track-height;
+				height: @agate-slider-track-horizontal-height;
+			}
+
+			.progressBar{
+				width: @agate-slider-track-horizontal-width;
 			}
 
 			.knob {
 				left: calc((var(--ui-slider-proportion-end-knob) * 100%) + @agate-slider-knob-left-offset);
-				// calc((var(--ui-slider-proportion-end-knob) * 100%) + (15px - (var(--ui-slider-proportion-end-knob) * 30px)))
 			}
 		}
 
@@ -98,7 +100,11 @@
 			.progressBar,
 			.fill,
 			.load {
-				width: @agate-slider-track-width;
+				width: @agate-slider-track-vertical-width;
+			}
+
+			.progressBar{
+				height: @agate-slider-track-vertical-height;
 			}
 
 			.knob {

--- a/styles/variables-base.less
+++ b/styles/variables-base.less
@@ -328,7 +328,7 @@
 
 // ProgressBar
 // ---------------------------------------
-@agate-progressbar-height: @agate-slider-track-height;
+@agate-progressbar-height: @agate-slider-track-horizontal-height;
 @agate-progressbar-vertical-width: @agate-progressbar-height;
 @agate-progressbar-small-height: (@agate-progressbar-height / 2);
 @agate-progressbar-vertical-small-width: @agate-progressbar-small-height;
@@ -349,13 +349,16 @@
 @agate-slider-knob-width: @agate-slider-knob-height;
 @agate-slider-border-radius: @agate-slider-height;
 @agate-slider-horizontal-margin: 0 @agate-component-spacing;
-@agate-slider-horizontal-padding: ((@agate-slider-height - @agate-slider-track-height) / 2) (@agate-slider-height / 2);
+@agate-slider-horizontal-padding: ((@agate-slider-height - @agate-slider-track-horizontal-height) / 2) (@agate-slider-height / 2);
 @agate-slider-vertical-margin: 0 @agate-component-spacing;
-@agate-slider-vertical-padding: (@agate-slider-height / 2) ((@agate-slider-height - @agate-slider-track-height) / 2);
+@agate-slider-vertical-padding: (@agate-slider-height / 2) ((@agate-slider-height - @agate-slider-track-horizontal-height) / 2);
 @agate-slider-height: @agate-button-height;
 @agate-slider-width: @agate-slider-height;
-@agate-slider-track-height: 12px;
-@agate-slider-track-width: @agate-slider-track-height;
+@agate-slider-track-margin: 0;
+@agate-slider-track-horizontal-height: 12px;
+@agate-slider-track-horizontal-width: 100%;
+@agate-slider-track-vertical-height: 100%;
+@agate-slider-track-vertical-width: @agate-slider-track-horizontal-height;
 @agate-slider-bg-transform: none;
 @agate-slider-track-transform: none;
 
@@ -364,7 +367,7 @@
 @agate-incrementslider-border-radius: 0;
 @agate-incrementslider-horizontal-margin: @agate-slider-horizontal-margin;
 @agate-incrementslider-horizontal-slider-margin: 0;
-@agate-incrementslider-horizontal-slider-padding: ((@agate-slider-height - @agate-slider-track-height) / 2) (((@agate-slider-knob-width / 2) * @agate-slider-knob-resting-state-scale) + 3px);
+@agate-incrementslider-horizontal-slider-padding: ((@agate-slider-height - @agate-slider-track-horizontal-height) / 2) (((@agate-slider-knob-width / 2) * @agate-slider-knob-resting-state-scale) + 3px);
 @agate-incrementslider-horizontal-button-margin: 0;
 @agate-incrementslider-horizontal-button-decrement-border-radius: @agate-slider-height 0 0 @agate-slider-height;
 @agate-incrementslider-horizontal-button-decrement-border-width: 0;

--- a/styles/variables-base.less
+++ b/styles/variables-base.less
@@ -342,7 +342,7 @@
 @agate-slider-knob-active-transform: @agate-slider-knob-transform;
 @agate-slider-knob-border-radius: @agate-slider-knob-height;
 @agate-slider-knob-border-width: 0;
-@agate-slider-knob-left-offset: 0px;
+@agate-slider-knob-position-offset: 0px;
 @agate-slider-knob-resting-state-scale: 1;
 @agate-slider-knob-transform: @agate-translate-center;
 @agate-slider-knob-height: @agate-slider-height;
@@ -354,9 +354,10 @@
 @agate-slider-vertical-padding: (@agate-slider-height / 2) ((@agate-slider-height - @agate-slider-track-horizontal-height) / 2);
 @agate-slider-height: @agate-button-height;
 @agate-slider-width: @agate-slider-height;
-@agate-slider-track-margin: 0;
+@agate-slider-track-horizontal-margin: 0;
 @agate-slider-track-horizontal-height: 12px;
 @agate-slider-track-horizontal-width: 100%;
+@agate-slider-track-vertical-margin: 0;
 @agate-slider-track-vertical-height: 100%;
 @agate-slider-track-vertical-width: @agate-slider-track-horizontal-height;
 @agate-slider-bg-transform: none;

--- a/styles/variables-base.less
+++ b/styles/variables-base.less
@@ -329,6 +329,7 @@
 @agate-slider-knob-active-transform: @agate-slider-knob-transform;
 @agate-slider-knob-border-radius: @agate-slider-knob-height;
 @agate-slider-knob-border-width: 0;
+@agate-slider-knob-left-offset: 0px;
 @agate-slider-knob-resting-state-scale: 1;
 @agate-slider-knob-transform: @agate-translate-center;
 @agate-slider-knob-height: @agate-slider-height;

--- a/styles/variables-carbon.less
+++ b/styles/variables-carbon.less
@@ -84,15 +84,15 @@
 @agate-slider-knob-width: @agate-slider-knob-height;
 @agate-slider-border-radius: 0;
 @agate-slider-horizontal-margin: 0 @agate-component-spacing;
-@agate-slider-horizontal-padding: ((@agate-slider-knob-height - @agate-slider-track-height) / 2) (@agate-slider-knob-height / 2);
+@agate-slider-horizontal-padding: ((@agate-slider-knob-height - @agate-slider-track-horizontal-height) / 2) (@agate-slider-knob-height / 2);
 @agate-slider-vertical-margin: 0;
-@agate-slider-vertical-padding: (@agate-slider-knob-height / 2) ((@agate-slider-knob-height - @agate-slider-track-height) / 2);
-@agate-slider-track-height: 6px;
+@agate-slider-vertical-padding: (@agate-slider-knob-height / 2) ((@agate-slider-knob-height - @agate-slider-track-horizontal-height) / 2);
+@agate-slider-track-horizontal-height: 6px;
 
 // IncrementSlider
 // ---------------------------------------
 @agate-incrementslider-horizontal-slider-margin: 0 (@agate-component-spacing * 2);
-@agate-incrementslider-horizontal-slider-padding: ((@agate-slider-height - @agate-slider-track-height) / 2) ((@agate-slider-knob-width / 2) * @agate-slider-knob-resting-state-scale);
+@agate-incrementslider-horizontal-slider-padding: ((@agate-slider-height - @agate-slider-track-horizontal-height) / 2) ((@agate-slider-knob-width / 2) * @agate-slider-knob-resting-state-scale);
 @agate-incrementslider-horizontal-button-decrement-border-radius: @agate-button-border-radius;
 @agate-incrementslider-horizontal-button-decrement-border-width: @agate-button-border-width;
 @agate-incrementslider-horizontal-button-increment-border-radius: @agate-incrementslider-horizontal-button-decrement-border-radius;

--- a/styles/variables-electro.less
+++ b/styles/variables-electro.less
@@ -126,9 +126,9 @@
 @agate-slider-knob-width: 30px;
 @agate-slider-border-radius: @electro-border-radius;
 @agate-slider-horizontal-margin: 3px 24px;
-@agate-slider-horizontal-padding: ((@agate-slider-height - @agate-slider-track-height) / 2) ((@agate-slider-knob-width / 2) + 9);
+@agate-slider-horizontal-padding: ((@agate-slider-height - @agate-slider-track-horizontal-height) / 2) ((@agate-slider-knob-width / 2) + 9);
 @agate-slider-vertical-margin: 24px 3px;
-@agate-slider-vertical-padding: (@agate-slider-height / 2) ((@agate-slider-height - @agate-slider-track-height) / 2);
+@agate-slider-vertical-padding: (@agate-slider-height / 2) ((@agate-slider-height - @agate-slider-track-horizontal-height) / 2);
 @agate-slider-bg-transform: skewX(@electro-skew);
 @agate-slider-track-transform: skewX(@electro-negate-skew);
 
@@ -137,7 +137,7 @@
 @electro-incrementslider-horizontal-slider-undertuck: 15px; // the amount the slider tucks underneath the side buttons
 @agate-incrementslider-horizontal-margin: 3px @agate-component-spacing;
 @agate-incrementslider-horizontal-slider-margin: 0 -@electro-incrementslider-horizontal-slider-undertuck;
-@agate-incrementslider-horizontal-slider-padding: ((@agate-slider-height - @agate-slider-track-height) / 2) (((@agate-slider-knob-width / 2) * @agate-slider-knob-resting-state-scale) + @electro-incrementslider-horizontal-slider-undertuck + 9px);
+@agate-incrementslider-horizontal-slider-padding: ((@agate-slider-height - @agate-slider-track-horizontal-height) / 2) (((@agate-slider-knob-width / 2) * @agate-slider-knob-resting-state-scale) + @electro-incrementslider-horizontal-slider-undertuck + 9px);
 @agate-incrementslider-horizontal-button-decrement-border-radius: @agate-button-border-radius;
 @agate-incrementslider-horizontal-button-decrement-border-width: @agate-button-border-width;
 @agate-incrementslider-horizontal-button-increment-border-radius: @agate-incrementslider-horizontal-button-decrement-border-radius;

--- a/styles/variables-gallium.less
+++ b/styles/variables-gallium.less
@@ -116,23 +116,29 @@
 
 // Slider
 // ---------------------------------------
+@gallium-knob-offset: 18px; // the offset to keep the knob inside the progressbar.
+
 @agate-slider-knob-height: 45px;
 @agate-slider-knob-border-radius: (@agate-slider-knob-height / 2);
 @agate-slider-knob-resting-state-scale: 0.77;
 // Additional offset (-18px at min position, 0px halfway, and -18px at max position, with a total distance of 36px) is needed so that the knob stays within the progressbar.
-@agate-slider-knob-left-offset: calc(18px - (var(--ui-slider-proportion-end-knob) * 36px));
+@agate-slider-knob-left-offset: calc(@gallium-knob-offset - (var(--ui-slider-proportion-end-knob) * (@gallium-knob-offset * 2)));
 @agate-slider-knob-active-transform: @agate-translate-center scale(1);
 @agate-slider-knob-transform: @agate-translate-center scale(@agate-slider-knob-resting-state-scale);
 @agate-slider-border-radius: 3px;
-@agate-slider-horizontal-padding: ((@agate-slider-knob-height - @agate-slider-track-height) / 2) (@agate-slider-knob-height / 2);
+@agate-slider-horizontal-padding: ((@agate-slider-knob-height - @agate-slider-track-horizontal-height) / 2) (@agate-slider-knob-height / 2);
 @agate-slider-vertical-margin: 0;
-@agate-slider-vertical-padding: (@agate-slider-knob-height / 2) ((@agate-slider-knob-height - @agate-slider-track-height) / 2);
-@agate-slider-track-height: 6px;
+@agate-slider-vertical-padding: (@agate-slider-knob-height / 2) ((@agate-slider-knob-height - @agate-slider-track-horizontal-height) / 2);
+@agate-slider-track-horizontal-height: 6px;
+// offsetting the progress bar so that `PositionDecorator` can calculate the knob position properly at the min and max
+@agate-slider-track-margin: 0 -@gallium-knob-offset;
+@agate-slider-track-horizontal-width: calc(100% + (@gallium-knob-offset * 2));
+@agate-slider-track-vertical-height: @agate-slider-track-horizontal-width;
 
 // IncrementSlider
 // ---------------------------------------
 @agate-incrementslider-horizontal-slider-margin: 0 (@agate-component-spacing * 2);
-@agate-incrementslider-horizontal-slider-padding: ((@agate-slider-height - @agate-slider-track-height) / 2) ((@agate-slider-knob-width / 2) * @agate-slider-knob-resting-state-scale);
+@agate-incrementslider-horizontal-slider-padding: ((@agate-slider-height - @agate-slider-track-horizontal-height) / 2) ((@agate-slider-knob-width / 2) * @agate-slider-knob-resting-state-scale);
 @agate-incrementslider-horizontal-button-decrement-border-radius: @agate-button-border-radius;
 @agate-incrementslider-horizontal-button-decrement-border-width: @agate-button-border-width;
 @agate-incrementslider-horizontal-button-increment-border-radius: @agate-incrementslider-horizontal-button-decrement-border-radius;

--- a/styles/variables-gallium.less
+++ b/styles/variables-gallium.less
@@ -122,7 +122,7 @@
 @agate-slider-knob-border-radius: (@agate-slider-knob-height / 2);
 @agate-slider-knob-resting-state-scale: 0.77;
 // Additional offset (-18px at min position, 0px halfway, and -18px at max position, with a total distance of 36px) is needed so that the knob stays within the progressbar.
-@agate-slider-knob-left-offset: calc(@gallium-knob-offset - (var(--ui-slider-proportion-end-knob) * (@gallium-knob-offset * 2)));
+@agate-slider-knob-position-offset: calc(@gallium-knob-offset - (var(--ui-slider-proportion-end-knob) * (@gallium-knob-offset * 2)));
 @agate-slider-knob-active-transform: @agate-translate-center scale(1);
 @agate-slider-knob-transform: @agate-translate-center scale(@agate-slider-knob-resting-state-scale);
 @agate-slider-border-radius: 3px;
@@ -131,8 +131,9 @@
 @agate-slider-vertical-padding: (@agate-slider-knob-height / 2) ((@agate-slider-knob-height - @agate-slider-track-horizontal-height) / 2);
 @agate-slider-track-horizontal-height: 6px;
 // offsetting the progress bar so that `PositionDecorator` can calculate the knob position properly at the min and max
-@agate-slider-track-margin: 0 -@gallium-knob-offset;
+@agate-slider-track-horizontal-margin: 0 -@gallium-knob-offset;
 @agate-slider-track-horizontal-width: calc(100% + (@gallium-knob-offset * 2));
+@agate-slider-track-vertical-margin: -@gallium-knob-offset 0;
 @agate-slider-track-vertical-height: @agate-slider-track-horizontal-width;
 
 // IncrementSlider

--- a/styles/variables-gallium.less
+++ b/styles/variables-gallium.less
@@ -121,7 +121,7 @@
 @agate-slider-knob-height: 45px;
 @agate-slider-knob-border-radius: (@agate-slider-knob-height / 2);
 @agate-slider-knob-resting-state-scale: 0.77;
-// Additional offset (-18px at min position, 0px halfway, and -18px at max position, with a total distance of 36px) is needed so that the knob stays within the progressbar.
+// Additional offset (+18px at min position, 0px halfway, and -18px at max position) is needed so that the knob stays within the progressbar.
 @agate-slider-knob-position-offset: calc(@gallium-knob-offset - (var(--ui-slider-proportion-end-knob) * (@gallium-knob-offset * 2)));
 @agate-slider-knob-active-transform: @agate-translate-center scale(1);
 @agate-slider-knob-transform: @agate-translate-center scale(@agate-slider-knob-resting-state-scale);
@@ -130,7 +130,7 @@
 @agate-slider-vertical-margin: 0;
 @agate-slider-vertical-padding: (@agate-slider-knob-height / 2) ((@agate-slider-knob-height - @agate-slider-track-horizontal-height) / 2);
 @agate-slider-track-horizontal-height: 6px;
-// offsetting the progress bar so that `PositionDecorator` can calculate the knob position properly at the min and max
+// adding the width and offsetting the progress bar margin so that `PositionDecorator` can calculate the knob position properly at the min and max
 @agate-slider-track-horizontal-margin: 0 -@gallium-knob-offset;
 @agate-slider-track-horizontal-width: calc(100% + (@gallium-knob-offset * 2));
 @agate-slider-track-vertical-margin: -@gallium-knob-offset 0;

--- a/styles/variables-gallium.less
+++ b/styles/variables-gallium.less
@@ -109,10 +109,10 @@
 @agate-slider-knob-height: 45px;
 @agate-slider-knob-border-radius: (@agate-slider-knob-height / 2);
 @agate-slider-knob-resting-state-scale: 0.77;
-// Additional offset (-12% at min position, 0% halfway, and +12% at max position) is needed when scaled down to 0.77 so that the knob stays within the progressbar
-@agate-slider-knob-transform: translate(calc((var(--ui-slider-proportion-end-knob) * -100%) + (-12% + (var(--ui-slider-proportion-end-knob) * 24%))), -50%) scale(@agate-slider-knob-resting-state-scale);
-// Additional offset (-5px at min position, 0px halfway, and +5px at max position) is needed when focused and scaled back to 1
-@agate-slider-knob-active-transform: translate(calc((var(--ui-slider-proportion-end-knob) * -100%) + (-5px + (var(--ui-slider-proportion-end-knob) * 10px))), -50%) scale(1);
+// Additional offset (-18px at min position, 0px halfway, and -18px at max position, with a total distance of 36px) is needed so that the knob stays within the progressbar.
+@agate-slider-knob-left-offset: calc(18px - (var(--ui-slider-proportion-end-knob) * 36px));
+@agate-slider-knob-active-transform: @agate-translate-center scale(1);
+@agate-slider-knob-transform: @agate-translate-center scale(@agate-slider-knob-resting-state-scale);
 @agate-slider-border-radius: 3px;
 @agate-slider-horizontal-padding: ((@agate-slider-knob-height - @agate-slider-track-height) / 2) (@agate-slider-knob-height / 2);
 @agate-slider-vertical-margin: 0;


### PR DESCRIPTION
Adding onto https://github.com/enactjs/agate/pull/189
Needed to move the knob offset to the knob's container instead of translating the knob itself, so that the knob won't animate the position offset.

Readjusted the `ProgressBar`'s width and margin so that `PositionDecorator` will calculate correctly given the knob's offset.

The math is: the knob needs to be +18px at min and -18px at max to be inside the progress bar. Added additional 18px to the progress bar on both sides, and then had to resort to negative 18px margin to center the progress bar.