### PR TITLE
PLAT-104180: VirtualList: Fix jumping focus when keys pressed in a row

### DIFF
--- a/VirtualList/useThemeVirtualList.js
+++ b/VirtualList/useThemeVirtualList.js
@@ -147,6 +147,7 @@ const useSpottable = (props, instances) => {
 				focusByIndex(nextIndex);
 			} else {
 				const itemNode = getItemNode(nextIndex);
+				const stickTo = Math.abs(endBoundary - end) < Math.abs(startBoundary - start) ? 'end' : 'start';
 
 				mutableRef.current.isScrolledBy5way = true;
 				mutableRef.current.isWrappedBy5way = isWrapped;
@@ -166,7 +167,7 @@ const useSpottable = (props, instances) => {
 
 				cbScrollTo({
 					index: nextIndex,
-					stickTo: index < nextIndex ? 'end' : 'start',
+					stickTo,
 					animate: !(isWrapped && wrap === 'noAnimation')
 				});
 			}
@@ -188,6 +189,9 @@ const useSpottable = (props, instances) => {
 			// Item is valid but since the the dom doesn't exist yet, we set the index to focus after the ongoing update
 			setPreservedIndex(index);
 		} else {
+			// Remove any preservedIndex
+			setPreservedIndex(-1);
+
 			if (mutableRef.current.isWrappedBy5way) {
 				SpotlightAccelerator.reset();
 				mutableRef.current.isWrappedBy5way = false;
@@ -272,6 +276,10 @@ const useSpottable = (props, instances) => {
 		return scrollContentHandle.current.getScrollBounds();
 	}
 
+	function getScrollPositionTarget () {
+		return scrollContentHandle.current.scrollPositionTarget;
+	}
+
 	// Return
 
 	return {
@@ -280,6 +288,7 @@ const useSpottable = (props, instances) => {
 		focusOnNode,
 		getNodeIndexToBeFocused,
 		getScrollBounds,
+		getScrollPositionTarget,
 		handlePlaceholderFocus,
 		handleRestoreLastFocus,
 		initItemRef,
@@ -303,6 +312,7 @@ const useThemeVirtualList = (props) => {
 		focusOnNode,
 		getNodeIndexToBeFocused,
 		getScrollBounds,
+		getScrollPositionTarget,
 		handlePlaceholderFocus,
 		handleRestoreLastFocus,
 		initItemRef,
@@ -319,6 +329,7 @@ const useThemeVirtualList = (props) => {
 		focusByIndex,
 		focusOnNode,
 		getScrollBounds,
+		getScrollPositionTarget,
 		setContainerDisabled,
 		setLastFocusedNode,
 		shouldPreventScrollByFocus
@@ -337,10 +348,7 @@ const useThemeVirtualList = (props) => {
 
 	const {itemRenderer, ...rest} = props;
 
-	// not used by VirtualList
 	delete rest.scrollContainerContainsDangerously;
-	// not used by VirtualList
-	delete rest.focusableScrollbar;
 	delete rest.scrollAndFocusScrollbarButton;
 	delete rest.scrollContainerRef;
 	delete rest.scrollContentHandle;

--- a/VirtualList/useThemeVirtualList.js
+++ b/VirtualList/useThemeVirtualList.js
@@ -348,6 +348,7 @@ const useThemeVirtualList = (props) => {
 
 	const {itemRenderer, ...rest} = props;
 
+	delete rest.focusableScrollbar;
 	delete rest.scrollContainerContainsDangerously;
 	delete rest.scrollAndFocusScrollbarButton;
 	delete rest.scrollContainerRef;

--- a/useScroll/useEvent.js
+++ b/useScroll/useEvent.js
@@ -83,6 +83,10 @@ const useEventFocus = (props, instances, context) => {
 				}
 
 				pos = positionFn({item: spotItem, scrollPosition});
+			} else if (scrollMode === 'native' && scrollContainerHandle.current.scrolling) {
+				const scrollPositionTarget = themeScrollContentHandle.current.getScrollPositionTarget();
+
+				pos = positionFn({item: spotItem, scrollPosition: scrollPositionTarget});
 			} else {
 				pos = positionFn({item: spotItem});
 			}

--- a/useScroll/useEvent.js
+++ b/useScroll/useEvent.js
@@ -63,14 +63,15 @@ const useEventFocus = (props, instances, context) => {
 
 		if (spotItem && positionFn && utilDOM.containsDangerously(scrollContentNode, spotItem)) {
 			const lastPos = spottable.current.lastScrollPositionOnFocus;
+			const isScrolling = (
+				scrollMode === 'translate' && scrollContainerHandle.current.animator.isAnimating() ||
+				scrollMode === 'native' && scrollContainerHandle.current.scrolling
+			);
 			let pos;
 
 			// If scroll animation is ongoing, we need to pass last target position to
 			// determine correct scroll position.
-			if (lastPos & (
-				scrollMode === 'translate' && scrollContainerHandle.current.animator.isAnimating() ||
-				scrollMode === 'native' && scrollContainerHandle.current.scrolling
-			)) {
+			if (lastPos & isScrolling) {
 				const
 					contentRect = getRect(scrollContentNode),
 					itemRect = getRect(spotItem);
@@ -83,7 +84,7 @@ const useEventFocus = (props, instances, context) => {
 				}
 
 				pos = positionFn({item: spotItem, scrollPosition});
-			} else if (scrollMode === 'native' && scrollContainerHandle.current.scrolling) {
+			} else if (isScrolling) {
 				const scrollPositionTarget = themeScrollContentHandle.current.getScrollPositionTarget();
 
 				pos = positionFn({item: spotItem, scrollPosition: scrollPositionTarget});

--- a/useScroll/useEvent.js
+++ b/useScroll/useEvent.js
@@ -84,7 +84,7 @@ const useEventFocus = (props, instances, context) => {
 				}
 
 				pos = positionFn({item: spotItem, scrollPosition});
-			} else if (isScrolling) {
+			} else if (isScrolling && themeScrollContentHandle.current.getScrollPositionTarget) {
 				const scrollPositionTarget = themeScrollContentHandle.current.getScrollPositionTarget();
 
 				pos = positionFn({item: spotItem, scrollPosition: scrollPositionTarget});

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -150,7 +150,7 @@ const useThemeScroll = (props, instances) => {
 
 		if (mutableRef.current.pointToFocus !== null) {
 			// no need to focus on pointer mode
-			if (!Spotlight.getPointerMode()) {
+			if (!Spotlight.getPointerMode() && !Spotlight.getCurrent()) {
 				const
 					{direction, x, y} = mutableRef.current.pointToFocus,
 					position = {x, y},

--- a/useScroll/useThemeScrollContentHandle.js
+++ b/useScroll/useThemeScrollContentHandle.js
@@ -8,10 +8,10 @@ const useThemeScrollContentHandle = () => {
 		focusByIndex: null,
 		focusOnNode: null,
 		getScrollBounds: null,
+		getScrollPositionTarget: null,
 		setContainerDisabled: null,
 		setLastFocusedNode: null,
-		shouldPreventScrollByFocus: null,
-		scrollMode: null
+		shouldPreventScrollByFocus: null
 	});
 
 	// Functions


### PR DESCRIPTION
This PR fixes jumping focus when keys pressed in a row in VirtualList.
1) directional keys right after Page up/down
2) an opposite directioanl key right after a series of directional keys

The first issue occurs when a user pressed directional key(up/down) right after page up/down key.
The list blurs the current focus and scrolls to the target position by page up/down key and then focuses the item. But if the directional key got in before focusing the item by page up/down key, the spotlight gives the focus the item nearby mouse pointer position(https://github.com/enactjs/enact/pull/1292), and then list focuses the item by page up/down key.
I confirmed that this issue is from moonstone and fixed not to focus when there is a focus already on the list and save the target scroll position(https://github.com/enactjs/enact/pull/2778) to make the spotlight focused item scroll into view.

The second issue occurs when a user pressed a series of directional keys and pressed the opposite side of the key.
The main root cause was that the list sticks to the 'start' and 'end' based on `index` and `nextIndex`. So if `nextIndex` is smaller than current `index` meaning backward direction, list always sticks to 'start' which is wrong because we don't need this kind of jump.
So I changed the condition to stick to the nearest one between 'start' and 'end'. Also, I had to clear `preservedIndex` set by previous key handling not to focus after we found the target in the current viewport.

Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)