### PR TITLE
PLAT-113850: Fixed broken logic covering edge cases of an invalid `data-index` value

### DIFF
--- a/VirtualList/useEvent.js
+++ b/VirtualList/useEvent.js
@@ -14,7 +14,12 @@ const
 	isPageDown = is('pageDown'),
 	isRight = is('right'),
 	isUp = is('up'),
-	getNumberValue = (index) => index | 0;
+	getNumberValue = (index) => {
+		// using '+ operator' for string > number conversion based on performance: https://jsperf.com/convert-string-to-number-techniques/7
+		let number = +index;
+		// should return -1 if index is not a number or a negative value
+		return number >= 0 ? number : -1;
+	};
 
 const useEventKey = (props, instances, context) => {
 	// Mutable value

--- a/VirtualList/useSpotlight.js
+++ b/VirtualList/useSpotlight.js
@@ -64,7 +64,12 @@ const useSpotlightConfig = (props, instances) => {
 	}
 };
 
-const getNumberValue = (index) => index | 0;
+const getNumberValue = (index) => {
+	// using '+ operator' for string > number conversion based on performance: https://jsperf.com/convert-string-to-number-techniques/7
+	let number = +index;
+	// should return -1 if index is not a number or a negative value
+	return number >= 0 ? number : -1;
+};
 
 const useSpotlightRestore = (props, instances, context) => {
 	const {scrollContentRef, spottable} = instances;

--- a/VirtualList/useThemeVirtualList.js
+++ b/VirtualList/useThemeVirtualList.js
@@ -15,8 +15,12 @@ const SpotlightPlaceholder = Spottable('div');
 
 const
 	nop = () => {},
-	// using 'bitwise or' for string > number conversion based on performance: https://jsperf.com/convert-string-to-number-techniques/7
-	getNumberValue = (index) => index | 0;
+	getNumberValue = (index) => {
+		// using '+ operator' for string > number conversion based on performance: https://jsperf.com/convert-string-to-number-techniques/7
+		let number = +index;
+		// should return -1 if index is not a number or a negative value
+		return number >= 0 ? number : -1;
+	};
 
 const useSpottable = (props, instances) => {
 	const {scrollMode} = props;
@@ -49,7 +53,8 @@ const useSpottable = (props, instances) => {
 		},
 		handleDirectionKeyDown: (ev, eventType, param) => {
 			switch (eventType) {
-				case 'acceleratedKeyDown': onAcceleratedKeyDown(param);
+				case 'acceleratedKeyDown':
+					onAcceleratedKeyDown(param);
 					break;
 				case 'keyDown':
 					if (Spotlight.move(param.direction)) {
@@ -63,7 +68,8 @@ const useSpottable = (props, instances) => {
 						}
 					}
 					break;
-				case 'keyLeave': SpotlightAccelerator.reset();
+				case 'keyLeave':
+					SpotlightAccelerator.reset();
 					break;
 			}
 		},
@@ -141,7 +147,7 @@ const useSpottable = (props, instances) => {
 		mutableRef.current.isScrolledBy5way = false;
 		mutableRef.current.isScrolledByJump = false;
 
-		if (nextIndex >= 0) {
+		if (nextIndex >= 0 && index >= 0) {
 			const
 				row = Math.floor(index / dimensionToExtent),
 				nextRow = Math.floor(nextIndex / dimensionToExtent),
@@ -240,7 +246,7 @@ const useSpottable = (props, instances) => {
 			offsetToClientEnd = primary.clientSize - primary.itemSize,
 			focusedIndex = getNumberValue(item.getAttribute(dataIndexAttribute));
 
-		if (!isNaN(focusedIndex)) {
+		if (focusedIndex >= 0) {
 			let gridPosition = scrollContentHandle.current.getGridPosition(focusedIndex);
 
 			if (numOfItems > 0 && focusedIndex % numOfItems !== mutableRef.current.lastFocusedIndex % numOfItems) {


### PR DESCRIPTION
We're using an internal `getNumberValue` function to convert a string into a number for internal logic. The current implementation of `getNumberLogic` is much faster than `parseInt` but if a string is _undefined_ or _a string contains any character beside space_, it returns 0 instead of invalid value like NaN so we can't catch an exceptional case.
Also, in our usage, `getNumberValue` should return an invalid value like _-1_ or _NaN_ to test if a DOM node is an item or not since we use this function to check `data-index` attribute value of an item's DOM node.
To handle this issue, this PR updates `getNumberValue` with another fast implementation and makes it to return _-1_ for an invalid string.

Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)