### PR TITLE
PLAT-113569: Update @enact/ui-test-utils to 0.5.0

### DIFF
--- a/AgateDecorator/AgateDecorator.js
+++ b/AgateDecorator/AgateDecorator.js
@@ -7,7 +7,7 @@
  */
 
 import deprecate from '@enact/core/internal/deprecate';
-import ThemeDecorator from '@enact/agate/ThemeDecorator';
+import ThemeDecorator from '../ThemeDecorator';
 
 const AgateDecorator = deprecate(ThemeDecorator, {
 	name: 'agate/AgateDecorator',

--- a/package.json
+++ b/package.json
@@ -55,8 +55,7 @@
     "ilib": "^14.4.0 || ^14.4.0-webostv1"
   },
   "devDependencies": {
-    "@babel/preset-env": "^7.4.3",
-    "@enact/ui-test-utils": "^0.3.0",
+    "@enact/ui-test-utils": "^0.5.0",
     "eslint-config-enact-proxy": "^1.0.0",
     "ilib": "^14.4.0"
   }


### PR DESCRIPTION
* Updates `@enact/ui-test-utils` dependency to `0.5.0`
* Fixes `AgateDecorator`'s import of `ThemeDecorator` to be relative rather than absolute.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>