### PR TITLE
PLAT-107424: Reduce the number of DOM elements in VirtualList

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
     - npm config set prefer-offline true
     - npm install -g enactjs/cli#develop
     - npm install -g codecov
-    - git clone --branch=feature/PLAT-107424 --depth 1 https://github.com/enactjs/enact ../enact
+    - git clone --branch=develop --depth 1 https://github.com/enactjs/enact ../enact
     - pushd ../enact
     - npm install
     - npm run lerna exec -- --ignore enact-sampler --concurrency 1 -- npm --no-package-lock link

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
     - npm config set prefer-offline true
     - npm install -g enactjs/cli#develop
     - npm install -g codecov
-    - git clone --branch=develop --depth 1 https://github.com/enactjs/enact ../enact
+    - git clone --branch=feature/PLAT-107424 --depth 1 https://github.com/enactjs/enact ../enact
     - pushd ../enact
     - npm install
     - npm run lerna exec -- --ignore enact-sampler --concurrency 1 -- npm --no-package-lock link

--- a/VirtualList/useThemeVirtualList.js
+++ b/VirtualList/useThemeVirtualList.js
@@ -214,10 +214,6 @@ const useSpottable = (props, instances) => {
 		}
 	}
 
-	function isNeededScrollingPlaceholder () {
-		return mutableRef.current.nodeIndexToBeFocused != null && Spotlight.isPaused();
-	}
-
 	function calculatePositionOnFocus ({item, scrollPosition = scrollContentHandle.current.scrollPosition}) {
 		const
 
@@ -287,7 +283,6 @@ const useSpottable = (props, instances) => {
 		handlePlaceholderFocus,
 		handleRestoreLastFocus,
 		initItemRef,
-		isNeededScrollingPlaceholder,
 		setContainerDisabled,
 		setLastFocusedNode,
 		shouldPreventScrollByFocus,
@@ -312,7 +307,6 @@ const useThemeVirtualList = (props) => {
 		handlePlaceholderFocus,
 		handleRestoreLastFocus,
 		initItemRef,
-		isNeededScrollingPlaceholder,
 		setContainerDisabled,
 		setLastFocusedNode,
 		shouldPreventScrollByFocus,
@@ -343,9 +337,7 @@ const useThemeVirtualList = (props) => {
 
 	// Render
 
-	const
-		{itemRenderer, role, ...rest} = props,
-		needsScrollingPlaceholder = isNeededScrollingPlaceholder();
+	const {itemRenderer, ...rest} = props;
 
 	// not used by VirtualList
 	delete rest.scrollContainerContainsDangerously;
@@ -368,12 +360,10 @@ const useThemeVirtualList = (props) => {
 				index
 			})
 		),
-		itemsRenderer: (itemsRendererProps) => {
-			return listItemsRenderer({
-				...itemsRendererProps,
+		placeholderRenderer: (primary) => {
+			return placeholderRenderer({
 				handlePlaceholderFocus: handlePlaceholderFocus,
-				needsScrollingPlaceholder,
-				role,
+				primary,
 				SpotlightPlaceholder
 			});
 		},
@@ -383,36 +373,23 @@ const useThemeVirtualList = (props) => {
 };
 
 /* eslint-disable enact/prop-types */
-function listItemsRenderer (props) {
+function placeholderRenderer (props) {
 	const {
-		cc,
 		handlePlaceholderFocus,
-		needsScrollingPlaceholder,
 		primary,
-		role,
 		SpotlightPlaceholder // eslint-disable-line no-shadow
 	} = props;
 
-	return (
-		<>
-			{cc.length ? (
-				<div role={role}>{cc}</div>
-			) : null}
-			{primary ? null : (
-				<SpotlightPlaceholder
-					data-index={0}
-					data-vl-placeholder
-					// a zero width/height element can't be focused by spotlight so we're giving
-					// the placeholder a small size to ensure it is navigable
-					onFocus={handlePlaceholderFocus}
-					style={{width: 10}}
-				/>
-			)}
-			{needsScrollingPlaceholder ? (
-				<SpotlightPlaceholder />
-			) : null}
-		</>
-	);
+	return (primary ? null : (
+		<SpotlightPlaceholder
+			data-index={0}
+			data-vl-placeholder
+			// a zero width/height element can't be focused by spotlight so we're giving
+			// the placeholder a small size to ensure it is navigable
+			onFocus={handlePlaceholderFocus}
+			style={{width: 10}}
+		/>
+	));
 }
 /* eslint-enable enact/prop-types */
 

--- a/VirtualList/useThemeVirtualList.js
+++ b/VirtualList/useThemeVirtualList.js
@@ -286,7 +286,6 @@ const useSpottable = (props, instances) => {
 		setContainerDisabled,
 		setLastFocusedNode,
 		shouldPreventScrollByFocus,
-		SpotlightPlaceholder,
 		updateStatesAndBounds
 	};
 };
@@ -310,7 +309,6 @@ const useThemeVirtualList = (props) => {
 		setContainerDisabled,
 		setLastFocusedNode,
 		shouldPreventScrollByFocus,
-		SpotlightPlaceholder, // eslint-disable-line no-shadow
 		updateStatesAndBounds
 	} = useSpottable(props, instance);
 
@@ -362,9 +360,8 @@ const useThemeVirtualList = (props) => {
 		),
 		placeholderRenderer: (primary) => {
 			return placeholderRenderer({
-				handlePlaceholderFocus: handlePlaceholderFocus,
-				primary,
-				SpotlightPlaceholder
+				handlePlaceholderFocus,
+				primary
 			});
 		},
 		onUpdateItems: handleRestoreLastFocus,
@@ -375,8 +372,7 @@ const useThemeVirtualList = (props) => {
 /* eslint-disable enact/prop-types */
 function placeholderRenderer ({
 	handlePlaceholderFocus,
-	primary,
-	SpotlightPlaceholder // eslint-disable-line no-shadow
+	primary
 }) {
 	return (primary ? null : (
 		<SpotlightPlaceholder

--- a/VirtualList/useThemeVirtualList.js
+++ b/VirtualList/useThemeVirtualList.js
@@ -382,7 +382,7 @@ function placeholderRenderer ({
 		<SpotlightPlaceholder
 			data-index={0}
 			data-vl-placeholder
-			key='placeholder'
+			key="placeholder"
 			// a zero width/height element can't be focused by spotlight so we're giving
 			// the placeholder a small size to ensure it is navigable
 			onFocus={handlePlaceholderFocus}

--- a/VirtualList/useThemeVirtualList.js
+++ b/VirtualList/useThemeVirtualList.js
@@ -373,17 +373,16 @@ const useThemeVirtualList = (props) => {
 };
 
 /* eslint-disable enact/prop-types */
-function placeholderRenderer (props) {
-	const {
-		handlePlaceholderFocus,
-		primary,
-		SpotlightPlaceholder // eslint-disable-line no-shadow
-	} = props;
-
+function placeholderRenderer ({
+	handlePlaceholderFocus,
+	primary,
+	SpotlightPlaceholder // eslint-disable-line no-shadow
+}) {
 	return (primary ? null : (
 		<SpotlightPlaceholder
 			data-index={0}
 			data-vl-placeholder
+			key='placeholder'
 			// a zero width/height element can't be focused by spotlight so we're giving
 			// the placeholder a small size to ensure it is navigable
 			onFocus={handlePlaceholderFocus}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added / Resolution
[//]: # (Describe the issue resolved or feature added by this pull request)

To remove the `div` with role attribute, the `itemRenderer` was renamed as `placeholderRenderer` in https://github.com/enactjs/enact/pull/2770. So all theme libraries should be updated align to that API.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

We don't need to handle the `needsScrollingPlaceholder`. In other theme library, it was already deprecated.

### Links
[//]: # (Related issues, references)

PLAT-107424

### Comments
