### PR TITLE
ENYO-6444: Fix console warning of scrollAndFocusScrollbarButton prop

### DIFF
--- a/Scroller/useThemeScroller.js
+++ b/Scroller/useThemeScroller.js
@@ -245,6 +245,7 @@ const useThemeScroller = (props) => {
 	const {scrollContentHandle, scrollContentRef} = rest;
 
 	delete rest.onUpdate;
+	delete rest.scrollAndFocusScrollbarButton;
 	delete rest.scrollContainerContainsDangerously;
 	delete rest.scrollContainerHandle;
 	delete rest.scrollContainerRef;


### PR DESCRIPTION
### Issue Resolved / Feature Added
Agate sampler shows console warning of React does not recognize the `scrollAndFocusScrollbarButton` prop on a DOM element

### Resolution
Delete prop on `useThemeScroller` render