### PR TITLE
PLAT-101226: Scroller Cleanup> scrollMode, propsObject, and so on

### DIFF
--- a/Scroller/useThemeScroller.js
+++ b/Scroller/useThemeScroller.js
@@ -255,7 +255,7 @@ const useThemeScroller = (props) => {
 	delete rest.scrollContainerContainsDangerously;
 	delete rest.scrollContainerHandle;
 	delete rest.scrollContainerRef;
-  delete rest.scrollContentHandle;
+	delete rest.scrollContentHandle;
 	delete rest.setThemeScrollContentHandle;
 	delete rest.spotlightId;
 

--- a/Scroller/useThemeScroller.js
+++ b/Scroller/useThemeScroller.js
@@ -248,7 +248,15 @@ const useSpottable = (props, instances) => {
 };
 
 const useThemeScroller = (props) => {
-	const {scrollContainerRef, scrollContentHandle, scrollContentRef} = props;
+	const {scrollContainerRef, ...rest} = props;
+	const {scrollContentHandle, scrollContentRef} = rest;
+
+	delete rest.onUpdate;
+	delete rest.scrollContainerContainsDangerously;
+	delete rest.scrollContainerHandle;
+	delete rest.scrollContainerRef;
+	delete rest.setThemeScrollContentHandle;
+	delete rest.spotlightId;
 
 	// Hooks
 
@@ -264,17 +272,7 @@ const useThemeScroller = (props) => {
 
 	// Render
 
-	const propsObject = Object.assign({}, props);
-
-	delete propsObject.scrollContainerContainsDangerously;
-	delete propsObject.onUpdate;
-	delete propsObject.scrollAndFocusScrollbarButton;
-	delete propsObject.scrollContainerRef;
-	delete propsObject.setThemeScrollContentHandle;
-	delete propsObject.spotlightId;
-	delete propsObject.scrollContainerHandle;
-
-	return propsObject;
+	return rest;
 };
 
 export default useThemeScroller;

--- a/VirtualList/usePreventScroll.js
+++ b/VirtualList/usePreventScroll.js
@@ -1,9 +1,9 @@
 import utilEvent from '@enact/ui/useScroll/utilEvent';
 import {useEffect} from 'react';
 
-const usePreventScroll = (props, instances, context) => {
+const usePreventScroll = (props, instances) => {
+	const {scrollMode} = props;
 	const {scrollContentRef} = instances;
-	const {scrollMode} = context;
 
 	// Hooks
 

--- a/VirtualList/useThemeVirtualList.js
+++ b/VirtualList/useThemeVirtualList.js
@@ -18,9 +18,9 @@ const
 	// using 'bitwise or' for string > number conversion based on performance: https://jsperf.com/convert-string-to-number-techniques/7
 	getNumberValue = (index) => index | 0;
 
-const useSpottable = (props, instances, context) => {
+const useSpottable = (props, instances) => {
+	const {scrollMode} = props;
 	const {itemRefs, scrollContainerRef, scrollContentHandle} = instances;
-	const {scrollMode} = context;
 	const getItemNode = (index) => {
 		const itemNode = itemRefs.current[index % scrollContentHandle.current.state.numOfItems];
 		return (itemNode && parseInt(itemNode.dataset.index) === index) ? itemNode : null;
@@ -302,7 +302,7 @@ const useSpottable = (props, instances, context) => {
 };
 
 const useThemeVirtualList = (props) => {
-	const {itemRefs, scrollMode, scrollContainerRef, scrollContentHandle, scrollContentRef} = props;
+	const {itemRefs, scrollContainerRef, scrollContentHandle, scrollContentRef} = props;
 
 	// Hooks
 
@@ -324,9 +324,9 @@ const useThemeVirtualList = (props) => {
 		shouldPreventScrollByFocus,
 		SpotlightPlaceholder, // eslint-disable-line no-shadow
 		updateStatesAndBounds
-	} = useSpottable(props, instance, {scrollMode});
+	} = useSpottable(props, instance);
 
-	usePreventScroll(props, instance, {scrollMode});
+	usePreventScroll(props, instance);
 
 	const handle = {
 		calculatePositionOnFocus,

--- a/useScroll/useEvent.js
+++ b/useScroll/useEvent.js
@@ -13,8 +13,9 @@ const {animationDuration, epsilon, isPageDown, isPageUp, paginationPageMultiplie
 let lastPointer = {x: 0, y: 0};
 
 const useEventFocus = (props, instances, context) => {
-	const {themeScrollContentHandle, spottable, scrollContainerRef, scrollContentRef, scrollContainerHandle} = instances;
-	const {alertThumb, isWheeling, scrollMode} = context;
+	const {scrollMode} = props;
+	const {scrollContainerHandle, scrollContainerRef, scrollContentRef, spottable, themeScrollContentHandle} = instances;
+	const {alertThumb, isWheeling} = context;
 
 	// Functions
 
@@ -147,8 +148,9 @@ const useEventFocus = (props, instances, context) => {
 };
 
 const useEventKey = (props, instances, context) => {
+	const {scrollMode} = props;
 	const {themeScrollContentHandle, spottable, scrollContentRef, scrollContainerHandle} = instances;
-	const {hasFocus, isContent, scrollMode} = context;
+	const {hasFocus, isContent} = context;
 
 	// Functions
 
@@ -342,8 +344,9 @@ onWindowReady(() => {
 });
 
 const useEventMouse = (props, instances, context) => {
+	const {scrollMode} = props;
 	const {themeScrollContentHandle, scrollContainerHandle} = instances;
-	const {isScrollButtonFocused, scrollMode} = context;
+	const {isScrollButtonFocused} = context;
 
 	// Functions
 
@@ -545,8 +548,9 @@ const useEventVoice = (props, instances, context) => {
 };
 
 const useEventWheel = (props, instances, context) => {
+	const {scrollMode} = props;
 	const {themeScrollContentHandle, horizontalScrollbarRef, scrollContainerHandle, verticalScrollbarRef} = instances;
-	const {isScrollButtonFocused, scrollMode} = context;
+	const {isScrollButtonFocused} = context;
 
 	// Mutable value
 

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -56,9 +56,9 @@ const getTargetInViewByDirectionFromPosition = (direction, position, container) 
 	return getIntersectingElement(target, container);
 };
 
-const useThemeScroll = (props, instances, context) => {
+const useThemeScroll = (props, instances) => {
+	const {scrollMode} = props;
 	const {themeScrollContentHandle, scrollContentRef, scrollContainerHandle, scrollContainerRef} = instances;
-	const {scrollMode} = context;
 	const contextSharedState = useContext(SharedState);
 
 	// Mutable value
@@ -364,7 +364,7 @@ const useScroll = (props) => {
 		scrollTo,
 		start, // scrollMode 'native'
 		stop // scrollMode 'translate'
-	} = useThemeScroll(props, instance, {scrollMode});
+	} = useThemeScroll(props, instance);
 
 	// Render
 

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -85,15 +85,15 @@ const useThemeScroll = (props, instances) => {
 
 	useSpotlightRestore(props, instances);
 
-	const {handleWheel, isWheeling} = useEventWheel(props, instances, {isScrollButtonFocused, scrollMode});
+	const {handleWheel, isWheeling} = useEventWheel(props, instances, {isScrollButtonFocused});
 
-	const {calculateAndScrollTo, handleFocus, hasFocus} = useEventFocus(props, {...instances, spottable: mutableRef}, {alertThumb, isWheeling, scrollMode});
+	const {calculateAndScrollTo, handleFocus, hasFocus} = useEventFocus(props, {...instances, spottable: mutableRef}, {alertThumb, isWheeling});
 
-	const {handleKeyDown, lastPointer, scrollByPageOnPointerMode} = useEventKey(props, {...instances, spottable: mutableRef}, {hasFocus, isContent, scrollMode});
+	const {handleKeyDown, lastPointer, scrollByPageOnPointerMode} = useEventKey(props, {...instances, spottable: mutableRef}, {hasFocus, isContent});
 
 	useEventMonitor({}, instances, {lastPointer, scrollByPageOnPointerMode});
 
-	const {handleDragEnd, handleDragStart, handleFlick, handleMouseDown} = useEventMouse({}, instances, {isScrollButtonFocused, scrollMode});
+	const {handleDragEnd, handleDragStart, handleFlick, handleMouseDown} = useEventMouse({}, instances, {isScrollButtonFocused});
 
 	const {handleTouchStart} = useEventTouch({}, instances, {isScrollButtonFocused});
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added / Resolution
[//]: # (Describe the issue resolved or feature added by this pull request)

- Extract the `scrollMode` from not `context` parameter but `props` parameter.
- Rename `propsObject` as `rest` and cleanup

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)

PLAT-101226

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)