### PR TITLE
PLAT-102854: Use I18nDecorator in synchronous mode to support prerendering.

### DIFF
--- a/AgateDecorator/AgateDecorator.js
+++ b/AgateDecorator/AgateDecorator.js
@@ -215,7 +215,7 @@ const AgateDecorator = hoc(defaultConfig, (config, Wrapped) => {
 	let App = Wrapped;
 	if (float) App = FloatingLayerDecorator({wrappedClassName: bgClassName}, App);
 	if (ri) App = ResolutionDecorator(ri, App);
-	if (i18n) App = I18nDecorator(App);
+	if (i18n) App = I18nDecorator({sync: true}, App);
 	if (spotlight) App = SpotlightRootDecorator({noAutoFocus}, App);
 	if (skin) App = Skinnable({defaultSkin: 'gallium'}, App);
 


### PR DESCRIPTION
Previously, we supported I18nDecorator without any config options passed. This allowed resulted in async iLib usage.  Prerendering multi-locales currently requires synchronous operation (the initial state prior to async callbacks is locale-less).  This changes AgateDecorator to setup I18nDecorator with `{sync: true}` and allow agate apps to prerender multiple locale builds.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>