### PR TITLE
PLAT-98491: Gallium slider knob fully encapsulated

### DIFF
--- a/IncrementSlider/IncrementSlider.module.less
+++ b/IncrementSlider/IncrementSlider.module.less
@@ -31,7 +31,10 @@
 			.slider {
 				flex-grow: 1;
 				margin: @agate-incrementslider-horizontal-slider-margin;
-				border-radius: @agate-incrementslider-border-radius;
+
+				&::before {
+					border-radius: @agate-incrementslider-border-radius;
+				}
 			}
 		}
 
@@ -55,7 +58,10 @@
 				order: 2;
 				margin: @agate-incrementslider-vertical-slider-margin;
 				padding: @agate-incrementslider-vertical-slider-padding;
-				border-radius: @agate-incrementslider-border-radius;
+
+				&::before {
+					border-radius: @agate-incrementslider-border-radius;
+				}
 			}
 
 			.incrementButton {

--- a/Slider/Slider.module.less
+++ b/Slider/Slider.module.less
@@ -11,10 +11,18 @@
 		width: @agate-slider-width;
 		box-sizing: border-box;
 		direction: ltr;
-		background-color: @agate-slider-bg-color;
-		background-image: @agate-slider-bg-image;
-		border-radius: @agate-slider-border-radius;
-		transform: @agate-slider-bg-transform;
+		background-color: transparent;
+		background-image: none;
+
+		&::before {
+			content: "";
+			position: absolute;
+			.position(0);
+			background-color: @agate-slider-bg-color;
+			background-image: @agate-slider-bg-image;
+			border-radius: @agate-slider-border-radius;
+			transform: @agate-slider-bg-transform;
+		}
 
 		.progressBar {
 			position: relative;
@@ -141,8 +149,13 @@
 			}
 
 			.focus({
-				background-color: @agate-slider-focus-bg-color;
-				background-image: @agate-slider-focus-bg-image;
+				background-color: transparent;
+				background-image: none;
+
+				&::before {
+					background-color: @agate-slider-focus-bg-color;
+					background-image: @agate-slider-focus-bg-image;
+				}
 
 				.bar {
 					background-color: @agate-slider-track-focus-bg-color;

--- a/Slider/Slider.module.less
+++ b/Slider/Slider.module.less
@@ -20,6 +20,9 @@
 			position: relative;
 			height: 100%;
 			width: 100%;
+		}
+
+		.bar {
 			background-color: @agate-slider-track-bg-color;
 			background-image: @agate-slider-track-bg-image;
 			border-radius: @agate-slider-border-radius;
@@ -53,6 +56,8 @@
 				background-color: @agate-slider-knob-bg-color;
 				background-image: @agate-slider-knob-bg-image;
 				box-shadow: @agate-slider-knob-shadow;
+				top: 50%;
+				left: 50%;
 			}
 		}
 
@@ -76,6 +81,11 @@
 			margin: @agate-slider-horizontal-margin;
 			padding: @agate-slider-horizontal-padding;
 
+			.bar {
+				left: ((@agate-slider-horizontal-anchorpoint-width / 2) * -1);
+				width: ~"calc(100% + " @agate-slider-horizontal-anchorpoint-width ~")";
+			}
+
 			.progressBar,
 			.fill,
 			.load {
@@ -93,6 +103,11 @@
 			min-height: 120px;
 			display: inline-block;
 			vertical-align: top;
+
+			.bar {
+				bottom: ((@agate-slider-vertical-anchorpoint-height / 2) * -1);
+				height: ~"calc(100% + " @agate-slider-vertical-anchorpoint-height ~")";
+			}
 
 			.progressBar,
 			.fill,
@@ -129,7 +144,7 @@
 				background-color: @agate-slider-focus-bg-color;
 				background-image: @agate-slider-focus-bg-image;
 
-				.progressBar {
+				.bar {
 					background-color: @agate-slider-track-focus-bg-color;
 					background-image: @agate-slider-track-focus-bg-image;
 				}

--- a/styles/variables-base.less
+++ b/styles/variables-base.less
@@ -340,6 +340,10 @@
 
 // Slider
 // ---------------------------------------
+@agate-slider-horizontal-anchorpoint-height: 0px;  // This is used in `calc` which means it needs the unit specified to work correctly
+@agate-slider-horizontal-anchorpoint-width: 0px;  // This is used in `calc` which means it needs the unit specified to work correctly
+@agate-slider-vertical-anchorpoint-height: 0px;  // This is used in `calc` which means it needs the unit specified to work correctly
+@agate-slider-vertical-anchorpoint-width: 0px;  // This is used in `calc` which means it needs the unit specified to work correctly
 @agate-slider-knob-height: @agate-slider-height;
 @agate-slider-knob-active-transform: @agate-slider-knob-transform;
 @agate-slider-knob-border-radius: @agate-slider-knob-height;

--- a/styles/variables-electro.less
+++ b/styles/variables-electro.less
@@ -121,15 +121,14 @@
 // ---------------------------------------
 @agate-slider-knob-border-radius: @electro-border-radius;
 @agate-slider-knob-resting-state-scale: 0.8;
-@agate-slider-knob-transform: @agate-translate-center scale(@agate-slider-knob-resting-state-scale);
+@agate-slider-knob-transform: @agate-translate-center scale(@agate-slider-knob-resting-state-scale) skewX(@electro-skew);
 @agate-slider-knob-width: 30px;
 @agate-slider-border-radius: @electro-border-radius;
-@agate-slider-horizontal-margin: 3px 24px;
+@agate-slider-horizontal-margin: 3px 21px;
 @agate-slider-horizontal-padding: ((@agate-slider-height - @agate-slider-track-height) / 2) ((@agate-slider-knob-width / 2) + 9);
-@agate-slider-vertical-margin: 24px 3px;
+@agate-slider-vertical-margin: 0 3px;
 @agate-slider-vertical-padding: (@agate-slider-height / 2) ((@agate-slider-height - @agate-slider-track-height) / 2);
 @agate-slider-bg-transform: skewX(@electro-skew);
-@agate-slider-track-transform: skewX(@electro-negate-skew);
 
 // IncrementSlider
 // ---------------------------------------

--- a/styles/variables-electro.less
+++ b/styles/variables-electro.less
@@ -119,10 +119,9 @@
 
 // Slider
 // ---------------------------------------
-@agate-slider-knob-active-transform: @agate-translate-center scale(1), skewX(@electro-skew);
 @agate-slider-knob-border-radius: @electro-border-radius;
 @agate-slider-knob-resting-state-scale: 0.8;
-@agate-slider-knob-transform: @agate-translate-center scale(0.8) skewX(@electro-skew);
+@agate-slider-knob-transform: @agate-translate-center scale(@agate-slider-knob-resting-state-scale);
 @agate-slider-knob-width: 30px;
 @agate-slider-border-radius: @electro-border-radius;
 @agate-slider-horizontal-margin: 3px 24px;

--- a/styles/variables-gallium.less
+++ b/styles/variables-gallium.less
@@ -120,8 +120,8 @@
 @agate-slider-height: @agate-item-height;
 @agate-slider-width: @agate-slider-knob-height;
 @agate-slider-knob-height: 45px;
-@agate-slider-horizontal-anchorpoint-width: @agate-slider-knob-height;
-@agate-slider-vertical-anchorpoint-height: @agate-slider-knob-height;
+@agate-slider-horizontal-anchorpoint-width: (@agate-slider-knob-height * @agate-slider-knob-resting-state-scale - 1px); // just a touch under the resting state scale, to avoid subpixel rendering overflow
+@agate-slider-vertical-anchorpoint-height: (@agate-slider-knob-height * @agate-slider-knob-resting-state-scale - 1px); // just a touch under the resting state scale, to avoid subpixel rendering overflow
 @agate-slider-knob-border-radius: (@agate-slider-knob-height / 2);
 @agate-slider-knob-resting-state-scale: 0.9;
 @agate-slider-knob-transform: @agate-translate-center scale(@agate-slider-knob-resting-state-scale);

--- a/styles/variables-gallium.less
+++ b/styles/variables-gallium.less
@@ -117,16 +117,18 @@
 
 // Slider
 // ---------------------------------------
+@agate-slider-height: @agate-item-height;
+@agate-slider-width: @agate-slider-knob-height;
 @agate-slider-knob-height: 45px;
+@agate-slider-horizontal-anchorpoint-width: @agate-slider-knob-height;
+@agate-slider-vertical-anchorpoint-height: @agate-slider-knob-height;
 @agate-slider-knob-border-radius: (@agate-slider-knob-height / 2);
-@agate-slider-knob-resting-state-scale: 0.77;
-// Additional offset (-12% at min position, 0% halfway, and +12% at max position) is needed when scaled down to 0.77 so that the knob stays within the progressbar
-@agate-slider-knob-transform: translate(calc((var(--ui-slider-proportion-end-knob) * -100%) + (-12% + (var(--ui-slider-proportion-end-knob) * 24%))), -50%) scale(@agate-slider-knob-resting-state-scale);
-// Additional offset (-5px at min position, 0px halfway, and +5px at max position) is needed when focused and scaled back to 1
-@agate-slider-knob-active-transform: translate(calc((var(--ui-slider-proportion-end-knob) * -100%) + (-5px + (var(--ui-slider-proportion-end-knob) * 10px))), -50%) scale(1);
+@agate-slider-knob-resting-state-scale: 0.9;
+@agate-slider-knob-transform: @agate-translate-center scale(@agate-slider-knob-resting-state-scale);
+@agate-slider-knob-active-transform: @agate-translate-center scale(1);
 @agate-slider-border-radius: 3px;
-@agate-slider-horizontal-padding: ((@agate-slider-knob-height - @agate-slider-track-height) / 2) (@agate-slider-knob-height / 2);
-@agate-slider-vertical-margin: 0;
+@agate-slider-horizontal-padding: ((@agate-slider-height - @agate-slider-track-height) / 2) (@agate-slider-knob-height / 2);
+@agate-slider-vertical-margin: 6px;
 @agate-slider-vertical-padding: (@agate-slider-knob-height / 2) ((@agate-slider-knob-height - @agate-slider-track-height) / 2);
 @agate-slider-track-height: 6px;
 


### PR DESCRIPTION
The Gallium slider design shows the knob always fully within the bounds of the slider track. This update extends the visible track to protrude past the measurement boundaries of the slider track, so the knob never appears to leave the track area.

This is achieved by relocating and decoupling the visuals from the "math container" of the slider. The benefit of which is that now the knob always remains centered under the drag point, and behaves as expected when the extreme edges are clicked, as well as remains stationary on repeated tapping on the bar.

One minor visual regression arose with the Electro skin, which is also corrected in this PR. Conveniently, this made the Electro configuration simpler while creating no visual differences. All other skins were unaffected by this change.

The following code can be used to add all skinned sliders to a sample app (moot, however, now that we have "all skins" knob in storybook)
```
	<Slider skin="gallium" />
	<Slider skin="carbon" />
	<Slider skin="cobalt" />
	<Slider skin="copper" />
	<Slider skin="electro" />
	<Slider skin="titanium" />
	<Slider orientation="vertical" skin="gallium" />
```