### PR TITLE
PLAT-101126: Replace VirtualListBase, ScrollerBase, and Scrollable with VirtualListBasic, ScrollerBasic, and useScroll

### DIFF
--- a/Scrollable/ScrollButtons.js
+++ b/Scrollable/ScrollButtons.js
@@ -2,7 +2,7 @@ import {forward} from '@enact/core/handle';
 import {getTargetByDirectionFromElement} from '@enact/spotlight/src/target';
 import {is} from '@enact/core/keymap';
 import Spotlight, {getDirection} from '@enact/spotlight';
-import utilEvent from '@enact/ui/Scrollable/utilEvent';
+import utilEvent from '@enact/ui/useScroll/utilEvent';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import ReactDOM from 'react-dom';

--- a/Scrollable/ScrollThumb.js
+++ b/Scrollable/ScrollThumb.js
@@ -1,4 +1,4 @@
-import {ScrollThumb as UiScrollThumb} from '@enact/ui/Scrollable/Scrollbar';
+import {ScrollThumb as UiScrollThumb} from '@enact/ui/useScroll/Scrollbar';
 import PropTypes from 'prop-types';
 import React, {forwardRef, useEffect} from 'react';
 

--- a/Scrollable/Scrollable.js
+++ b/Scrollable/Scrollable.js
@@ -12,11 +12,11 @@ import Spotlight from '@enact/spotlight';
 import {spottableClass} from '@enact/spotlight/Spottable';
 import {getTargetByDirectionFromPosition} from '@enact/spotlight/src/target';
 import {getRect, intersects} from '@enact/spotlight/src/utils';
-import {useScrollBase} from '@enact/ui/Scrollable';
-import {useChildAdapter as useUiChildAdapter} from '@enact/ui/Scrollable/useChild';
-import {utilDecorateChildProps} from '@enact/ui/Scrollable';
-import utilDOM from '@enact/ui/Scrollable/utilDOM';
-import utilEvent from '@enact/ui/Scrollable/utilEvent';
+import {useScrollBase} from '@enact/ui/useScroll';
+import {useChildAdapter as useUiChildAdapter} from '@enact/ui/useScroll/useChild';
+import {utilDecorateChildProps} from '@enact/ui/useScroll';
+import utilDOM from '@enact/ui/useScroll/utilDOM';
+import utilEvent from '@enact/ui/useScroll/utilEvent';
 import PropTypes from 'prop-types';
 import {Component, useContext, useRef} from 'react';
 

--- a/Scrollable/Scrollbar.js
+++ b/Scrollable/Scrollbar.js
@@ -1,5 +1,5 @@
 // import ApiDecorator from '@enact/core/internal/ApiDecorator';
-import {ScrollbarBase as UiScrollbarBase} from '@enact/ui/Scrollable/Scrollbar';
+import {ScrollbarBase as UiScrollbarBase} from '@enact/ui/useScroll/Scrollbar';
 import PropTypes from 'prop-types';
 import React, {forwardRef, memo, useImperativeHandle, useRef} from 'react';
 

--- a/Scrollable/useEvent.js
+++ b/Scrollable/useEvent.js
@@ -4,9 +4,9 @@ import {onWindowReady} from '@enact/core/snapshot';
 import {clamp} from '@enact/core/util';
 import Spotlight, {getDirection} from '@enact/spotlight';
 import {getRect} from '@enact/spotlight/src/utils';
-import {constants} from '@enact/ui/Scrollable';
-import utilEvent from '@enact/ui/Scrollable/utilEvent';
-import utilDOM from '@enact/ui/Scrollable/utilDOM';
+import {constants} from '@enact/ui/useScroll/';
+import utilEvent from '@enact/ui/useScroll/utilEvent';
+import utilDOM from '@enact/ui/useScroll/utilDOM';
 import {useEffect, useRef} from 'react';
 
 const {animationDuration, epsilon, isPageDown, isPageUp, paginationPageMultiplier, scrollWheelPageMultiplierForMaxPixel} = constants;

--- a/Scrollable/useScrollbar.js
+++ b/Scrollable/useScrollbar.js
@@ -1,5 +1,5 @@
 import Spotlight from '@enact/spotlight';
-import {constants} from '@enact/ui/Scrollable';
+import {constants} from '@enact/ui/useScroll';
 
 const {paginationPageMultiplier} = constants;
 

--- a/Scrollable/useSpotlight.js
+++ b/Scrollable/useSpotlight.js
@@ -1,5 +1,5 @@
 import Spotlight from '@enact/spotlight';
-import utilDOM from '@enact/ui/Scrollable/utilDOM';
+import utilDOM from '@enact/ui/useScroll/utilDOM';
 import {useContext, useEffect, useLayoutEffect} from 'react';
 
 import {SharedState} from '../Panels/SharedStateDecorator';

--- a/Scroller/Scroller.js
+++ b/Scroller/Scroller.js
@@ -13,7 +13,7 @@
  *
  * @module agate/Scroller
  * @exports Scroller
- * @exports ScrollerBase
+ * @exports ScrollerBasic
  */
 
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
@@ -22,8 +22,8 @@ import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDeco
 import {getRect} from '@enact/spotlight/src/utils';
 import {ResizeContext} from '@enact/ui/Resizable';
 import ri from '@enact/ui/resolution';
-import utilDOM from '@enact/ui/Scrollable/utilDOM';
-import {ScrollerBase as UiScrollerBase} from '@enact/ui/Scroller';
+import utilDOM from '@enact/ui/useScroll/utilDOM';
+import {ScrollerBasic as UiScrollerBasic} from '@enact/ui/Scroller';
 import PropTypes from 'prop-types';
 import React, {Component, useCallback, useEffect} from 'react';
 
@@ -41,16 +41,16 @@ const dataContainerDisabledAttribute = 'data-spotlight-container-disabled';
  * [SpotlightContainerDecorator]{@link spotlight/SpotlightContainerDecorator.SpotlightContainerDecorator}
  * and the Scrollable version, [Scroller]{@link agate/Scroller.Scroller}.
  *
- * @class ScrollerBase
+ * @class ScrollerBasic
  * @memberof agate/Scroller
- * @extends ui/Scroller.ScrollerBase
+ * @extends ui/Scroller.ScrollerBasic
  * @ui
  * @public
  */
-class ScrollerBase extends Component {
-	static displayName = 'ScrollerBase'
+class ScrollerBasic extends Component {
+	static displayName = 'ScrollerBasic'
 
-	static propTypes = /** @lends agate/Scroller.ScrollerBase.prototype */ {
+	static propTypes = /** @lends agate/Scroller.ScrollerBasic.prototype */ {
 		/**
 		 * Passes the instance of [Scroller]{@link ui/Scroller.Scroller}.
 		 *
@@ -373,7 +373,7 @@ const useSpottableScroller = (props) => {
  * not move focus to the scrollbar controls.
  *
  * @name focusableScrollbar
- * @memberof agate/Scroller.ScrollerBase.prototype
+ * @memberof agate/Scroller.ScrollerBasic.prototype
  * @type {Boolean}
  * @default false
  * @public
@@ -387,7 +387,7 @@ const useSpottableScroller = (props) => {
  * `Panel`.
  *
  * @name id
- * @memberof agate/Scroller.ScrollerBase.prototype
+ * @memberof agate/Scroller.ScrollerBasic.prototype
  * @type {String}
  * @public
  */
@@ -396,7 +396,7 @@ const useSpottableScroller = (props) => {
  * Sets the hint string read when focusing the next button in the vertical scroll bar.
  *
  * @name scrollDownAriaLabel
- * @memberof agate/Scroller.ScrollerBase.prototype
+ * @memberof agate/Scroller.ScrollerBasic.prototype
  * @type {String}
  * @default $L('scroll down')
  * @public
@@ -406,7 +406,7 @@ const useSpottableScroller = (props) => {
  * Sets the hint string read when focusing the previous button in the horizontal scroll bar.
  *
  * @name scrollLeftAriaLabel
- * @memberof agate/Scroller.ScrollerBase.prototype
+ * @memberof agate/Scroller.ScrollerBasic.prototype
  * @type {String}
  * @default $L('scroll left')
  * @public
@@ -416,7 +416,7 @@ const useSpottableScroller = (props) => {
  * Sets the hint string read when focusing the next button in the horizontal scroll bar.
  *
  * @name scrollRightAriaLabel
- * @memberof agate/Scroller.ScrollerBase.prototype
+ * @memberof agate/Scroller.ScrollerBasic.prototype
  * @type {String}
  * @default $L('scroll right')
  * @public
@@ -426,7 +426,7 @@ const useSpottableScroller = (props) => {
  * Sets the hint string read when focusing the previous button in the vertical scroll bar.
  *
  * @name scrollUpAriaLabel
- * @memberof agate/Scroller.ScrollerBase.prototype
+ * @memberof agate/Scroller.ScrollerBasic.prototype
  * @type {String}
  * @default $L('scroll up')
  * @public
@@ -442,7 +442,7 @@ const useSpottableScroller = (props) => {
  *
  * @class Scroller
  * @memberof agate/Scroller
- * @extends agate/Scroller.ScrollerBase
+ * @extends agate/Scroller.ScrollerBasic
  * @ui
  * @public
  */
@@ -472,7 +472,7 @@ let Scroller = (props) => {
 			<div {...scrollContainerProps}>
 				<div {...innerScrollContainerProps}>
 					<ChildWrapper {...childWrapperProps}>
-						<UiScrollerBase {...uiChildProps} />
+						<UiScrollerBasic {...uiChildProps} />
 					</ChildWrapper>
 					{isVerticalScrollbarVisible ? <Scrollbar {...verticalScrollbarProps} /> : null}
 				</div>
@@ -548,5 +548,5 @@ Scroller = Skinnable(
 export default Scroller;
 export {
 	Scroller,
-	ScrollerBase
+	ScrollerBasic
 };

--- a/Scroller/useEvent.js
+++ b/Scroller/useEvent.js
@@ -1,4 +1,4 @@
-import utilEvent from '@enact/ui/Scrollable/utilEvent';
+import utilEvent from '@enact/ui/useScroll/utilEvent';
 import {useRef} from 'react';
 
 const useEventKey = () => {

--- a/VirtualList/VirtualList.js
+++ b/VirtualList/VirtualList.js
@@ -4,13 +4,13 @@
  * @module agate/VirtualList
  * @exports VirtualGridList
  * @exports VirtualList
- * @exports VirtualListBase
+ * @exports VirtualListBasic
  */
 
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import {ResizeContext} from '@enact/ui/Resizable';
-import {gridListItemSizeShape, itemSizesShape, VirtualListBase as UiVirtualListBase} from '@enact/ui/VirtualList';
+import {gridListItemSizeShape, itemSizesShape, VirtualListBasic as UiVirtualListBasic} from '@enact/ui/VirtualList';
 import PropTypes from 'prop-types';
 import React from 'react';
 import warning from 'warning';
@@ -19,14 +19,14 @@ import useScroll from '../Scrollable';
 import Scrollbar from '../Scrollable/Scrollbar';
 import Skinnable from '../Skinnable';
 
-import {useSpottableVirtualList, VirtualListBase} from './VirtualListBase';
+import {useSpottableVirtualList, VirtualListBasic} from './VirtualListBasic';
 
 /**
  * An Agate-styled scrollable and spottable virtual list component.
  *
  * @class VirtualList
  * @memberof agate/VirtualList
- * @extends agate/VirtualList.VirtualListBase
+ * @extends agate/VirtualList.VirtualListBasic
  * @ui
  * @public
  */
@@ -74,7 +74,7 @@ let VirtualList = ({itemSize, role, ...rest}) => {
 			<div {...scrollContainerProps}>
 				<div {...innerScrollContainerProps}>
 					<ChildWrapper {...childWrapperProps}>
-						<UiVirtualListBase {...uiChildProps} />
+						<UiVirtualListBasic {...uiChildProps} />
 					</ChildWrapper>
 					{isVerticalScrollbarVisible ? <Scrollbar {...verticalScrollbarProps} /> : null}
 				</div>
@@ -213,7 +213,7 @@ VirtualList = Skinnable(
  *
  * @class VirtualGridList
  * @memberof agate/VirtualList
- * @extends agate/VirtualList.VirtualListBase
+ * @extends agate/VirtualList.VirtualListBasic
  * @ui
  * @public
  */
@@ -245,7 +245,7 @@ let VirtualGridList = ({role, ...rest}) => {
 			<div {...scrollContainerProps}>
 				<div {...innerScrollContainerProps}>
 					<ChildWrapper {...childWrapperProps}>
-						<UiVirtualListBase {...uiChildProps} />
+						<UiVirtualListBasic {...uiChildProps} />
 					</ChildWrapper>
 					{isVerticalScrollbarVisible ? <Scrollbar {...verticalScrollbarProps} /> : null}
 				</div>
@@ -383,5 +383,5 @@ export default VirtualList;
 export {
 	VirtualGridList,
 	VirtualList,
-	VirtualListBase
+	VirtualListBasic
 };

--- a/VirtualList/VirtualListBasic.js
+++ b/VirtualList/VirtualListBasic.js
@@ -5,7 +5,7 @@ import {Spottable, spottableClass} from '@enact/spotlight/Spottable';
 import PropTypes from 'prop-types';
 import React, {Component, useCallback, useEffect, useRef} from 'react';
 
-import {dataIndexAttribute} from '../Scrollable';
+import {dataIndexAttribute} from '../Scrollable/Scrollable';
 
 import {useEventKey} from './useEvent';
 import usePreventScroll from './usePreventScroll';
@@ -17,9 +17,9 @@ const SpotlightPlaceholder = Spottable('div');
 const nop = () => {};
 
 class VirtualListCore extends Component {
-	displayName = 'VirtualListBase'
+	displayName = 'VirtualListBasic'
 
-	static propTypes = /** @lends agate/VirtualList.VirtualListBase.prototype */ {
+	static propTypes = /** @lends agate/VirtualList.VirtualListBasic.prototype */ {
 		/**
 		 * The `render` function called for each item in the list.
 		 *
@@ -202,7 +202,7 @@ const useSpottable = (props, instances, context) => {
 		isWrappedBy5way: false,
 		lastFocusedIndex: null,
 		nodeIndexToBeFocused: false,
-		pause: new Pause('VirtualListBase')
+		pause: new Pause('VirtualListBasic')
 	});
 
 	const {pause} = mutableRef.current;
@@ -564,20 +564,20 @@ const useSpottableVirtualList = (props) => {
  * An Agate-styled base component for [VirtualList]{@link agate/VirtualList.VirtualList} and
  * [VirtualGridList]{@link agate/VirtualList.VirtualGridList}.
  *
- * @class VirtualListBase
+ * @class VirtualListBasic
  * @memberof agate/VirtualList
- * @extends ui/VirtualList.VirtualListBase
+ * @extends ui/VirtualList.VirtualListBasic
  * @ui
  * @public
  */
-const VirtualListBase = VirtualListCore;
+const VirtualListBasic = VirtualListCore;
 
 /**
  * Allows 5-way navigation to the scrollbar controls. By default, 5-way will
  * not move focus to the scrollbar controls.
  *
  * @name focusableScrollbar
- * @memberof agate/VirtualList.VirtualListBase.prototype
+ * @memberof agate/VirtualList.VirtualListBasic.prototype
  * @type {Boolean}
  * @default false
  * @public
@@ -591,7 +591,7 @@ const VirtualListBase = VirtualListCore;
  * the `Panel`.
  *
  * @name id
- * @memberof agate/VirtualList.VirtualListBase.prototype
+ * @memberof agate/VirtualList.VirtualListBasic.prototype
  * @type {String}
  * @public
  */
@@ -600,7 +600,7 @@ const VirtualListBase = VirtualListCore;
  * Sets the hint string read when focusing the next button in the vertical scroll bar.
  *
  * @name scrollDownAriaLabel
- * @memberof agate/VirtualList.VirtualListBase.prototype
+ * @memberof agate/VirtualList.VirtualListBasic.prototype
  * @type {String}
  * @default $L('scroll down')
  * @public
@@ -610,7 +610,7 @@ const VirtualListBase = VirtualListCore;
  * Sets the hint string read when focusing the previous button in the horizontal scroll bar.
  *
  * @name scrollLeftAriaLabel
- * @memberof agate/VirtualList.VirtualListBase.prototype
+ * @memberof agate/VirtualList.VirtualListBasic.prototype
  * @type {String}
  * @default $L('scroll left')
  * @public
@@ -620,7 +620,7 @@ const VirtualListBase = VirtualListCore;
  * Sets the hint string read when focusing the next button in the horizontal scroll bar.
  *
  * @name scrollRightAriaLabel
- * @memberof agate/VirtualList.VirtualListBase.prototype
+ * @memberof agate/VirtualList.VirtualListBasic.prototype
  * @type {String}
  * @default $L('scroll right')
  * @public
@@ -630,7 +630,7 @@ const VirtualListBase = VirtualListCore;
  * Sets the hint string read when focusing the previous button in the vertical scroll bar.
  *
  * @name scrollUpAriaLabel
- * @memberof agate/VirtualList.VirtualListBase.prototype
+ * @memberof agate/VirtualList.VirtualListBasic.prototype
  * @type {String}
  * @default $L('scroll up')
  * @public
@@ -674,5 +674,5 @@ function listItemsRenderer (props) {
 export default useSpottableVirtualList;
 export {
 	useSpottableVirtualList,
-	VirtualListBase
+	VirtualListBasic
 };

--- a/VirtualList/useEvent.js
+++ b/VirtualList/useEvent.js
@@ -1,8 +1,8 @@
 import {is} from '@enact/core/keymap';
 import Spotlight, {getDirection} from '@enact/spotlight';
 import {getTargetByDirectionFromElement} from '@enact/spotlight/src/target';
-import utilDOM from '@enact/ui/Scrollable/utilDOM';
-import utilEvent from '@enact/ui/Scrollable/utilEvent';
+import utilDOM from '@enact/ui/useScroll/utilDOM';
+import utilEvent from '@enact/ui/useScroll/utilEvent';
 import clamp from 'ramda/src/clamp';
 import {useCallback, useEffect, useRef} from 'react';
 

--- a/VirtualList/usePreventScroll.js
+++ b/VirtualList/usePreventScroll.js
@@ -1,4 +1,4 @@
-import utilEvent from '@enact/ui/Scrollable/utilEvent';
+import utilEvent from '@enact/ui/useScroll/utilEvent';
 import {useEffect} from 'react';
 
 const usePreventScroll = (props, instances, context) => {

--- a/VirtualList/useSpotlight.js
+++ b/VirtualList/useSpotlight.js
@@ -1,5 +1,5 @@
 import Spotlight from '@enact/spotlight';
-import utilDOM from '@enact/ui/Scrollable/utilDOM';
+import utilDOM from '@enact/ui/useScroll/utilDOM';
 import {useEffect, useRef} from 'react';
 
 const useSpotlightConfig = (props, instances) => {

--- a/samples/sampler/stories/default/VirtualList.js
+++ b/samples/sampler/stories/default/VirtualList.js
@@ -8,7 +8,7 @@ import {storiesOf} from '@storybook/react';
 import {VirtualListBase as UiVirtualListBase} from '@enact/ui/VirtualList';
 
 import Item from '@enact/agate/Item';
-import VirtualList, {VirtualListBase} from '@enact/agate/VirtualList';
+import VirtualList, {VirtualListBasic} from '@enact/agate/VirtualList';
 
 const
 	wrapOption = {
@@ -52,7 +52,7 @@ const updateDataSize = (dataSize) => {
 
 updateDataSize(defaultDataSize);
 
-const VirtualListConfig = mergeComponentMetadata('VirtualList', UiVirtualListBase, UiScrollableBase, VirtualListBase);
+const VirtualListConfig = mergeComponentMetadata('VirtualList', UiVirtualListBase, UiScrollableBase, VirtualListBasic);
 
 storiesOf('Agate', module)
 	.add(


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

All modules from ui/Scrollable were moved to ui/useScroll.
VirtualListBase from ui/VirtualList.js was replaced with VirtualListBasic
ScrollerBase from ui/Scroller.js was replaced with ScrollerBasic
So some modules should be imported from proper modules.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Import
- not ui/Scrollable but ui/useScroll
- not VirtualBase but VirtualListBasic from ui/VirtualList
- not ScrollerBase but ScrollerBasic from ui/Scroller

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)

PLAT-101126

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)