### PR TITLE
PLAT-115835: In-editor linting cleanup

### DIFF
--- a/samples/sampler/package.json
+++ b/samples/sampler/package.json
@@ -18,10 +18,6 @@
   "enact": {
     "theme": "agate"
   },
-  "eslintConfig": {
-    "extends": "enact/strict",
-    "root": true
-  },
   "dependencies": {
     "@enact/agate": "../../",
     "@enact/core": "^3.4.0",


### PR DESCRIPTION
* Fixes in-editor linting of sampler by removing localized eslintConfig overrides.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>