### PR TITLE
PLAT-104180: VirtualList: Fix jumping focus when keys pressed in a row

### DIFF
--- a/useScroll/useEvent.js
+++ b/useScroll/useEvent.js
@@ -225,11 +225,12 @@ const useEventKey = (props, instances, context) => {
 
 					focusedItem.blur();
 
-					if (themeScrollContentHandle.current.pauseSpotlight) {
-						themeScrollContentHandle.current.pauseSpotlight(true);
-					}
 					if (!props['data-spotlight-container-disabled']) {
 						themeScrollContentHandle.current.setContainerDisabled(true);
+					}
+
+					if (themeScrollContentHandle.current.pauseSpotlight) {
+						themeScrollContentHandle.current.pauseSpotlight(true);
 					}
 
 					spottable.current.pointToFocus = {direction, x, y};

--- a/useScroll/useEvent.js
+++ b/useScroll/useEvent.js
@@ -225,6 +225,9 @@ const useEventKey = (props, instances, context) => {
 
 					focusedItem.blur();
 
+					if (themeScrollContentHandle.current.pauseSpotlight) {
+						themeScrollContentHandle.current.pauseSpotlight(true);
+					}
 					if (!props['data-spotlight-container-disabled']) {
 						themeScrollContentHandle.current.setContainerDisabled(true);
 					}

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -126,6 +126,10 @@ const useThemeScroll = (props, instances) => {
 			themeScrollContentHandle.current.setContainerDisabled(false);
 		}
 
+		if (themeScrollContentHandle.current.pauseSpotlight) {
+			themeScrollContentHandle.current.pauseSpotlight(false);
+		}
+
 		focusOnItem();
 		mutableRef.current.lastScrollPositionOnFocus = null;
 		mutableRef.current.isFlicked = false;

--- a/useScroll/useThemeScrollContentHandle.js
+++ b/useScroll/useThemeScrollContentHandle.js
@@ -8,10 +8,10 @@ const useThemeScrollContentHandle = () => {
 		focusByIndex: null,
 		focusOnNode: null,
 		getScrollBounds: null,
+		pauseSpotlight: null,
 		setContainerDisabled: null,
 		setLastFocusedNode: null,
-		shouldPreventScrollByFocus: null,
-		scrollMode: null
+		shouldPreventScrollByFocus: null
 	});
 
 	// Functions


### PR DESCRIPTION
This PR fixes jumping focus when keys pressed in a row in VirtualList.
1) directional keys right after Page up/down
2) an opposite directioanl key right after a series of directional keys

The first issue occurs when a user pressed directional key(up/down) right after page up/down key.
The list blurs the current focus and scrolls to the target position by page up/down key and then focuses the item. But if the directional key got in before focusing the item by page up/down key, the spotlight gives the focus the item nearby mouse pointer position(https://github.com/enactjs/enact/pull/1292), and then list focuses the item by page up/down key.
I confirmed that this issue is from moonstone and fixed this by pausing spotlight while page up/down key handling.

The second issue occurs when a user pressed a series of directional keys and pressed the opposite side of the key.
The main root cause was that the list sticks to the 'start' and 'end' based on `index` and `nextIndex`. So if `nextIndex` is smaller than current `index` meaning backward direction, list always sticks to 'start' which is wrong because we don't need this kind of jump.
So I changed the condition to stick to the nearest one between 'start' and 'end'. Also, I had to clear `preservedIndex` set by previous key handling not to focus after we found the target in the current viewport.

Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)