### PR TITLE
ENYO-6440: Apply ri-scale on sampler and qa-sampler

### DIFF
--- a/samples/sampler/stories/default/VirtualList.js
+++ b/samples/sampler/stories/default/VirtualList.js
@@ -26,7 +26,7 @@ const
 		const itemStyle = {
 			borderBottom: ri.unit(6, 'rem') + ' solid #202328',
 			boxSizing: 'border-box',
-			height: size + 'px'
+			height: ri.unit(size, 'rem')
 		};
 
 		return (
@@ -60,7 +60,7 @@ storiesOf('Agate', module)
 		() => {
 			return (
 				<VirtualList
-					style={{height: ri.scale(600) + 'px'}}
+					style={{height: ri.scaleToRem(600)}}
 					dataSize={updateDataSize(number('dataSize', VirtualListConfig, defaultDataSize))}
 					focusableScrollbar={boolean('focusableScrollbar', VirtualListConfig)}
 					horizontalScrollbar={select('horizontalScrollbar', prop.scrollbarOption, VirtualListConfig)}


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn <jeonghee27.ahn@lge.com>

### Checklist
* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In some samples, the layout is different depending on the resolution.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?) 
Apply ri.scale properly.
- In most cases, use ri.scaleToRem.
- Use the ri.scale method to pass parameter numerically or to values related to Knobs.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
N/A

### Links
[//]: # (Related issues, references)
ENYO-6440

### Comments