### PR TITLE
PLAT-100154: Link develop Enact in theme library Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,12 @@ install:
     - npm config set prefer-offline true
     - npm install -g enactjs/cli#develop
     - npm install -g codecov
-    - git clone --branch=develop --depth 1 https://github.com/enactjs/enact .enact
-    - cd .enact
+    - git clone --branch=develop --depth 1 https://github.com/enactjs/enact ../enact
+    - pushd ../enact
     - npm install
     - npm run bootstrap -- --ignore enact-sampler
     - npm run link-all
-    - cd ..
+    - popd
     - npm install
     - enact link
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ install:
     - npm run bootstrap -- --ignore enact-sampler
     - npm run link-all
     - popd
+    - ls node_modules
     - npm install
     - enact link
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ language: node_js
 node_js:
     - "10"
 sudo: false
-cache:
-  directories:
-    - $(npm config get cache)
+cache: npm
 install:
     - npm config set prefer-offline true
     - npm install -g enactjs/cli#develop
@@ -15,7 +13,7 @@ install:
     - npm run bootstrap -- --ignore enact-sampler
     - npm run link-all
     - popd
-    - rm -fr node_modules
+    - rm -fr node_modules/@enact
     - npm install
     - enact link
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
     - npm run bootstrap -- --ignore enact-sampler
     - npm run link-all
     - popd
-    - ls node_modules
+    - rm -fr node_modules
     - npm install
     - enact link
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,15 @@ cache:
 install:
     - npm config set prefer-offline true
     - npm install -g enactjs/cli#develop
+    - npm install -g codecov
+    - git clone --branch=develop --depth 1 https://github.com/enactjs/enact .enact
+    - cd .enact
     - npm install
-
+    - npm run bootstrap -- --ignore enact-sampler
+    - npm run link-all
+    - cd ..
+    - npm install
+    - enact link
 script:
     - npm run lint -- -- --max-warnings 0 .
     - npm run test


### PR DESCRIPTION
Adds setup steps to clone `develop` of Enact, bootstrap Enact, and use it linked into sandstone.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>