### PR TITLE
PLAT-101226: Scroller Cleanup> Bind scroll content instance with ref

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
     - npm config set prefer-offline true
     - npm install -g enactjs/cli#develop
     - npm install -g codecov
-    - git clone --branch=develop --depth 1 https://github.com/enactjs/enact ../enact
+    - git clone --branch=feature/PLAT-101226-setScrollContentHandle --depth 1 https://github.com/enactjs/enact ../enact
     - pushd ../enact
     - npm install
     - npm run bootstrap -- --ignore enact-sampler

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
     - npm config set prefer-offline true
     - npm install -g enactjs/cli#develop
     - npm install -g codecov
-    - git clone --branch=feature/PLAT-101226-setScrollContentHandle --depth 1 https://github.com/enactjs/enact ../enact
+    - git clone --branch=develop --depth 1 https://github.com/enactjs/enact ../enact
     - pushd ../enact
     - npm install
     - npm run bootstrap -- --ignore enact-sampler

--- a/Scroller/Scroller.js
+++ b/Scroller/Scroller.js
@@ -50,6 +50,7 @@ let Scroller = (props) => {
 
 	const {
 		scrollContentWrapper: ScrollContentWrapper,
+		scrollContentHandle,
 		isHorizontalScrollbarVisible,
 		isVerticalScrollbarVisible,
 
@@ -71,7 +72,7 @@ let Scroller = (props) => {
 			<div {...scrollContainerProps}>
 				<div {...scrollInnerContainerProps}>
 					<ScrollContentWrapper {...scrollContentWrapperProps}>
-						<UiScrollerBasic {...themeScrollContentProps} />
+						<UiScrollerBasic {...themeScrollContentProps} ref={scrollContentHandle} />
 					</ScrollContentWrapper>
 					{isVerticalScrollbarVisible ? <Scrollbar {...verticalScrollbarProps} /> : null}
 				</div>

--- a/Scroller/useThemeScroller.js
+++ b/Scroller/useThemeScroller.js
@@ -270,6 +270,7 @@ const useThemeScroller = (props) => {
 	delete propsObject.onUpdate;
 	delete propsObject.scrollAndFocusScrollbarButton;
 	delete propsObject.scrollContainerRef;
+	delete propsObject.scrollContentHandle;
 	delete propsObject.setThemeScrollContentHandle;
 	delete propsObject.spotlightId;
 	delete propsObject.scrollContainerHandle;

--- a/VirtualList/VirtualList.js
+++ b/VirtualList/VirtualList.js
@@ -51,6 +51,7 @@ let VirtualList = ({itemSize, role, ...rest}) => {
 	const {
 		// Variables
 		scrollContentWrapper: ScrollContentWrapper,
+		scrollContentHandle,
 		isHorizontalScrollbarVisible,
 		isVerticalScrollbarVisible,
 
@@ -75,7 +76,7 @@ let VirtualList = ({itemSize, role, ...rest}) => {
 			<div {...scrollContainerProps}>
 				<div {...scrollInnerContainerProps}>
 					<ScrollContentWrapper {...scrollContentWrapperProps}>
-						<UiVirtualListBasic {...themeScrollContentProps} />
+						<UiVirtualListBasic {...themeScrollContentProps} ref={scrollContentHandle} />
 					</ScrollContentWrapper>
 					{isVerticalScrollbarVisible ? <Scrollbar {...verticalScrollbarProps} /> : null}
 				</div>
@@ -517,6 +518,7 @@ let VirtualGridList = ({role, ...rest}) => {
 	const {
 		// Variables
 		scrollContentWrapper: ScrollContentWrapper,
+		scrollContentHandle,
 		isHorizontalScrollbarVisible,
 		isVerticalScrollbarVisible,
 
@@ -541,7 +543,7 @@ let VirtualGridList = ({role, ...rest}) => {
 			<div {...scrollContainerProps}>
 				<div {...scrollInnerContainerProps}>
 					<ScrollContentWrapper {...scrollContentWrapperProps}>
-						<UiVirtualListBasic {...themeScrollContentProps} />
+						<UiVirtualListBasic {...themeScrollContentProps} ref={scrollContentHandle} />
 					</ScrollContentWrapper>
 					{isVerticalScrollbarVisible ? <Scrollbar {...verticalScrollbarProps} /> : null}
 				</div>

--- a/VirtualList/useThemeVirtualList.js
+++ b/VirtualList/useThemeVirtualList.js
@@ -360,6 +360,7 @@ const useThemeVirtualList = (props) => {
 	delete rest.focusableScrollbar;
 	delete rest.scrollAndFocusScrollbarButton;
 	delete rest.scrollContainerRef;
+	delete rest.scrollContentHandle;
 	delete rest.spotlightId;
 	delete rest.scrollContainerHandle;
 	delete rest.wrap;

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -184,10 +184,9 @@ const useThemeScroll = (props, instances, context) => {
 
 	// Callback for scroller updates; calculate and, if needed, scroll to new position based on focused item.
 	function handleScrollerUpdate () {
-		const bounds = scrollContainerHandle.current.getScrollBounds();
-		const scrollHeight = bounds && bounds.scrollHeight || 0;
-
 		if (scrollContainerHandle.current.scrollToInfo === null) {
+			const scrollHeight = scrollContainerHandle.current.getScrollBounds().scrollHeight;
+
 			if (scrollHeight !== scrollContainerHandle.current.bounds.scrollHeight) {
 				calculateAndScrollTo();
 			}
@@ -196,7 +195,7 @@ const useThemeScroll = (props, instances, context) => {
 		// oddly, Scroller manages scrollContainerHandle.current.bounds so if we don't update it here (it is also
 		// updated in calculateAndScrollTo but we might not have made it to that point), it will be
 		// out of date when we land back in this method next time.
-		scrollContainerHandle.current.bounds.scrollHeight = scrollHeight;
+		scrollContainerHandle.current.bounds.scrollHeight = scrollContainerHandle.current.getScrollBounds().scrollHeight;
 	}
 
 	function handleResizeWindow () {

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -185,7 +185,7 @@ const useThemeScroll = (props, instances, context) => {
 	// Callback for scroller updates; calculate and, if needed, scroll to new position based on focused item.
 	function handleScrollerUpdate () {
 		const bounds = scrollContainerHandle.current.getScrollBounds();
-		const scrollHeight = bounds && bounds.scrollHeight && 0;
+		const scrollHeight = bounds && bounds.scrollHeight || 0;
 
 		if (scrollContainerHandle.current.scrollToInfo === null) {
 			if (scrollHeight !== scrollContainerHandle.current.bounds.scrollHeight) {

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -14,7 +14,6 @@ import {spottableClass} from '@enact/spotlight/Spottable';
 import {getTargetByDirectionFromPosition} from '@enact/spotlight/src/target';
 import {getRect, intersects} from '@enact/spotlight/src/utils';
 import {useScrollBase} from '@enact/ui/useScroll';
-import {useScrollContentHandle} from '@enact/ui/useScroll/useScrollContentHandle';
 import {assignPropertiesOf} from '@enact/ui/useScroll';
 import utilDOM from '@enact/ui/useScroll/utilDOM';
 import utilEvent from '@enact/ui/useScroll/utilEvent';
@@ -185,9 +184,10 @@ const useThemeScroll = (props, instances, context) => {
 
 	// Callback for scroller updates; calculate and, if needed, scroll to new position based on focused item.
 	function handleScrollerUpdate () {
-		if (scrollContainerHandle.current.scrollToInfo === null) {
-			const scrollHeight = scrollContainerHandle.current.getScrollBounds().scrollHeight;
+		const bounds = scrollContainerHandle.current.getScrollBounds();
+		const scrollHeight = bounds && bounds.scrollHeight && 0;
 
+		if (scrollContainerHandle.current.scrollToInfo === null) {
 			if (scrollHeight !== scrollContainerHandle.current.bounds.scrollHeight) {
 				calculateAndScrollTo();
 			}
@@ -196,7 +196,7 @@ const useThemeScroll = (props, instances, context) => {
 		// oddly, Scroller manages scrollContainerHandle.current.bounds so if we don't update it here (it is also
 		// updated in calculateAndScrollTo but we might not have made it to that point), it will be
 		// out of date when we land back in this method next time.
-		scrollContainerHandle.current.bounds.scrollHeight = scrollContainerHandle.current.getScrollBounds().scrollHeight;
+		scrollContainerHandle.current.bounds.scrollHeight = scrollHeight;
 	}
 
 	function handleResizeWindow () {
@@ -280,6 +280,7 @@ const useScroll = (props) => {
 	// Mutable value
 
 	const scrollContainerRef = useRef();
+	const scrollContentHandle = useRef();
 	const scrollContentRef = useRef();
 	const itemRefs = useRef([]);
 
@@ -322,8 +323,6 @@ const useScroll = (props) => {
 	const setScrollContainerHandle = (handle) => {
 		scrollContainerHandle.current = handle;
 	};
-
-	const [scrollContentHandle, setScrollContentHandle] = useScrollContentHandle();
 
 	// Hooks
 
@@ -396,7 +395,6 @@ const useScroll = (props) => {
 		onWheel: handleWheel,
 		removeEventListeners,
 		scrollTo,
-		setScrollContentHandle,
 		setScrollContainerHandle,
 		scrollMode,
 		scrollContentHandle,
@@ -448,6 +446,7 @@ const useScroll = (props) => {
 	return {
 		...collectionOfProperties,
 		scrollContentWrapper,
+		scrollContentHandle,
 		isHorizontalScrollbarVisible,
 		isVerticalScrollbarVisible
 	};


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed

* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

useScroll, useThemeScroll, useThemeVirtualList, and useThemeScroller referred the instance of scroll content which is ui/VirtualListBasic or ui/ScrollerBasic. That instance is shared by calling setScrollContentHandle in the ui/VirtualListBasic or ui/ScrollerBasic. But ui/VirtualListBasic and ui/ScrollerBasic are React component. So those instance could be referred by ref.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Bind scroll content instance with ref instead of calling the `setScrollContentHandle `.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)

PLAT-101226
PR in Enact: https://github.com/enactjs/enact/pull/2722

### Comments
