### PR TITLE
PLAT-101422: Sync naming in VirtualList and Scroller between sandstone and agate

### DIFF
--- a/Scroller/useThemeScroller.js
+++ b/Scroller/useThemeScroller.js
@@ -168,7 +168,7 @@ const useSpottable = (props, instances) => {
 	 * @private
 	 */
 	function calculateScrollLeft (item, scrollPosition) {
-		const childContainerNode = scrollContentRef.current;
+		const scrollContentNode = scrollContentRef.current;
 		const {
 			left: itemLeft,
 			width: itemWidth
@@ -178,11 +178,11 @@ const useSpottable = (props, instances) => {
 			{rtl} = props,
 			{clientWidth} = scrollContentHandle.current.scrollBounds,
 			rtlDirection = rtl ? -1 : 1,
-			{left: containerLeft} = childContainerNode.getBoundingClientRect(),
+			{left: containerLeft} = scrollContentNode.getBoundingClientRect(),
 			scrollLastPosition = scrollPosition ? scrollPosition : scrollContentHandle.current.scrollPos.left,
 			currentScrollLeft = rtl ? (scrollContentHandle.current.scrollBounds.maxLeft - scrollLastPosition) : scrollLastPosition,
 			// calculation based on client position
-			newItemLeft = childContainerNode.scrollLeft + (itemLeft - containerLeft);
+			newItemLeft = scrollContentNode.scrollLeft + (itemLeft - containerLeft);
 		let nextScrollLeft = scrollContentHandle.current.scrollPos.left;
 
 		if (newItemLeft + itemWidth > (clientWidth + currentScrollLeft) && itemWidth < clientWidth) {

--- a/VirtualList/VirtualList.js
+++ b/VirtualList/VirtualList.js
@@ -455,6 +455,10 @@ VirtualList.propTypes = /** @lends agate/VirtualList.VirtualList.prototype */ {
 	 * When it's `'noAnimation'`, the spotlight focus moves in wraparound manner as same as when it's `true`
 	 * except that a list is scrolled without an animation.
 	 *
+	 * Valid values are:
+	 * * `false`,
+	 * * `true`, and
+	 * * `'noAnimation'`
 	 * @type {Boolean|String}
 	 * @default false
 	 * @public
@@ -915,6 +919,11 @@ VirtualGridList.propTypes = /** @lends agate/VirtualList.VirtualGridList.prototy
 	 *
 	 * When it's `'noAnimation'`, the spotlight focus moves in wraparound manner as same as when it's `true`
 	 * except that a list is scrolled without an animation.
+	 *
+	 * Valid values are:
+	 * * `false`,
+	 * * `true`, and
+	 * * `'noAnimation'`
 	 *
 	 * @type {Boolean|String}
 	 * @default false

--- a/VirtualList/useEvent.js
+++ b/VirtualList/useEvent.js
@@ -123,13 +123,13 @@ const useEventKey = (props, instances, context) => {
 					const {focusableScrollbar, isHorizontalScrollbarVisible, isVerticalScrollbarVisible, spotlightId} = props;
 					const {dimensionToExtent, isPrimaryDirectionVertical} = scrollContentHandle.current;
 					const targetIndex = target.dataset.index;
-					const isScrollButton = (
-						// if target has an index, it must be an item so can't be a scroll button
+					const isNotItem = (
+						// if target has an index, it must be an item
 						!targetIndex &&
-						// if it lacks an index and is inside the scroller, it must be a button
+						// if it lacks an index and is inside the scroller, we need to handle this
 						target.matches(`[data-spotlight-id="${spotlightId}"] *`)
 					);
-					const index = !isScrollButton ? getNumberValue(targetIndex) : -1;
+					const index = !isNotItem ? getNumberValue(targetIndex) : -1;
 					const {isDownKey, isUpKey, isLeftMovement, isRightMovement, isWrapped, nextIndex} = getNextIndex({index, keyCode, repeat});
 					const directions = {};
 					let isLeaving = false;
@@ -149,7 +149,7 @@ const useEventKey = (props, instances, context) => {
 						isScrollbarVisible = isHorizontalScrollbarVisible;
 					}
 
-					if (!isScrollButton) {
+					if (!isNotItem) {
 						if (nextIndex >= 0) {
 							ev.preventDefault();
 							ev.stopPropagation();

--- a/VirtualList/usePreventScroll.js
+++ b/VirtualList/usePreventScroll.js
@@ -9,19 +9,19 @@ const usePreventScroll = (props, instances, context) => {
 
 	useEffect(() => {
 		const {rtl} = props;
-		const containerNode = scrollContentRef.current;
+		const scrollContentNode = scrollContentRef.current;
 
-		if (scrollMode === 'translate' && containerNode) {
+		if (scrollMode === 'translate' && scrollContentNode) {
 			const preventScroll = () => {
-				containerNode.scrollTop = 0;
-				containerNode.scrollLeft = rtl ? containerNode.scrollWidth : 0;
+				scrollContentNode.scrollTop = 0;
+				scrollContentNode.scrollLeft = rtl ? scrollContentNode.scrollWidth : 0;
 			};
 
-			utilEvent('scroll').addEventListener(containerNode, preventScroll);
+			utilEvent('scroll').addEventListener(scrollContentNode, preventScroll);
 
 			return () => {
 				// remove a function for preventing native scrolling by Spotlight
-				utilEvent('scroll').removeEventListener(containerNode, preventScroll);
+				utilEvent('scroll').removeEventListener(scrollContentNode, preventScroll);
 			};
 		}
 	}, [props, scrollMode]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/VirtualList/useSpotlight.js
+++ b/VirtualList/useSpotlight.js
@@ -67,7 +67,7 @@ const useSpotlightConfig = (props, instances) => {
 const getNumberValue = (index) => index | 0;
 
 const useSpotlightRestore = (props, instances, context) => {
-	const {spottable, scrollContentRef} = instances;
+	const {scrollContentRef, spottable} = instances;
 	const {getItemNode} = context;
 
 	// Mutable value

--- a/VirtualList/useThemeVirtualList.js
+++ b/VirtualList/useThemeVirtualList.js
@@ -151,7 +151,7 @@ const useSpottable = (props, instances, context) => {
 				mutableRef.current.isScrolledBy5way = true;
 				mutableRef.current.isWrappedBy5way = isWrapped;
 
-				if (isWrapped && itemNode == null) {
+				if (isWrapped && itemNode === null) {
 					if (wrap === true) {
 						pause.pause();
 						target.blur();
@@ -230,7 +230,7 @@ const useSpottable = (props, instances, context) => {
 			let gridPosition = scrollContentHandle.current.getGridPosition(focusedIndex);
 
 			if (numOfItems > 0 && focusedIndex % numOfItems !== mutableRef.current.lastFocusedIndex % numOfItems) {
-				const itemNode = scrollContentHandle.current.getItemNode(mutableRef.current.lastFocusedIndex);
+				const itemNode = getItemNode(mutableRef.current.lastFocusedIndex);
 
 				if (itemNode) {
 					itemNode.blur();

--- a/VirtualList/useThemeVirtualList.js
+++ b/VirtualList/useThemeVirtualList.js
@@ -230,10 +230,10 @@ const useSpottable = (props, instances, context) => {
 			let gridPosition = scrollContentHandle.current.getGridPosition(focusedIndex);
 
 			if (numOfItems > 0 && focusedIndex % numOfItems !== mutableRef.current.lastFocusedIndex % numOfItems) {
-				const node = scrollContentHandle.current.getItemNode(mutableRef.current.lastFocusedIndex);
+				const itemNode = scrollContentHandle.current.getItemNode(mutableRef.current.lastFocusedIndex);
 
-				if (node) {
-					node.blur();
+				if (itemNode) {
+					itemNode.blur();
 				}
 			}
 
@@ -304,6 +304,8 @@ const useSpottable = (props, instances, context) => {
 const useThemeVirtualList = (props) => {
 	const {itemRefs, scrollMode, scrollContainerRef, scrollContentHandle, scrollContentRef} = props;
 
+	// Mutable value
+
 	// Hooks
 
 	const instance = {itemRefs, scrollContainerRef, scrollContentHandle, scrollContentRef};
@@ -328,7 +330,7 @@ const useThemeVirtualList = (props) => {
 
 	usePreventScroll(props, instance, {scrollMode});
 
-	const adapter = {
+	const handle = {
 		calculatePositionOnFocus,
 		focusByIndex,
 		focusOnNode,
@@ -339,8 +341,8 @@ const useThemeVirtualList = (props) => {
 		shouldPreventScrollByFocus
 	};
 	useEffect(() => {
-		props.setThemeScrollContentHandle(adapter);
-	}, [adapter, props, props.setThemeScrollContentHandle]);
+		props.setThemeScrollContentHandle(handle);
+	}, [handle, props, props.setThemeScrollContentHandle]);
 
 	// Functions
 

--- a/VirtualList/useThemeVirtualList.js
+++ b/VirtualList/useThemeVirtualList.js
@@ -304,8 +304,6 @@ const useSpottable = (props, instances, context) => {
 const useThemeVirtualList = (props) => {
 	const {itemRefs, scrollMode, scrollContainerRef, scrollContentHandle, scrollContentRef} = props;
 
-	// Mutable value
-
 	// Hooks
 
 	const instance = {itemRefs, scrollContainerRef, scrollContentHandle, scrollContentRef};


### PR DESCRIPTION
Modify the scroller and virtuallist variables in sandstone and agate to be the same.

Enact-DCO-1.0-Signed-off-by: Baekwoo Jung (baekwoo.jung@lge.com)