### PR TITLE
PLAT-107712: Fix `inline` not found error on LabeledIcon and LabeledIconButton

### DIFF
--- a/LabeledIcon/LabeledIcon.js
+++ b/LabeledIcon/LabeledIcon.js
@@ -11,7 +11,7 @@
  */
 
 import kind from '@enact/core/kind';
-import UiLabeledIcon from '@enact/ui/LabeledIcon';
+import {LabeledIconBase as UiLabeledIcon} from '@enact/ui/LabeledIcon';
 import Pure from '@enact/ui/internal/Pure';
 import compose from 'ramda/src/compose';
 import PropTypes from 'prop-types';

--- a/LabeledIcon/LabeledIcon.js
+++ b/LabeledIcon/LabeledIcon.js
@@ -11,7 +11,7 @@
  */
 
 import kind from '@enact/core/kind';
-import {LabeledIconBase as UiLabeledIcon} from '@enact/ui/LabeledIcon';
+import {LabeledIconBase as UiLabeledIconBase} from '@enact/ui/LabeledIcon';
 import Pure from '@enact/ui/internal/Pure';
 import compose from 'ramda/src/compose';
 import PropTypes from 'prop-types';
@@ -55,7 +55,7 @@ const LabeledIconBase = kind({
 		publicClassNames: true
 	},
 
-	render: (props) => UiLabeledIcon.inline({
+	render: (props) => UiLabeledIconBase.inline({
 		iconComponent: Icon,
 		...props,
 		css: props.css

--- a/LabeledIcon/LabeledIcon.js
+++ b/LabeledIcon/LabeledIcon.js
@@ -11,7 +11,7 @@
  */
 
 import kind from '@enact/core/kind';
-import {LabeledIconBase as UiLabeledIconBase} from '@enact/ui/LabeledIcon';
+import {LabeledIconBase as UiLabeledIconBase, LabeledIconDecorator as UiLabeledIconDecorator} from '@enact/ui/LabeledIcon';
 import Pure from '@enact/ui/internal/Pure';
 import compose from 'ramda/src/compose';
 import PropTypes from 'prop-types';
@@ -67,10 +67,13 @@ const LabeledIconBase = kind({
  *
  * @hoc
  * @memberof agate/LabeledIcon
+ * @mixes agate/LabeledIcon.UiLabeledIconDecorator
  * @mixes agate/Skinnable.Skinnable
+ * @mixes ui/Pure.Pure
  * @public
  */
 const LabeledIconDecorator = compose(
+	UiLabeledIconDecorator, 
 	Pure,
 	Skinnable
 );

--- a/LabeledIcon/LabeledIcon.js
+++ b/LabeledIcon/LabeledIcon.js
@@ -26,7 +26,7 @@ import componentCss from './LabeledIcon.module.less';
  *
  * @class LabeledIconBase
  * @memberof agate/LabeledIcon
- * @extends ui/LabeledIcon.LabeledIcon
+ * @extends ui/LabeledIcon.LabeledIconBase
  * @ui
  * @public
  */
@@ -67,13 +67,12 @@ const LabeledIconBase = kind({
  *
  * @hoc
  * @memberof agate/LabeledIcon
- * @mixes agate/LabeledIcon.UiLabeledIconDecorator
+ * @mixes agate/LabeledIcon.LabeledIconDecorator
  * @mixes agate/Skinnable.Skinnable
- * @mixes ui/Pure.Pure
  * @public
  */
 const LabeledIconDecorator = compose(
-	UiLabeledIconDecorator, 
+	UiLabeledIconDecorator,
 	Pure,
 	Skinnable
 );

--- a/LabeledIconButton/LabeledIconButton.js
+++ b/LabeledIconButton/LabeledIconButton.js
@@ -12,7 +12,7 @@
 
 import EnactPropTypes from '@enact/core/internal/prop-types';
 import kind from '@enact/core/kind';
-import UiLabeledIcon from '@enact/ui/LabeledIcon';
+import {LabeledIconBase as UiLabeledIcon} from '@enact/ui/LabeledIcon';
 import PropTypes from 'prop-types';
 import React from 'react';
 

--- a/LabeledIconButton/LabeledIconButton.js
+++ b/LabeledIconButton/LabeledIconButton.js
@@ -12,7 +12,8 @@
 
 import EnactPropTypes from '@enact/core/internal/prop-types';
 import kind from '@enact/core/kind';
-import {LabeledIconBase as UiLabeledIconBase} from '@enact/ui/LabeledIcon';
+import {LabeledIconBase as UiLabeledIconBase, LabeledIconDecorator as UiLabeledIconDecorator} from '@enact/ui/LabeledIcon';
+import compose from 'ramda/src/compose';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -28,7 +29,7 @@ const Button = Skinnable(ButtonBase);
  *
  * @class LabeledIconButtonBase
  * @memberof agate/LabeledIconButton
- * @extends ui/LabeledIcon.LabeledIcon
+ * @extends ui/LabeledIcon.LabeledIconBase
  * @ui
  * @public
  */
@@ -143,10 +144,14 @@ const LabeledIconButtonBase = kind({
  *
  * @hoc
  * @memberof agate/LabeledIconButton
- * @mixes agate/Skinnable.Skinnable
+ * @mixes agate/Button.ButtonDecorator
+ * @mixes agate/LabeledIcon.LabeledIconDecorator
  * @public
  */
-const LabeledIconButtonDecorator = ButtonDecorator;
+const LabeledIconButtonDecorator = compose(
+	UiLabeledIconDecorator,
+	ButtonDecorator
+);
 
 /**
  * An Agate-styled icon button component with a label.

--- a/LabeledIconButton/LabeledIconButton.js
+++ b/LabeledIconButton/LabeledIconButton.js
@@ -12,7 +12,7 @@
 
 import EnactPropTypes from '@enact/core/internal/prop-types';
 import kind from '@enact/core/kind';
-import {LabeledIconBase as UiLabeledIcon} from '@enact/ui/LabeledIcon';
+import {LabeledIconBase as UiLabeledIconBase} from '@enact/ui/LabeledIcon';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -120,7 +120,7 @@ const LabeledIconButtonBase = kind({
 		spriteCount,
 		...rest
 	}) => {
-		return UiLabeledIcon.inline({
+		return UiLabeledIconBase.inline({
 			...rest,
 			icon: (
 				<Button


### PR DESCRIPTION
Fixed "inline is not a function" error on LabeledIcon and LabeledIconButton.
This error is due to ui/Slottable migration from `kind` to `function`
Changed import from `ui/LabeledIcon` to `ui/LabeldIconBase` as it looks make sense to me rather than removing the use of inline

Enact-DCO-1.0-Signed-off-by: Seungho Park <seunghoh.park@lge.com>