### PR TITLE
PLAT-113142: Use ilib-webos NPM package in webOS templates and framework setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "warning": "^3.0.0"
   },
   "peerDependencies": {
-    "ilib": "^14.4.0 || ^14.4.0-webostv1"
+    "ilib": "^14.4.0 || ^14.6.0-webos"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.4.3",


### PR DESCRIPTION
* Updates peer dependency to support all `-webos*` variants (both old `ilib-webos-tv` and new `ilib-webos` version naming)

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>