### PR TITLE
PLAT-98821: Changed the `TabbedPanels` components structure to pass props to panels

### DIFF
--- a/Panels/TabbedPanels.js
+++ b/Panels/TabbedPanels.js
@@ -26,6 +26,7 @@ const TabbedPanelsBase = kind({
 		afterTabs: PropTypes.node,
 		beforeTabs: PropTypes.node,
 		css: PropTypes.object,
+		disabled: PropTypes.bool,
 		index: PropTypes.number,
 		noCloseButton: PropTypes.bool,
 		orientation: PropTypes.oneOf(['horizontal', 'vertical']),

--- a/Panels/TabbedPanels.js
+++ b/Panels/TabbedPanels.js
@@ -63,9 +63,14 @@ const TabbedPanelsBase = kind({
 		className: ({css, orientation, styler, tabPosition}) => styler.append(tabPosition === 'after' ? css.reverse : '', orientation === 'vertical' ? css.column : ''),
 		tabOrientation: ({orientation}) => orientation === 'vertical' ? 'horizontal' : 'vertical'
 	},
-	render: ({afterTabs, beforeTabs, children, css, index, noCloseButton, onSelect, tabOrientation, tabPosition, tabs, ...rest}) => {
+	render: ({afterTabs, beforeTabs, children, className, css, index, noCloseButton, onSelect, orientation, tabOrientation, tabPosition, tabs, ...rest}) => {
+		delete rest.disabled;
+
 		return (
-			<Layout {...rest}>
+			<Layout
+				className={className}
+				orientation={orientation}
+			>
 				<Cell shrink>
 					<TabGroup
 						afterTabs={afterTabs}
@@ -84,6 +89,7 @@ const TabbedPanelsBase = kind({
 					noCloseButton={noCloseButton}
 					orientation={tabOrientation}
 					index={index}
+					{...rest}
 				>
 					{children}
 				</Cell>

--- a/Panels/TabbedPanels.js
+++ b/Panels/TabbedPanels.js
@@ -29,15 +29,11 @@ const TabbedPanelsBase = kind({
 		beforeTabs: PropTypes.node,
 		childProps: PropTypes.object,
 		closeButtonAriaLabel: PropTypes.string,
-		controls: PropTypes.node,
-		controlsMeasurements: PropTypes.object,
-		cover: PropTypes.oneOf(['full', 'partial']),
 		css: PropTypes.object,
 		duration: PropTypes.number,
 		index: PropTypes.number,
 		noAnimation: PropTypes.bool,
 		noCloseButton: PropTypes.bool,
-		noSharedState: PropTypes.bool,
 		onApplicationClose: PropTypes.func,
 		onBack: PropTypes.func,
 		orientation: PropTypes.oneOf(['horizontal', 'vertical']),
@@ -82,15 +78,11 @@ const TabbedPanelsBase = kind({
 		childProps,
 		children,
 		closeButtonAriaLabel,
-		controls,
-		controlsMeasurements,
-		cover,
 		css,
 		duration,
 		index,
 		noAnimation,
 		noCloseButton,
-		noSharedState,
 		onApplicationClose,
 		onBack,
 		onSelect,
@@ -119,13 +111,9 @@ const TabbedPanelsBase = kind({
 					className={css.panels}
 					closeButtonAriaLabel={closeButtonAriaLabel}
 					component={Panels}
-					controls={controls}
-					controlsMeasurements={controlsMeasurements}
-					cover={cover}
 					duration={duration}
 					noAnimation={noAnimation}
 					noCloseButton={noCloseButton}
-					noSharedState={noSharedState}
 					onApplicationClose={onApplicationClose}
 					onBack={onBack}
 					orientation={tabOrientation}

--- a/Panels/TabbedPanels.js
+++ b/Panels/TabbedPanels.js
@@ -1,10 +1,11 @@
 import {adaptEvent, forward, handle} from '@enact/core/handle';
-import {Cell, Layout} from '@enact/ui/Layout';
-import {Changeable} from '@enact/ui/Changeable';
 import kind from '@enact/core/kind';
+import {Changeable} from '@enact/ui/Changeable';
+import {Cell, Layout} from '@enact/ui/Layout';
+import Slottable from '@enact/ui/Slottable';
+import {shape} from '@enact/ui/ViewManager';
 import PropTypes from 'prop-types';
 import React from 'react';
-import Slottable from '@enact/ui/Slottable';
 
 import TabGroup from '../TabGroup';
 
@@ -24,11 +25,21 @@ const TabbedPanelsBase = kind({
 	name: 'TabbedPanels',
 	propTypes: /** @lends agate/Panels.TabbedPanels.prototype */ {
 		afterTabs: PropTypes.node,
+		arranger: shape,
 		beforeTabs: PropTypes.node,
+		childProps: PropTypes.object,
+		closeButtonAriaLabel: PropTypes.string,
+		controls: PropTypes.node,
+		controlsMeasurements: PropTypes.object,
+		cover: PropTypes.oneOf(['full', 'partial']),
 		css: PropTypes.object,
-		disabled: PropTypes.bool,
+		duration: PropTypes.number,
 		index: PropTypes.number,
+		noAnimation: PropTypes.bool,
 		noCloseButton: PropTypes.bool,
+		noSharedState: PropTypes.bool,
+		onApplicationClose: PropTypes.func,
+		onBack: PropTypes.func,
 		orientation: PropTypes.oneOf(['horizontal', 'vertical']),
 		tabPosition: PropTypes.string,
 		tabs: PropTypes.oneOfType([TabGroup])
@@ -64,14 +75,32 @@ const TabbedPanelsBase = kind({
 		className: ({css, orientation, styler, tabPosition}) => styler.append(tabPosition === 'after' ? css.reverse : '', orientation === 'vertical' ? css.column : ''),
 		tabOrientation: ({orientation}) => orientation === 'vertical' ? 'horizontal' : 'vertical'
 	},
-	render: ({afterTabs, beforeTabs, children, className, css, index, noCloseButton, onSelect, orientation, tabOrientation, tabPosition, tabs, ...rest}) => {
-		delete rest.disabled;
-
+	render: ({
+		afterTabs,
+		arranger,
+		beforeTabs,
+		childProps,
+		children,
+		closeButtonAriaLabel,
+		controls,
+		controlsMeasurements,
+		cover,
+		css,
+		duration,
+		index,
+		noAnimation,
+		noCloseButton,
+		noSharedState,
+		onApplicationClose,
+		onBack,
+		onSelect,
+		tabOrientation,
+		tabPosition,
+		tabs,
+		...rest
+	}) => {
 		return (
-			<Layout
-				className={className}
-				orientation={orientation}
-			>
+			<Layout {...rest}>
 				<Cell shrink>
 					<TabGroup
 						afterTabs={afterTabs}
@@ -85,12 +114,22 @@ const TabbedPanelsBase = kind({
 					/>
 				</Cell>
 				<Cell
+					arranger={arranger}
+					childProps={childProps}
 					className={css.panels}
+					closeButtonAriaLabel={closeButtonAriaLabel}
 					component={Panels}
+					controls={controls}
+					controlsMeasurements={controlsMeasurements}
+					cover={cover}
+					duration={duration}
+					noAnimation={noAnimation}
 					noCloseButton={noCloseButton}
+					noSharedState={noSharedState}
+					onApplicationClose={onApplicationClose}
+					onBack={onBack}
 					orientation={tabOrientation}
 					index={index}
-					{...rest}
 				>
 					{children}
 				</Cell>

--- a/Panels/TabbedPanels.js
+++ b/Panels/TabbedPanels.js
@@ -27,7 +27,6 @@ const TabbedPanelsBase = kind({
 		afterTabs: PropTypes.node,
 		arranger: shape,
 		beforeTabs: PropTypes.node,
-		childProps: PropTypes.object,
 		closeButtonAriaLabel: PropTypes.string,
 		css: PropTypes.object,
 		duration: PropTypes.number,
@@ -75,7 +74,6 @@ const TabbedPanelsBase = kind({
 		afterTabs,
 		arranger,
 		beforeTabs,
-		childProps,
 		children,
 		closeButtonAriaLabel,
 		css,
@@ -107,7 +105,6 @@ const TabbedPanelsBase = kind({
 				</Cell>
 				<Cell
 					arranger={arranger}
-					childProps={childProps}
 					className={css.panels}
 					closeButtonAriaLabel={closeButtonAriaLabel}
 					component={Panels}

--- a/samples/sampler/src/AgateEnvironment/AgateEnvironment.js
+++ b/samples/sampler/src/AgateEnvironment/AgateEnvironment.js
@@ -173,7 +173,9 @@ const StorybookDecorator = (story, config) => {
 	memory.skin = currentSkin;  // Remember the skin for the next time we load.
 	const accentFromURL = getPropFromURL('accent');
 	const highlightFromURL = getPropFromURL('highlight');
-	const locale = select('locale', locales, Config);
+	const localeFromURL = getPropFromURL('locale');
+	const currentLocale = localeFromURL ? localeFromURL : Config.defaultProps.locale;
+	const locale = select('locale', locales, Config, currentLocale);
 	const allSkins = boolean('show all skins', Config);
 	const skinKnobs = {};
 	if (!allSkins) {


### PR DESCRIPTION
There is no way to pass some props to Panels via TabbedPanels.
When this PR is merged, App can pass props such as duration, noAnimation, and etc to panels.
(Added props: arranger, childProps, closeButtonAriaLabel, duration, noAnimation, onApplicationClose, onBack)

Enact-DCO-1.0-Signed-off-by: Baekwoo Jung (baekwoo.jung@lge.com)