### PR TITLE
PLAT-100708: Fix VirtualList and Scroller JSDoc parse error

### DIFF
--- a/Scroller/Scroller.js
+++ b/Scroller/Scroller.js
@@ -30,6 +30,19 @@ import Skinnable from '../Skinnable';
 import ScrollerBasic from './ScrollerBasic';
 import useThemeScroller from './useThemeScroller';
 
+/**
+ * An Agate-styled Scroller, Scrollable applied.
+ *
+ * Usage:
+ * ```
+ * <Scroller>Scroll me.</Scroller>
+ * ```
+ *
+ * @class Scroller
+ * @memberof agate/Scroller
+ * @ui
+ * @private
+ */
 let Scroller = (props) => {
 	// Hooks
 

--- a/Scroller/ScrollerBasic.js
+++ b/Scroller/ScrollerBasic.js
@@ -125,21 +125,6 @@ class ScrollerBasic extends Component {
  * @private
  */
 
-/**
- * An Agate-styled Scroller, Scrollable applied.
- *
- * Usage:
- * ```
- * <Scroller>Scroll me.</Scroller>
- * ```
- *
- * @class Scroller
- * @memberof agate/Scroller
- * @extends agate/Scroller.ScrollerBasic
- * @ui
- * @private
- */
-
 export default ScrollerBasic;
 export {
 	ScrollerBasic

--- a/VirtualList/VirtualList.js
+++ b/VirtualList/VirtualList.js
@@ -27,7 +27,6 @@ import {VirtualListBasic} from './VirtualListBasic';
  *
  * @class VirtualList
  * @memberof agate/VirtualList
- * @extends agate/VirtualList.VirtualListBasic
  * @ui
  * @public
  */
@@ -214,7 +213,6 @@ VirtualList = Skinnable(
  *
  * @class VirtualGridList
  * @memberof agate/VirtualList
- * @extends agate/VirtualList.VirtualListBasic
  * @ui
  * @public
  */


### PR DESCRIPTION
Fix VirtualList and Scroller JSDoc parse error
```
Invalid reference: agate/VirtualList.VirtualListBasic:
    type: extends - VirtualList in /docs/raw/agate/VirtualList/VirtualList.js:34
    type: extends - VirtualGridList in /docs/raw/agate/VirtualList/VirtualList.js:221
```

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)