### PR TITLE
Rename ScrollerBasic, VirtualListBasic as ScrollerBase, VirtualListBase from agate

### DIFF
--- a/Scroller/Scroller.js
+++ b/Scroller/Scroller.js
@@ -19,7 +19,7 @@
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import {ResizeContext} from '@enact/ui/Resizable';
-import {ScrollerBasic as UiScrollerBasic} from '@enact/ui/Scroller';
+import {ScrollerBase as UiScrollerBase} from '@enact/ui/Scroller';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -41,7 +41,7 @@ const nop = () => {};
  *
  * @class Scroller
  * @memberof agate/Scroller
- * @extends ui/Scroller.ScrollerBasic
+ * @extends ui/Scroller.ScrollerBase
  * @ui
  * @public
  */
@@ -72,7 +72,7 @@ let Scroller = (props) => {
 			<div {...scrollContainerProps}>
 				<div {...scrollInnerContainerProps}>
 					<ScrollContentWrapper {...scrollContentWrapperProps}>
-						<UiScrollerBasic {...themeScrollContentProps} ref={scrollContentHandle} />
+						<UiScrollerBase {...themeScrollContentProps} ref={scrollContentHandle} />
 					</ScrollContentWrapper>
 					{isVerticalScrollbarVisible ? <Scrollbar {...verticalScrollbarProps} /> : null}
 				</div>

--- a/VirtualList/VirtualList.js
+++ b/VirtualList/VirtualList.js
@@ -9,7 +9,7 @@
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import {ResizeContext} from '@enact/ui/Resizable';
-import {gridListItemSizeShape, itemSizesShape, VirtualListBasic as UiVirtualListBasic} from '@enact/ui/VirtualList';
+import {gridListItemSizeShape, itemSizesShape, VirtualListBase as UiVirtualListBase} from '@enact/ui/VirtualList';
 import PropTypes from 'prop-types';
 import React from 'react';
 import warning from 'warning';
@@ -27,7 +27,7 @@ const nop = () => {};
  *
  * @class VirtualList
  * @memberof agate/VirtualList
- * @extends ui/VirtualList.VirtualListBasic
+ * @extends ui/VirtualList.VirtualListBase
  * @ui
  * @public
  */
@@ -76,7 +76,7 @@ let VirtualList = ({itemSize, role, ...rest}) => {
 			<div {...scrollContainerProps}>
 				<div {...scrollInnerContainerProps}>
 					<ScrollContentWrapper {...scrollContentWrapperProps}>
-						<UiVirtualListBasic {...themeScrollContentProps} ref={scrollContentHandle} />
+						<UiVirtualListBase {...themeScrollContentProps} ref={scrollContentHandle} />
 					</ScrollContentWrapper>
 					{isVerticalScrollbarVisible ? <Scrollbar {...verticalScrollbarProps} /> : null}
 				</div>
@@ -486,7 +486,7 @@ VirtualList.defaultProps = {
  *
  * @class VirtualGridList
  * @memberof agate/VirtualList
- * @extends ui/VirtualList.VirtualListBasic
+ * @extends ui/VirtualList.VirtualListBase
  * @ui
  * @public
  */
@@ -519,7 +519,7 @@ let VirtualGridList = ({role, ...rest}) => {
 			<div {...scrollContainerProps}>
 				<div {...scrollInnerContainerProps}>
 					<ScrollContentWrapper {...scrollContentWrapperProps}>
-						<UiVirtualListBasic {...themeScrollContentProps} ref={scrollContentHandle} />
+						<UiVirtualListBase {...themeScrollContentProps} ref={scrollContentHandle} />
 					</ScrollContentWrapper>
 					{isVerticalScrollbarVisible ? <Scrollbar {...verticalScrollbarProps} /> : null}
 				</div>

--- a/VirtualList/useThemeVirtualList.js
+++ b/VirtualList/useThemeVirtualList.js
@@ -34,7 +34,7 @@ const useSpottable = (props, instances) => {
 		isWrappedBy5way: false,
 		lastFocusedIndex: null,
 		nodeIndexToBeFocused: false,
-		pause: new Pause('VirtualListBasic')
+		pause: new Pause('VirtualListBase')
 	});
 
 	const {pause} = mutableRef.current;

--- a/samples/sampler/stories/default/VirtualList.js
+++ b/samples/sampler/stories/default/VirtualList.js
@@ -4,7 +4,7 @@ import {mergeComponentMetadata} from '@enact/storybook-utils';
 import React from 'react';
 import ri from '@enact/ui/resolution';
 import {storiesOf} from '@storybook/react';
-import {VirtualListBasic as UiVirtualListBasic} from '@enact/ui/VirtualList';
+import {VirtualListBase as UiVirtualListBase} from '@enact/ui/VirtualList';
 
 import Item from '@enact/agate/Item';
 import VirtualList from '@enact/agate/VirtualList';
@@ -52,7 +52,7 @@ const updateDataSize = (dataSize) => {
 
 updateDataSize(defaultDataSize);
 
-const VirtualListConfig = mergeComponentMetadata('VirtualList', UiVirtualListBasic, VirtualList);
+const VirtualListConfig = mergeComponentMetadata('VirtualList', UiVirtualListBase, VirtualList);
 
 storiesOf('Agate', module)
 	.add(
@@ -80,7 +80,7 @@ storiesOf('Agate', module)
 		},
 		{
 			info: {
-				text: 'Basic usage of VirtualList'
+				text: 'The basic usage of VirtualList'
 			}
 		}
 	);


### PR DESCRIPTION
In the https://github.com/enactjs/enact/pull/2760,
ui/VirtualList.VirtualListBasic.js was renamed as ui/VirtualList.VirtualListBase.js and
ui/Scroller.ScrollerBasic.js was renamed as ui/Scroller.ScrollerBase.js.
So the related code updated.

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)