### PR TITLE
ENYO-6446: Fix not showing scrollbar at initial time

### DIFF
--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -78,7 +78,7 @@ const useThemeScroll = (props, instances) => {
 		onScrollbarButtonClick,
 		scrollAndFocusScrollbarButton,
 		scrollbarProps
-	} = useScrollbar(props, instances, {isContent});
+	} = useScrollbar(props, instances);
 
 	useSpotlightConfig(props);
 
@@ -300,7 +300,6 @@ const useScroll = (props) => {
 		isDragging: null,
 		isFlicked: null,
 		isScrollAnimationTargetAccumulated: null,
-		isUpdatedScrollScrollbarTrack: null,
 		lastInputType: null,
 		rtl: null,
 		scrollBounds: null,

--- a/useScroll/useScrollbar.js
+++ b/useScroll/useScrollbar.js
@@ -1,14 +1,12 @@
-import Spotlight from '@enact/spotlight';
 import {constants} from '@enact/ui/useScroll';
 
 const {paginationPageMultiplier} = constants;
 
-const useScrollbar = (props, instances, context) => {
+const useScrollbar = (props, instances) => {
 	const {horizontalScrollbarHandle, scrollContainerHandle, verticalScrollbarHandle} = instances;
-	const {isContent} = context;
 
 	const scrollbarProps = {
-		cbAlertScrollbarTrack: alertScrollbarTrackAfterRendered,
+		cbAlertScrollbarTrack: alertScrollbarTrack,
 		onNextScroll: onScrollbarButtonClick,
 		onPrevScroll: onScrollbarButtonClick
 	};
@@ -76,14 +74,6 @@ const useScrollbar = (props, instances, context) => {
 
 		scrollContainerHandle.current.showScrollbarTrack(bounds);
 		scrollContainerHandle.current.startHidingScrollbarTrack();
-	}
-
-	function alertScrollbarTrackAfterRendered () {
-		const spotItem = Spotlight.getCurrent();
-
-		if (!Spotlight.getPointerMode() && isContent(spotItem) && scrollContainerHandle.current.isUpdatedScrollScrollbarTrack) {
-			alertScrollbarTrack();
-		}
 	}
 
 	// Return


### PR DESCRIPTION
After migrating hooks, `isUpdatedScrollbarTrack` cannot be referenced because the variable is updated later than `alertScrollbarTrackAfterRendered`.
To show the scrollbar at the initial time, we need to remove the condition.

Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)