### PR TITLE
PLAT-99809: Add locale to the Global Knobs of sampler

### DIFF
--- a/samples/sampler/src/AgateEnvironment/AgateEnvironment.js
+++ b/samples/sampler/src/AgateEnvironment/AgateEnvironment.js
@@ -80,6 +80,24 @@ const FullscreenBase = kind({
 const Agate = AgateDecorator({overlay: false}, PanelsBase);
 const AgateFullscreen = AgateDecorator({overlay: false}, FullscreenBase);
 
+const locales = {
+	'local':                                                             '',
+	'en-US - US English':                                                'en-US',
+	'ko-KR - Korean':                                                    'ko-KR',
+	'es-ES - Spanish, with alternate weekends':                          'es-ES',
+	'am-ET - Amharic, 5 meridiems':                                      'am-ET',
+	'th-TH - Thai, with tall characters':                                'th-TH',
+	'ar-SA - Arabic, RTL and standard font':                             'ar-SA',
+	'ur-PK - Urdu, RTL and custom Urdu font':                            'ur-PK',
+	'zh-Hans-HK - Simplified Chinese, custom Hans font':                 'zh-Hans-HK',
+	'zh-Hant-HK - Traditional Chinese, custom Hant font':                'zh-Hant-HK',
+	'vi-VN - Vietnamese, Special non-latin font handling':               'vi-VN',
+	'ta-IN - Tamil, custom Indian font':                                 'ta-IN',
+	'ja-JP - Japanese, custom Japanese font':                            'ja-JP',
+	'en-JP - English, custom Japanese font':                             'en-JP',
+	'si-LK - Sinhala, external font family with different line metrics': 'si-LK'
+};
+
 const skins = {
 	'Carbon': 'carbon',
 	'Cobalt': 'cobalt',
@@ -117,6 +135,7 @@ const StorybookDecorator = (story, config) => {
 	const sample = story();
 	const Config = {
 		defaultProps: {
+			locale: 'en-US',
 			'night mode': false,
 			skin: 'gallium'
 		},
@@ -154,6 +173,7 @@ const StorybookDecorator = (story, config) => {
 	memory.skin = currentSkin;  // Remember the skin for the next time we load.
 	const accentFromURL = getPropFromURL('accent');
 	const highlightFromURL = getPropFromURL('highlight');
+	const locale = select('locale', locales, Config);
 	const allSkins = boolean('show all skins', Config);
 	const skinKnobs = {};
 	if (!allSkins) {
@@ -164,6 +184,7 @@ const StorybookDecorator = (story, config) => {
 		<Agate
 			title={`${config.kind} ${config.story}`.trim()}
 			description={config.description}
+			locale={locale}
 			{...skinKnobs}
 			skinVariants={boolean('night mode', Config) && 'night'}
 			accent={color('accent', (!newSkin && accentFromURL ? accentFromURL : defaultColors[currentSkin].accent), Config.groupId)}


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
- Add locale to the Agate Storybook Global Knobs

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
PLAT-99809

### Comments

Enact-DCO-1.0-Signed-off-by: Seungho Park <seunghoh.park@lge.com>