### PR TITLE
PLAT-106938: Add prop to PopupMenu for customizing closeButton string 

### DIFF
--- a/PopupMenu/PopupMenu.js
+++ b/PopupMenu/PopupMenu.js
@@ -18,6 +18,7 @@ import Layout, {Cell} from '@enact/ui/Layout';
 import Slottable from '@enact/ui/Slottable';
 import Transition from '@enact/ui/Transition';
 
+import $L from '../internal/$L';
 import Skinnable from '../Skinnable';
 import Heading from '../Heading';
 import LabeledIconButton from '../LabeledIconButton';
@@ -39,6 +40,7 @@ const PopupMenuBase = kind({
 	name: 'PopupMenu',
 	propTypes: /** @lends agate/PopupMenu.PopupMenuBase.prototype */ {
 		closeButton: PropTypes.bool,
+		closeButtonLabel: PropTypes.string,
 		css: PropTypes.object,
 		noAnimation: PropTypes.bool,
 		onClose: PropTypes.func,
@@ -50,6 +52,7 @@ const PopupMenuBase = kind({
 
 	defaultProps: {
 		closeButton: false,
+		closeButtonLabel: $L('Cancel'),
 		noAnimation: false,
 		open: false,
 		orientation: 'horizontal'
@@ -64,7 +67,7 @@ const PopupMenuBase = kind({
 		className: ({orientation, styler}) => styler.append(orientation)
 	},
 
-	render: ({children, closeButton, css, noAnimation, onClose, onHide, open, orientation, title, ...rest}) => {
+	render: ({children, closeButton, closeButtonLabel, css, noAnimation, onClose, onHide, open, orientation, title, ...rest}) => {
 		return (
 			<Transition
 				noAnimation={noAnimation}
@@ -90,7 +93,7 @@ const PopupMenuBase = kind({
 								className={css.closeButton}
 								size="huge"
 								backgroundOpacity="lightOpaque"
-							>cancel</LabeledIconButton> : null}
+							>{closeButtonLabel}</LabeledIconButton> : null}
 						</Scroller>
 					</Cell>
 				</Layout>
@@ -118,6 +121,8 @@ const PopupMenuDecorator = compose(
  *
  * @class PopupMenu
  * @memberof agate/PopupMenu
+ * @extends agate/PopupMenu.PopupMenuBase
+ * @mixes agate/PopupMenu.PopupMenuDecorator
  * @ui
  * @public
  */

--- a/samples/sampler/stories/default/Popup.js
+++ b/samples/sampler/stories/default/Popup.js
@@ -4,9 +4,9 @@ import {boolean, select, text} from '@enact/storybook-utils/addons/knobs';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 
-import Popup from '@enact/agate/Popup';
+import {Popup, PopupBase} from '@enact/agate/Popup';
 
-const Config = mergeComponentMetadata('Popup', Popup);
+const Config = mergeComponentMetadata('Popup', PopupBase);
 
 storiesOf('Agate', module)
 	.add(

--- a/samples/sampler/stories/default/PopupMenu.js
+++ b/samples/sampler/stories/default/PopupMenu.js
@@ -5,9 +5,9 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 
 import LabeledIconButton from '@enact/agate/LabeledIconButton';
-import PopupMenu from '@enact/agate/PopupMenu';
+import {PopupMenu, PopupMenuBase} from '@enact/agate/PopupMenu';
 
-const Config = mergeComponentMetadata('PopupMenu', PopupMenu);
+const Config = mergeComponentMetadata('PopupMenu', PopupMenuBase);
 
 storiesOf('Agate', module)
 	.add(
@@ -16,13 +16,13 @@ storiesOf('Agate', module)
 			<div>
 				<PopupMenu
 					closeButton={boolean('closeButton', Config)}
-					closeButtonLabel={text('closeButtonLabel', Config, 'Cancel')}
+					closeButtonLabel={text('closeButtonLabel', Config)}
 					noAnimation={boolean('noAnimation', Config)}
 					noAutoDismiss={boolean('noAutoDismiss', Config)}
 					onClose={action('onClose')}
 					onHide={action('onHide')}
 					open={boolean('open', Config)}
-					orientation={select('orientation', ['horizontal'], Config, 'horizontal')}
+					orientation={select('orientation', ['horizontal'], Config)}
 					scrimType={select('scrimType', ['none', 'translucent', 'transparent'], Config, 'translucent')}
 					spotlightRestrict={select('spotlightRestrict', ['self-first', 'self-only'], Config, 'self-only')}
 					title={text('title', Config, 'Title')}

--- a/samples/sampler/stories/default/PopupMenu.js
+++ b/samples/sampler/stories/default/PopupMenu.js
@@ -4,6 +4,7 @@ import {boolean, select, text} from '@enact/storybook-utils/addons/knobs';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 
+import LabeledIconButton from '@enact/agate/LabeledIconButton';
 import PopupMenu from '@enact/agate/PopupMenu';
 
 const Config = mergeComponentMetadata('PopupMenu', PopupMenu);
@@ -15,6 +16,7 @@ storiesOf('Agate', module)
 			<div>
 				<PopupMenu
 					closeButton={boolean('closeButton', Config)}
+					closeButtonLabel={text('closeButtonLabel', Config, 'Cancel')}
 					noAnimation={boolean('noAnimation', Config)}
 					noAutoDismiss={boolean('noAutoDismiss', Config)}
 					onClose={action('onClose')}
@@ -25,7 +27,12 @@ storiesOf('Agate', module)
 					spotlightRestrict={select('spotlightRestrict', ['self-first', 'self-only'], Config, 'self-only')}
 					title={text('title', Config, 'Title')}
 				>
-					<div>{text('children', Config, 'Hello Popup')}</div>
+					<LabeledIconButton
+						inline
+						icon="profileA1"
+						size="huge"
+						backgroundOpacity="lightOpaque"
+					>User1</LabeledIconButton>
 				</PopupMenu>
 				Use KNOBS to interact with PopupMenu.
 			</div>

--- a/samples/sampler/stories/default/PopupMenu.js
+++ b/samples/sampler/stories/default/PopupMenu.js
@@ -1,0 +1,36 @@
+import {mergeComponentMetadata} from '@enact/storybook-utils';
+import {action} from '@enact/storybook-utils/addons/actions';
+import {boolean, select, text} from '@enact/storybook-utils/addons/knobs';
+import React from 'react';
+import {storiesOf} from '@storybook/react';
+
+import PopupMenu from '@enact/agate/PopupMenu';
+
+const Config = mergeComponentMetadata('PopupMenu', PopupMenu);
+
+storiesOf('Agate', module)
+	.add(
+		'PopupMenu',
+		() => (
+			<div>
+				<PopupMenu
+					closeButton={boolean('closeButton', Config)}
+					noAnimation={boolean('noAnimation', Config)}
+					noAutoDismiss={boolean('noAutoDismiss', Config)}
+					onClose={action('onClose')}
+					onHide={action('onHide')}
+					open={boolean('open', Config)}
+					orientation={select('orientation', ['horizontal'], Config, 'horizontal')}
+					scrimType={select('scrimType', ['none', 'translucent', 'transparent'], Config, 'translucent')}
+					spotlightRestrict={select('spotlightRestrict', ['self-first', 'self-only'], Config, 'self-only')}
+					title={text('title', Config, 'Title')}
+				>
+					<div>{text('children', Config, 'Hello Popup')}</div>
+				</PopupMenu>
+				Use KNOBS to interact with PopupMenu.
+			</div>
+		),
+		{
+			text: 'Basic usage of PopupMenu'
+		}
+	);


### PR DESCRIPTION
Add `closeButtonLabel` prop so that developer can customize string for `closeButton`
Add `popupMenu` sampler
Enact-DCO-1.0-Signed-off-by: Seungho Park <seunghoh.park@lge.com>