### PR TITLE
PLAT-105257: Enact repo package.json cleanup

### DIFF
--- a/samples/sampler/package.json
+++ b/samples/sampler/package.json
@@ -15,6 +15,9 @@
     "serve": "start-storybook -p 8080 -c .storybook --ci"
   },
   "license": "Apache-2.0",
+  "enact": {
+    "theme": "agate"
+  },
   "eslintConfig": {
     "extends": "enact/strict",
     "root": true


### PR DESCRIPTION
Explicitly sets `"theme": "agate"` to the Sampler `package.json`. This is done both for reference/example and to ensure all current/future agate-specific settings are accessible for storybook.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>