### PR TITLE
PLAT-112159: Support `default skin styles` knob to use default accent and highlight colors

### DIFF
--- a/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
+++ b/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
@@ -196,11 +196,11 @@ const StorybookDecorator = (story, config) => {
 			locale={locale}
 			{...skinKnobs}
 			skinVariants={boolean('night mode', Config) && 'night'}
-			accent={useSkinDefaultStyles ?
+			accent={useSkinDefaultStyles && !allSkins ?
 				defaultColors[skinKnobs.skin].accent :
 				color('accent', (!newSkin && accentFromURL ? accentFromURL : defaultColors[currentSkin].accent), Config.groupId)
 			}
-			highlight={useSkinDefaultStyles ?
+			highlight={useSkinDefaultStyles && !allSkins ?
 				defaultColors[skinKnobs.skin].highlight :
 				color('highlight', (!newSkin && highlightFromURL ? highlightFromURL : defaultColors[currentSkin].highlight), Config.groupId)
 			}

--- a/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
+++ b/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
@@ -176,6 +176,7 @@ const StorybookDecorator = (story, config) => {
 	const currentSkin = skinFromURL ? skinFromURL : Config.defaultProps.skin;
 	const newSkin = (memory.skin !== currentSkin);
 	memory.skin = currentSkin;  // Remember the skin for the next time we load.
+	const useSkinDefaultStyles = boolean('default skin styles', Config);
 	const accentFromURL = getPropFromURL('accent');
 	const highlightFromURL = getPropFromURL('highlight');
 	const localeFromURL = getPropFromURL('locale');
@@ -189,13 +190,22 @@ const StorybookDecorator = (story, config) => {
 
 	return (
 		<Agate
+			key={skinKnobs.skin}
 			title={`${config.kind} ${config.story}`.trim()}
 			description={config.description}
 			locale={locale}
 			{...skinKnobs}
 			skinVariants={boolean('night mode', Config) && 'night'}
-			accent={color('accent', (!newSkin && accentFromURL ? accentFromURL : defaultColors[currentSkin].accent), Config.groupId)}
-			highlight={color('highlight', (!newSkin && highlightFromURL ? highlightFromURL : defaultColors[currentSkin].highlight), Config.groupId)}
+			accent={
+				useSkinDefaultStyles ?
+				defaultColors[skinKnobs.skin].accent :
+				color('accent', (!newSkin && accentFromURL ? accentFromURL : defaultColors[currentSkin].accent), Config.groupId)
+			}
+			highlight={
+				useSkinDefaultStyles ?
+				defaultColors[skinKnobs.skin].highlight :
+				color('highlight', (!newSkin && highlightFromURL ? highlightFromURL : defaultColors[currentSkin].highlight), Config.groupId)
+			}
 		>
 			<Scroller>
 				{allSkins ? Object.keys(skins).map(skin => (

--- a/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
+++ b/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
@@ -198,13 +198,13 @@ const StorybookDecorator = (story, config) => {
 			skinVariants={boolean('night mode', Config) && 'night'}
 			accent={
 				useSkinDefaultStyles ?
-				defaultColors[skinKnobs.skin].accent :
-				color('accent', (!newSkin && accentFromURL ? accentFromURL : defaultColors[currentSkin].accent), Config.groupId)
+					defaultColors[skinKnobs.skin].accent :
+					color('accent', (!newSkin && accentFromURL ? accentFromURL : defaultColors[currentSkin].accent), Config.groupId)
 			}
 			highlight={
 				useSkinDefaultStyles ?
-				defaultColors[skinKnobs.skin].highlight :
-				color('highlight', (!newSkin && highlightFromURL ? highlightFromURL : defaultColors[currentSkin].highlight), Config.groupId)
+					defaultColors[skinKnobs.skin].highlight :
+					color('highlight', (!newSkin && highlightFromURL ? highlightFromURL : defaultColors[currentSkin].highlight), Config.groupId)
 			}
 		>
 			<Scroller>

--- a/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
+++ b/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
@@ -187,6 +187,7 @@ const StorybookDecorator = (story, config) => {
 	if (!allSkins) {
 		skinKnobs.skin = select('skin', skins, Config, currentSkin);
 	}
+	const {accent, highlight} = useSkinDefaultStyles && !allSkins ? defaultColors[skinKnobs.skin] : {};
 
 	return (
 		<Agate
@@ -195,14 +196,8 @@ const StorybookDecorator = (story, config) => {
 			locale={locale}
 			{...skinKnobs}
 			skinVariants={boolean('night mode', Config) && 'night'}
-			accent={useSkinDefaultStyles && !allSkins ?
-				defaultColors[skinKnobs.skin].accent :
-				color('accent', (!newSkin && accentFromURL ? accentFromURL : defaultColors[currentSkin].accent), Config.groupId)
-			}
-			highlight={useSkinDefaultStyles && !allSkins ?
-				defaultColors[skinKnobs.skin].highlight :
-				color('highlight', (!newSkin && highlightFromURL ? highlightFromURL : defaultColors[currentSkin].highlight), Config.groupId)
-			}
+			accent={accent || color('accent', (!newSkin && accentFromURL ? accentFromURL : defaultColors[currentSkin].accent), Config.groupId)}
+			highlight={highlight || color('highlight', (!newSkin && highlightFromURL ? highlightFromURL : defaultColors[currentSkin].highlight), Config.groupId)}
 		>
 			<Scroller>
 				{allSkins ? Object.keys(skins).map(skin => (

--- a/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
+++ b/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
@@ -176,7 +176,6 @@ const StorybookDecorator = (story, config) => {
 	const currentSkin = skinFromURL ? skinFromURL : Config.defaultProps.skin;
 	const newSkin = (memory.skin !== currentSkin);
 	memory.skin = currentSkin;  // Remember the skin for the next time we load.
-	const useSkinDefaultStyles = boolean('default skin styles', Config);
 	const accentFromURL = getPropFromURL('accent');
 	const highlightFromURL = getPropFromURL('highlight');
 	const localeFromURL = getPropFromURL('locale');
@@ -187,7 +186,7 @@ const StorybookDecorator = (story, config) => {
 	if (!allSkins) {
 		skinKnobs.skin = select('skin', skins, Config, currentSkin);
 	}
-	const {accent, highlight} = useSkinDefaultStyles && !allSkins ? defaultColors[skinKnobs.skin] : {};
+	const {accent, highlight} = !allSkins && boolean('default skin styles', Config) ? defaultColors[skinKnobs.skin] : {};
 
 	return (
 		<Agate

--- a/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
+++ b/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
@@ -196,15 +196,13 @@ const StorybookDecorator = (story, config) => {
 			locale={locale}
 			{...skinKnobs}
 			skinVariants={boolean('night mode', Config) && 'night'}
-			accent={
-				useSkinDefaultStyles ?
-					defaultColors[skinKnobs.skin].accent :
-					color('accent', (!newSkin && accentFromURL ? accentFromURL : defaultColors[currentSkin].accent), Config.groupId)
+			accent={useSkinDefaultStyles ?
+				defaultColors[skinKnobs.skin].accent :
+				color('accent', (!newSkin && accentFromURL ? accentFromURL : defaultColors[currentSkin].accent), Config.groupId)
 			}
-			highlight={
-				useSkinDefaultStyles ?
-					defaultColors[skinKnobs.skin].highlight :
-					color('highlight', (!newSkin && highlightFromURL ? highlightFromURL : defaultColors[currentSkin].highlight), Config.groupId)
+			highlight={useSkinDefaultStyles ?
+				defaultColors[skinKnobs.skin].highlight :
+				color('highlight', (!newSkin && highlightFromURL ? highlightFromURL : defaultColors[currentSkin].highlight), Config.groupId)
 			}
 		>
 			<Scroller>

--- a/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
+++ b/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
@@ -190,7 +190,6 @@ const StorybookDecorator = (story, config) => {
 
 	return (
 		<Agate
-			key={skinKnobs.skin}
 			title={`${config.kind} ${config.story}`.trim()}
 			description={config.description}
 			locale={locale}


### PR DESCRIPTION
Even though changing the `skin`, the `accent` and the `highlight` colors were preserved. So it was hard to verify the updated CSS styles based on the default `accent` and the `highlight` colors in the changed skin.

The `default skin styles` knob is now supported to use default `accent` and `highlight` colors instead of the preserved colors. If checking it, then the `accent` and `highlight` color knobs will be hidden.

Step to reproduce:
1. Select `Agate > Button`
2. Select `Global Knobs`
3. Select `Cobalt` as the `skin`
4. Check `default skin styles`

Expected Result: 
Button background color changes from  #E16253 to white because the highlight color of the Cobalt is white.

Before PR:
![image](https://user-images.githubusercontent.com/4239873/88018417-abeeaa00-cb62-11ea-9564-3911367d7eb0.png)

After PR:
![image](https://user-images.githubusercontent.com/4239873/88018447-b27d2180-cb62-11ea-9174-b0ff1464a3ef.png)

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)