### PR TITLE
PLAT-100617: Fixed the wrong prop types

### DIFF
--- a/Panels/TabbedPanels.js
+++ b/Panels/TabbedPanels.js
@@ -37,7 +37,7 @@ const TabbedPanelsBase = kind({
 		onBack: PropTypes.func,
 		orientation: PropTypes.oneOf(['horizontal', 'vertical']),
 		tabPosition: PropTypes.string,
-		tabs: PropTypes.oneOfType([TabGroup])
+		tabs: PropTypes.array
 	},
 	defaultProps: {
 		index: 0,


### PR DESCRIPTION
I fixed the wrong prop types in TabbedPanels that shows an error on the console.

Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)
