### PR TITLE
ENYO-6364: Restore compatibility with Enact 3.2.5

### DIFF
--- a/Button/Button.js
+++ b/Button/Button.js
@@ -127,13 +127,13 @@ const ButtonBase = kind({
 		 */
 		highlighted: PropTypes.bool,
 
-		/**
-		 * The component used to render the icon.
-		 *
-		 * @type {Component}
-		 * @public
-		 */
-		iconComponent: EnactPropTypes.component,
+		// /**
+		//  * The component used to render the icon.
+		//  *
+		//  * @type {Component}
+		//  * @public
+		//  */
+		// iconComponent: EnactPropTypes.component,
 
 		/**
 		 * The position of this button in relation to other buttons.
@@ -166,13 +166,13 @@ const ButtonBase = kind({
 		 */
 		size: PropTypes.oneOf(['smallest', 'small', 'large', 'huge']),
 
-		/**
-		 * The amount of sprite "cells" in the src image of the `icon` being supplied. This prop has no effect without `icon`.
-		 *
-		 * @type {Number}
-		 * @public
-		 */
-		spriteCount: PropTypes.number,
+		// /**
+		//  * The amount of sprite "cells" in the src image of the `icon` being supplied. This prop has no effect without `icon`.
+		//  *
+		//  * @type {Number}
+		//  * @public
+		//  */
+		// spriteCount: PropTypes.number,
 
 		/**
 		 * The button type.
@@ -219,17 +219,18 @@ const ButtonBase = kind({
 				</React.Fragment>
 			);
 		},
-		iconComponent: ({iconComponent, spriteCount}) => {
-			// Don't burden basic HTML elements with the spriteCount prop (or other Icon-specific props)
-			if (typeof iconComponent === 'string') return iconComponent;
+		// Temporary reversion until > alpha.11
+		// iconComponent: ({iconComponent, spriteCount}) => {
+		// 	// Don't burden basic HTML elements with the spriteCount prop (or other Icon-specific props)
+		// 	if (typeof iconComponent === 'string') return iconComponent;
 
-			return (
-				<ComponentOverride
-					component={iconComponent}
-					spriteCount={spriteCount}
-				/>
-			);
-		},
+		// 	return (
+		// 		<ComponentOverride
+		// 			component={iconComponent}
+		// 			spriteCount={spriteCount}
+		// 		/>
+		// 	);
+		// },
 		style: ({animationDelay, badgeColor, style}) => ({
 			...style,
 			'--agate-button-animation-delay': animationDelay,

--- a/Button/Button.js
+++ b/Button/Button.js
@@ -12,10 +12,10 @@
 
 import kind from '@enact/core/kind';
 import {cap} from '@enact/core/util';
-import EnactPropTypes from '@enact/core/internal/prop-types';
+// import EnactPropTypes from '@enact/core/internal/prop-types';
 import Spottable from '@enact/spotlight/Spottable';
 import {ButtonBase as UiButtonBase, ButtonDecorator as UiButtonDecorator} from '@enact/ui/Button';
-import ComponentOverride from '@enact/ui/ComponentOverride';
+// import ComponentOverride from '@enact/ui/ComponentOverride';
 import Pure from '@enact/ui/internal/Pure';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -247,6 +247,7 @@ const ButtonBase = kind({
 		delete rest.highlighted;
 		delete rest.joinedPosition;
 		delete rest.selected;
+		// eslint-disable-next-line enact/prop-types
 		delete rest.spriteCount;
 		delete rest.type;
 


### PR DESCRIPTION
Reverts the changes from #181 to restore compatibility with Enact 3.2.5. It does maintain deleting the `spriteCount` prop to avoid possible prop type warnings.

The changes will be reapplied after releasing alpha.11.

Signed-off-by: Ryan Duffy <ryan.duffy@lge.com>