### PR TITLE
PLAT-105596: Fixed the ApplicationClosebutton doesn't work when touch near the button area

### DIFF
--- a/Panels/ApplicationCloseButton.js
+++ b/Panels/ApplicationCloseButton.js
@@ -46,7 +46,7 @@ const ApplicationCloseButton = kind({
 		return (
 			<Button
 				{...rest}
-				onTap={onApplicationClose}
+				onClick={onApplicationClose}
 				size="small"
 				icon="closex"
 			/>


### PR DESCRIPTION
### Issue Resolved / Feature Added
Fixed the ApplicationClosebutton of the Panel doesn't work when touching near the button. The visual effect turns to pressed effect but touch event doesn't triggered.

### Resolution
Changed event `onTap` to `onClick` on ApplicationCloseButton 

### Additional Considerations
I think the best immediate solution is to use `onClick` instead of `onTap`. I'm not sure what the long term solution is though. We can add some margin to `hasTouchLeftTarget` to simulate finger size but that seems error prone. Relying on the platform to detect that is probably a better solution so a little more investigation is required.

Enact-DCO-1.0-Signed-off-by: Seungho Park <seunghoh.park@lge.com>