### PR TITLE
PLAT-104513: Remove render prop from ScrollbarButtons

### DIFF
--- a/VirtualList/tests/VirtualList-specs.js
+++ b/VirtualList/tests/VirtualList-specs.js
@@ -122,7 +122,7 @@ describe('VirtualList', () => {
 		);
 
 		const expected = 1;
-		const actual = subject.find('ScrollButtons').length;
+		const actual = subject.find('Scrollbar').length;
 
 		expect(actual).toBe(expected);
 	});

--- a/useScroll/ScrollButtons.js
+++ b/useScroll/ScrollButtons.js
@@ -3,11 +3,9 @@ import {getTargetByDirectionFromElement} from '@enact/spotlight/src/target';
 import {is} from '@enact/core/keymap';
 import Spotlight, {getDirection} from '@enact/spotlight';
 import utilEvent from '@enact/ui/useScroll/utilEvent';
-import PropTypes from 'prop-types';
-import React, {Component} from 'react';
+import React, {useState, useEffect} from 'react';
 import ReactDOM from 'react-dom';
 
-import ScrollButton from './ScrollButton';
 
 const
 	nop = () => {},
@@ -34,212 +32,81 @@ const
 /**
  * An Agate-styled scroll buttons. It is used in [Scrollbar]{@link agate/useScroll.Scrollbar}.
  *
- * @class ScrollButtons
+ * @function useScrollButtons
  * @memberof agate/useScroll
  * @ui
  * @private
  */
-class ScrollButtons extends Component {
-	static displayName = 'ScrollButtons';
+const useScrollButtons = (props) => {
+	const [prevButtonDisabled, setPrevButtonDisabled] = useState(true);
+	const [nextButtonDisabled, setNextButtonDisabled] = useState(true);
 
-	static propTypes = /** @lends agate/useScroll.ScrollButtons.prototype */ {
-		/**
-		 * The render function for scrollbar track.
-		 *
-		 * @type {Function}
-		 * @required
-		 * @private
-		 */
-		scrollbarTrackRenderer: PropTypes.func.isRequired,
+	const nextButtonRef = React.createRef();
+	const prevButtonRef = React.createRef();
 
-		/**
-		 * Specifies to reflect scrollbar's disabled property to the paging controls.
-		 * When it is `true`, both prev/next buttons are going to be disabled.
-		 *
-		 * @type {Boolean}
-		 * @public
-		 */
-		disabled: PropTypes.bool,
-
-		/**
-		 * When it is `true`, it allows 5 way navigation to the ScrollButtons.
-		 *
-		 * @type {Boolean}
-		 * @default false
-		 * @private
-		 */
-		focusableScrollButtons: PropTypes.bool,
-
-		/**
-		 * Sets the hint string read when focusing the next button in the scroll bar.
-		 *
-		 * @type {String}
-		 * @public
-		 */
-		nextButtonAriaLabel: PropTypes.string,
-
-		/**
-		 * Called when the scrollbar's button is pressed and needs to be bubbled.
-		 *
-		 * @type {Function}
-		 * @private
-		 */
-		onKeyDownButton: PropTypes.func,
-
-		/**
-		 * Called when the scrollbar's down/right button is pressed.
-		 *
-		 * @type {Function}
-		 * @public
-		 */
-		onNextScroll: PropTypes.func,
-
-		/**
-		 * Called when the scrollbar's up/left button is pressed.
-		 *
-		 * @type {Function}
-		 * @public
-		 */
-		onPrevScroll: PropTypes.func,
-
-		/**
-		 * Specifies preventing keydown events from bubbling up to applications.
-		 * Valid values are `'none'`, and `'programmatic'`.
-		 *
-		 * When it is `'none'`, every keydown event is bubbled.
-		 * When it is `'programmatic'`, an event bubbling is not allowed for a keydown input
-		 * which invokes programmatic spotlight moving.
-		 *
-		 * @type {String}
-		 * @private
-		 */
-		preventBubblingOnKeyDown: PropTypes.oneOf(['none', 'programmatic']),
-
-		/**
-		 * Sets the hint string read when focusing the previous button in the scroll bar.
-		 *
-		 * @type {String}
-		 * @public
-		 */
-		previousButtonAriaLabel: PropTypes.string,
-
-		/**
-		 * `true` if rtl, `false` if ltr.
-		 *
-		 * @type {Boolean}
-		 * @private
-		 */
-		rtl: PropTypes.bool,
-
-		/**
-		 * The scrollbar will be oriented vertically.
-		 *
-		 * @type {Boolean}
-		 * @default true
-		 * @public
-		 */
-		vertical: PropTypes.bool
-	};
-
-	static defaultProps = {
-		focusableScrollButtons: false,
-		onKeyDownButton: nop,
-		onNextScroll: nop,
-		onPrevScroll: nop
-	};
-
-	constructor (props) {
-		super(props);
-
-		this.state = {
-			prevButtonDisabled: true,
-			nextButtonDisabled: true
-		};
-
-		this.nextButtonRef = React.createRef();
-		this.prevButtonRef = React.createRef();
-	}
-
-	componentDidMount () {
-		utilEvent('keydown').addEventListener(this.nextButtonRef, this.onKeyDownNext);
-		utilEvent('keydown').addEventListener(this.prevButtonRef, this.onKeyDownPrev);
-	}
-
-	componentWillUnmount () {
-		utilEvent('keydown').removeEventListener(this.nextButtonRef, this.onKeyDownNext);
-		utilEvent('keydown').removeEventListener(this.prevButtonRef, this.onKeyDownPrev);
-	}
-
-	updateButtons = (bounds) => {
+	const updateButtons = (bounds) => {
 		const
-			{vertical} = this.props,
+			{vertical} = props,
 			currentPos = vertical ? bounds.scrollTop : bounds.scrollLeft,
 			maxPos = vertical ? bounds.maxTop : bounds.maxLeft,
 			shouldDisablePrevButton = currentPos <= 0,
 			/* If a scroll size or a client size is not integer,
 			   browser's max scroll position could be smaller than maxPos by 1 pixel.*/
 			shouldDisableNextButton = maxPos - currentPos <= 1,
-			updatePrevButton = (this.state.prevButtonDisabled !== shouldDisablePrevButton),
-			updateNextButton = (this.state.nextButtonDisabled !== shouldDisableNextButton);
+			updatePrevButton = (prevButtonDisabled !== shouldDisablePrevButton),
+			updateNextButton = (nextButtonDisabled !== shouldDisableNextButton);
 
-		if (updatePrevButton || updateNextButton) {
-			this.setState(() => {
-				if (updatePrevButton && updateNextButton) {
-					return {prevButtonDisabled: shouldDisablePrevButton, nextButtonDisabled: shouldDisableNextButton};
-				} else if (updatePrevButton) {
-					return {prevButtonDisabled: shouldDisablePrevButton};
-				} else if (updateNextButton) {
-					return {nextButtonDisabled: shouldDisableNextButton};
-				}
-			});
+		if (updatePrevButton) {
+			setPrevButtonDisabled(shouldDisablePrevButton);
+		} else if (updateNextButton) {
+			setNextButtonDisabled(shouldDisableNextButton);
 		}
-
 	};
 
-	isOneOfScrollButtonsFocused = () => {
+	const isOneOfScrollButtonsFocused = () => {
 		const current = Spotlight.getCurrent();
-		return current === this.prevButtonRef.current || current === this.nextButtonRef.current;
+		return current === prevButtonRef.current || current === nextButtonRef.current;
 	};
 
-	onClickPrev = (ev) => {
-		const {onPrevScroll, vertical} = this.props;
+	const onClickPrev = (ev) => {
+		const {onPrevScroll = nop, vertical} = props;
 		onPrevScroll({...ev, isPreviousScrollButton: true, isVerticalScrollBar: vertical});
 	};
 
-	onClickNext = (ev) => {
-		const {onNextScroll, vertical} = this.props;
+	const onClickNext = (ev) => {
+		const {onNextScroll = nop, vertical} = props;
 		onNextScroll({...ev, isPreviousScrollButton: false, isVerticalScrollBar: vertical});
 	};
 
-	focusOnButton = (isPrev) => {
-		Spotlight.focus(isPrev ? this.prevButtonRef.current : this.nextButtonRef.current);
+	const focusOnButton = (isPrev) => {
+		Spotlight.focus(isPrev ? prevButtonRef.current : nextButtonRef.current);
 	};
 
-	focusOnOppositeScrollButton = (ev, direction) => {
-		const buttonNode = (ev.target === this.nextButtonRef.current) ? this.prevButtonRef.current : this.nextButtonRef.current;
+	const focusOnOppositeScrollButton = (ev, direction) => {
+		const buttonNode = (ev.target === nextButtonRef.current) ? prevButtonRef.current : nextButtonRef.current;
 
 		if (!Spotlight.focus(buttonNode)) {
 			Spotlight.move(direction);
 		}
 	};
 
-	onKeyDownButton = (ev, position) => {
+	const onKeyDownButton = (ev, position) => {
 		const
-			{focusableScrollButtons, vertical, preventBubblingOnKeyDown} = this.props,
+			{focusableScrollButtons, vertical, preventBubblingOnKeyDown} = props,
 			{keyCode} = ev,
 			direction = getDirection(ev.keyCode),
 			preventBubbling = preventBubblingOnKeyDown === 'programmatic',
 			isNextButton = position === 'next',
 			isPrevButton = position === 'prev',
 			nextButton = {
-				disabled: this.state.nextButtonDisabled,
-				ref: this.nextButtonRef.current,
-				click: this.onClickNext
+				disabled: nextButtonDisabled,
+				ref: nextButtonRef.current,
+				click: onClickNext
 			},
 			prevButton = {
-				disabled: this.state.prevButtonDisabled,
-				ref: this.prevButtonRef.current,
-				click: this.onClickPrev
+				disabled: prevButtonDisabled,
+				ref: prevButtonRef.current,
+				click: onClickPrev
 			},
 			currentButton = isPrevButton ? prevButton : nextButton,
 			oppositeButton = isPrevButton ? nextButton : prevButton;
@@ -266,7 +133,7 @@ class ScrollButtons extends Component {
 			}
 		} else if (direction) {
 			const
-				{rtl} = this.props,
+				{rtl} = props,
 				isDown = direction === 'down',
 				isLeftMovement = direction === (rtl ? 'right' : 'left'),
 				isRightMovement = direction === (rtl ? 'left' : 'right'),
@@ -279,9 +146,9 @@ class ScrollButtons extends Component {
 			if (isNextButton && fromNextToPrev || isPrevButton && fromPrevToNext) {
 				if (focusableScrollButtons) {
 					consumeEvent(ev);
-					this.focusOnOppositeScrollButton(ev, direction);
+					focusOnOppositeScrollButton(ev, direction);
 					if (!preventBubbling) {
-						forward('onKeyDownButton', ev, this.props);
+						forward('onKeyDownButton', ev, props);
 					}
 				}
 			} else {
@@ -314,48 +181,41 @@ class ScrollButtons extends Component {
 		}
 	};
 
-	onKeyDownPrev = (ev) => {
-		this.onKeyDownButton(ev, 'prev');
+	const onKeyDownPrev = (ev) => {
+		onKeyDownButton(ev, 'prev');
 	};
 
-	onKeyDownNext = (ev) => {
-		this.onKeyDownButton(ev, 'next');
+	const onKeyDownNext = (ev) => {
+		onKeyDownButton(ev, 'next');
 	};
 
-	render () {
-		const
-			{disabled, nextButtonAriaLabel, previousButtonAriaLabel, rtl, scrollbarTrackRenderer, vertical} = this.props,
-			{prevButtonDisabled, nextButtonDisabled} = this.state,
-			prevIcon = preparePrevButton(vertical),
-			nextIcon = prepareNextButton(vertical);
+	useEffect(() => {
+		utilEvent('keydown').addEventListener(nextButtonRef, onKeyDownNext);
+		utilEvent('keydown').addEventListener(prevButtonRef, onKeyDownPrev);
 
-		return [
-			<ScrollButton
-				aria-label={rtl && !vertical ? nextButtonAriaLabel : previousButtonAriaLabel}
-				data-spotlight-overflow="ignore"
-				disabled={disabled || prevButtonDisabled}
-				key="prevButton"
-				onClick={this.onClickPrev}
-				onHoldPulse={this.onClickPrev}
-				ref={this.prevButtonRef}
-				icon={prevIcon}
-			/>,
-			scrollbarTrackRenderer(),
-			<ScrollButton
-				aria-label={rtl && !vertical ? previousButtonAriaLabel : nextButtonAriaLabel}
-				data-spotlight-overflow="ignore"
-				disabled={disabled || nextButtonDisabled}
-				key="nextButton"
-				onClick={this.onClickNext}
-				onHoldPulse={this.onClickNext}
-				ref={this.nextButtonRef}
-				icon={nextIcon}
-			/>
-		];
-	}
-}
+		return () => {
+			utilEvent('keydown').removeEventListener(nextButtonRef, onKeyDownNext);
+			utilEvent('keydown').removeEventListener(prevButtonRef, onKeyDownPrev);
+		};
+	}, []);	// eslint-disable-line react-hooks/exhaustive-deps
 
-export default ScrollButtons;
+	return {
+		prevButtonDisabled,
+		nextButtonDisabled,
+		prevIcon: preparePrevButton(props.vertical),
+		nextIcon: prepareNextButton(props.vertical),
+		onClickPrev,
+		onClickNext,
+		prevButtonRef,
+		nextButtonRef,
+
+		focusOnButton,
+		isOneOfScrollButtonsFocused,
+		updateButtons
+	};
+};
+
+export default useScrollButtons;
 export {
-	ScrollButtons
+	useScrollButtons
 };

--- a/useScroll/ScrollButtons.js
+++ b/useScroll/ScrollButtons.js
@@ -6,7 +6,6 @@ import utilEvent from '@enact/ui/useScroll/utilEvent';
 import React, {useState, useEffect} from 'react';
 import ReactDOM from 'react-dom';
 
-
 const
 	nop = () => {},
 	prepareButton = (isPrev) => (isVertical) => {
@@ -30,7 +29,7 @@ const
 	};
 
 /**
- * An Agate-styled scroll buttons. It is used in [Scrollbar]{@link agate/useScroll.Scrollbar}.
+ * A custom hook that returns Agate-themed scroll buttons behavior. It is used in [Scrollbar]{@link agate/useScroll.Scrollbar}.
  *
  * @function useScrollButtons
  * @memberof agate/useScroll
@@ -43,6 +42,16 @@ const useScrollButtons = (props) => {
 
 	const nextButtonRef = React.createRef();
 	const prevButtonRef = React.createRef();
+
+	useEffect(() => {
+		utilEvent('keydown').addEventListener(nextButtonRef, onKeyDownNext);
+		utilEvent('keydown').addEventListener(prevButtonRef, onKeyDownPrev);
+
+		return () => {
+			utilEvent('keydown').removeEventListener(nextButtonRef, onKeyDownNext);
+			utilEvent('keydown').removeEventListener(prevButtonRef, onKeyDownPrev);
+		};
+	}, []);	// eslint-disable-line react-hooks/exhaustive-deps
 
 	const updateButtons = (bounds) => {
 		const
@@ -58,39 +67,40 @@ const useScrollButtons = (props) => {
 
 		if (updatePrevButton) {
 			setPrevButtonDisabled(shouldDisablePrevButton);
-		} else if (updateNextButton) {
+		}
+		if (updateNextButton) {
 			setNextButtonDisabled(shouldDisableNextButton);
 		}
 	};
 
-	const isOneOfScrollButtonsFocused = () => {
+	function isOneOfScrollButtonsFocused () {
 		const current = Spotlight.getCurrent();
 		return current === prevButtonRef.current || current === nextButtonRef.current;
-	};
+	}
 
-	const onClickPrev = (ev) => {
+	function onClickPrev (ev) {
 		const {onPrevScroll = nop, vertical} = props;
 		onPrevScroll({...ev, isPreviousScrollButton: true, isVerticalScrollBar: vertical});
-	};
+	}
 
-	const onClickNext = (ev) => {
+	function onClickNext (ev) {
 		const {onNextScroll = nop, vertical} = props;
 		onNextScroll({...ev, isPreviousScrollButton: false, isVerticalScrollBar: vertical});
-	};
+	}
 
-	const focusOnButton = (isPrev) => {
+	function focusOnButton (isPrev) {
 		Spotlight.focus(isPrev ? prevButtonRef.current : nextButtonRef.current);
-	};
+	}
 
-	const focusOnOppositeScrollButton = (ev, direction) => {
+	function focusOnOppositeScrollButton (ev, direction) {
 		const buttonNode = (ev.target === nextButtonRef.current) ? prevButtonRef.current : nextButtonRef.current;
 
 		if (!Spotlight.focus(buttonNode)) {
 			Spotlight.move(direction);
 		}
-	};
+	}
 
-	const onKeyDownButton = (ev, position) => {
+	function onKeyDownButton (ev, position) {
 		const
 			{focusableScrollButtons, vertical, preventBubblingOnKeyDown} = props,
 			{keyCode} = ev,
@@ -179,38 +189,27 @@ const useScrollButtons = (props) => {
 				}
 			}
 		}
-	};
+	}
 
-	const onKeyDownPrev = (ev) => {
+	function onKeyDownPrev (ev) {
 		onKeyDownButton(ev, 'prev');
-	};
+	}
 
-	const onKeyDownNext = (ev) => {
+	function onKeyDownNext (ev) {
 		onKeyDownButton(ev, 'next');
-	};
-
-	useEffect(() => {
-		utilEvent('keydown').addEventListener(nextButtonRef, onKeyDownNext);
-		utilEvent('keydown').addEventListener(prevButtonRef, onKeyDownPrev);
-
-		return () => {
-			utilEvent('keydown').removeEventListener(nextButtonRef, onKeyDownNext);
-			utilEvent('keydown').removeEventListener(prevButtonRef, onKeyDownPrev);
-		};
-	}, []);	// eslint-disable-line react-hooks/exhaustive-deps
+	}
 
 	return {
-		prevButtonDisabled,
-		nextButtonDisabled,
-		prevIcon: preparePrevButton(props.vertical),
-		nextIcon: prepareNextButton(props.vertical),
-		onClickPrev,
-		onClickNext,
-		prevButtonRef,
-		nextButtonRef,
-
 		focusOnButton,
 		isOneOfScrollButtonsFocused,
+		nextButtonDisabled,
+		nextButtonRef,
+		nextIcon: prepareNextButton(props.vertical),
+		onClickNext,
+		onClickPrev,
+		prevButtonDisabled,
+		prevButtonRef,
+		prevIcon: preparePrevButton(props.vertical),
 		updateButtons
 	};
 };

--- a/useScroll/Scrollbar.js
+++ b/useScroll/Scrollbar.js
@@ -18,6 +18,7 @@ const useThemeScrollbar = (props) => {
 
 	const {
 		cbAlertScrollbarTrack,
+		disabled,
 		focusableScrollButtons,
 		nextButtonAriaLabel,
 		onKeyDownButton,
@@ -35,6 +36,7 @@ const useThemeScrollbar = (props) => {
 		restProps: rest,
 		scrollbarProps,
 		scrollbarButtonsProps: {
+			disabled,
 			focusableScrollButtons,
 			nextButtonAriaLabel,
 			onKeyDownButton,
@@ -253,6 +255,7 @@ ScrollbarBase.propTypes = /** @lends agate/useScroll.Scrollbar.prototype */ {
 ScrollbarBase.defaultProps = {
 	corner: false,
 	css: componentCss,
+	disabled: false,
 	minThumbSize: 18,
 	vertical: true
 };

--- a/useScroll/Scrollbar.js
+++ b/useScroll/Scrollbar.js
@@ -1,8 +1,9 @@
 import {useScrollbar as useScrollbarBase} from '@enact/ui/useScroll/Scrollbar';
 import PropTypes from 'prop-types';
-import React, {memo, useEffect, useRef} from 'react';
+import React, {memo, useEffect} from 'react';
 
-import ScrollButtons from './ScrollButtons';
+import ScrollButton from './ScrollButton';
+import useScrollButtons from './ScrollButtons';
 import ScrollbarTrack from './ScrollbarTrack';
 import Skinnable from '../Skinnable';
 
@@ -60,8 +61,6 @@ const useThemeScrollbar = (props) => {
  * @private
  */
 const ScrollbarBase = memo((props) => {
-	const scrollButtonsRef = useRef();
-
 	const {
 		restProps,
 		scrollbarProps,
@@ -69,10 +68,25 @@ const ScrollbarBase = memo((props) => {
 		scrollbarTrackProps
 	} = useThemeScrollbar(props);
 
+	const {
+		prevButtonDisabled,
+		nextButtonDisabled,
+		prevIcon,
+		nextIcon,
+		onClickPrev,
+		onClickNext,
+		prevButtonRef,
+		nextButtonRef,
+		focusOnButton,
+		isOneOfScrollButtonsFocused,
+		updateButtons
+	} = useScrollButtons(scrollbarButtonsProps);
+
+	const {disabled, nextButtonAriaLabel, previousButtonAriaLabel, rtl, vertical} = scrollbarButtonsProps;
+
 	useEffect(() => {
 		const {scrollbarHandle} = props;
 		const {update: uiUpdate} = scrollbarHandle.current;
-		const {focusOnButton, isOneOfScrollButtonsFocused, updateButtons} = scrollButtonsRef.current;
 
 		scrollbarHandle.current.update = (bounds) => {
 			updateButtons(bounds);
@@ -85,17 +99,29 @@ const ScrollbarBase = memo((props) => {
 
 	return (
 		<div {...restProps} {...scrollbarProps}>
-			<ScrollButtons
-				{...scrollbarButtonsProps}
-				ref={scrollButtonsRef}
-				scrollbarTrackRenderer={() => { // eslint-disable-line react/jsx-no-bind
-					return (
-						<ScrollbarTrack
-							{...scrollbarTrackProps}
-							key="scrollbarTrack"
-						/>
-					);
-				}}
+			<ScrollButton
+				aria-label={rtl && !vertical ? nextButtonAriaLabel : previousButtonAriaLabel}
+				data-spotlight-overflow="ignore"
+				disabled={disabled || prevButtonDisabled}
+				key="prevButton"
+				onClick={onClickPrev}
+				onHoldPulse={onClickPrev}
+				ref={prevButtonRef}
+				icon={prevIcon}
+			/>
+			<ScrollbarTrack
+				{...scrollbarTrackProps}
+				key="scrollbarTrack"
+			/>
+			<ScrollButton
+				aria-label={rtl && !vertical ? previousButtonAriaLabel : nextButtonAriaLabel}
+				data-spotlight-overflow="ignore"
+				disabled={disabled || nextButtonDisabled}
+				key="nextButton"
+				onClick={onClickNext}
+				onHoldPulse={onClickNext}
+				ref={nextButtonRef}
+				icon={nextIcon}
 			/>
 		</div>
 	);
@@ -127,6 +153,24 @@ ScrollbarBase.propTypes = /** @lends agate/useScroll.Scrollbar.prototype */ {
 	css: PropTypes.object,
 
 	/**
+	 * Specifies to reflect scrollbar's disabled property to the paging controls.
+	 * When it is `true`, both prev/next buttons are going to be disabled.
+	 *
+	 * @type {Boolean}
+	 * @public
+	 */
+	disabled: PropTypes.bool,
+
+	/**
+	 * When it is `true`, it allows 5 way navigation to the ScrollButtons.
+	 *
+	 * @type {Boolean}
+	 * @default false
+	 * @private
+	 */
+	focusableScrollButtons: PropTypes.bool,
+
+	/**
 	 * The minimum size of the thumb.
 	 * This value will be applied ri.scale.
 	 *
@@ -134,6 +178,59 @@ ScrollbarBase.propTypes = /** @lends agate/useScroll.Scrollbar.prototype */ {
 	 * @public
 	 */
 	minThumbSize: PropTypes.number,
+
+	/**
+	 * Sets the hint string read when focusing the next button in the scroll bar.
+	 *
+	 * @type {String}
+	 * @public
+	 */
+	nextButtonAriaLabel: PropTypes.string,
+
+	/**
+	 * Called when the scrollbar's button is pressed and needs to be bubbled.
+	 *
+	 * @type {Function}
+	 * @private
+	 */
+	onKeyDownButton: PropTypes.func,
+
+	/**
+	 * Called when the scrollbar's down/right button is pressed.
+	 *
+	 * @type {Function}
+	 * @public
+	 */
+	onNextScroll: PropTypes.func,
+
+	/**
+	 * Called when the scrollbar's up/left button is pressed.
+	 *
+	 * @type {Function}
+	 * @public
+	 */
+	onPrevScroll: PropTypes.func,
+
+	/**
+	 * Specifies preventing keydown events from bubbling up to applications.
+	 * Valid values are `'none'`, and `'programmatic'`.
+	 *
+	 * When it is `'none'`, every keydown event is bubbled.
+	 * When it is `'programmatic'`, an event bubbling is not allowed for a keydown input
+	 * which invokes programmatic spotlight moving.
+	 *
+	 * @type {String}
+	 * @private
+	 */
+	preventBubblingOnKeyDown: PropTypes.oneOf(['none', 'programmatic']),
+
+	/**
+	 * Sets the hint string read when focusing the previous button in the scroll bar.
+	 *
+	 * @type {String}
+	 * @public
+	 */
+	previousButtonAriaLabel: PropTypes.string,
 
 	/**
 	 * `true` if rtl, `false` if ltr.

--- a/useScroll/Scrollbar.js
+++ b/useScroll/Scrollbar.js
@@ -105,7 +105,6 @@ const ScrollbarBase = memo((props) => {
 				aria-label={rtl && !vertical ? nextButtonAriaLabel : previousButtonAriaLabel}
 				data-spotlight-overflow="ignore"
 				disabled={disabled || prevButtonDisabled}
-				key="prevButton"
 				onClick={onClickPrev}
 				onHoldPulse={onClickPrev}
 				ref={prevButtonRef}
@@ -119,7 +118,6 @@ const ScrollbarBase = memo((props) => {
 				aria-label={rtl && !vertical ? previousButtonAriaLabel : nextButtonAriaLabel}
 				data-spotlight-overflow="ignore"
 				disabled={disabled || nextButtonDisabled}
-				key="nextButton"
 				onClick={onClickNext}
 				onHoldPulse={onClickNext}
 				ref={nextButtonRef}

--- a/useScroll/Scrollbar.js
+++ b/useScroll/Scrollbar.js
@@ -156,6 +156,7 @@ ScrollbarBase.propTypes = /** @lends agate/useScroll.Scrollbar.prototype */ {
 	 * When it is `true`, both prev/next buttons are going to be disabled.
 	 *
 	 * @type {Boolean}
+	 * @default false
 	 * @public
 	 */
 	disabled: PropTypes.bool,
@@ -250,9 +251,7 @@ ScrollbarBase.propTypes = /** @lends agate/useScroll.Scrollbar.prototype */ {
 };
 
 ScrollbarBase.defaultProps = {
-	corner: false,
 	css: componentCss,
-	disabled: false,
 	minThumbSize: 18,
 	vertical: true
 };

--- a/useScroll/Scrollbar.js
+++ b/useScroll/Scrollbar.js
@@ -71,16 +71,16 @@ const ScrollbarBase = memo((props) => {
 	} = useThemeScrollbar(props);
 
 	const {
-		prevButtonDisabled,
-		nextButtonDisabled,
-		prevIcon,
-		nextIcon,
-		onClickPrev,
-		onClickNext,
-		prevButtonRef,
-		nextButtonRef,
 		focusOnButton,
 		isOneOfScrollButtonsFocused,
+		nextButtonDisabled,
+		nextButtonRef,
+		nextIcon,
+		onClickNext,
+		onClickPrev,
+		prevButtonDisabled,
+		prevButtonRef,
+		prevIcon,
 		updateButtons
 	} = useScrollButtons(scrollbarButtonsProps);
 
@@ -112,7 +112,6 @@ const ScrollbarBase = memo((props) => {
 			/>
 			<ScrollbarTrack
 				{...scrollbarTrackProps}
-				key="scrollbarTrack"
 			/>
 			<ScrollButton
 				aria-label={rtl && !vertical ? previousButtonAriaLabel : nextButtonAriaLabel}

--- a/useScroll/Scrollbar.module.less
+++ b/useScroll/Scrollbar.module.less
@@ -74,7 +74,7 @@
 				width: @agate-scroller-scrollbar-thumb-width;
 			}
 		}
-		&:not(.vertical) {
+		&.horizontal {
 			::before {
 				height: @agate-scroller-scrollbar-thumb-width;
 			}

--- a/useScroll/Scrollbar.module.less
+++ b/useScroll/Scrollbar.module.less
@@ -65,10 +65,18 @@
 
 .applySkins({
 	.scrollbar {
-		.scrollbarTrackShown {
-			&::before {
-				background-color: @agate-scroller-scrollbar-thumb-bg-color;
+		::before {
+			background-color: @agate-scroller-scrollbar-thumb-bg-color;
+		}
+
+		&.vertical {
+			::before {
 				width: @agate-scroller-scrollbar-thumb-width;
+			}
+		}
+		&:not(.vertical) {
+			::before {
+				height: @agate-scroller-scrollbar-thumb-width;
 			}
 		}
 

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -267,7 +267,6 @@ const useScroll = (props) => {
 			'data-spotlight-container': spotlightContainer,
 			'data-spotlight-container-disabled': spotlightContainerDisabled,
 			'data-spotlight-id': spotlightId,
-			disabled,
 			focusableScrollbar,
 			preventBubblingOnKeyDown,
 			scrollDownAriaLabel,
@@ -388,7 +387,6 @@ const useScroll = (props) => {
 		assignProperties,
 		noScrollByDrag: !platform.touchscreen,
 		addEventListeners,
-		disabled,
 		handleResizeWindow,
 		horizontalScrollbarHandle,
 		onDragEnd: handleDragEnd,
@@ -431,7 +429,6 @@ const useScroll = (props) => {
 
 	assignProperties('verticalScrollbarProps', {
 		...scrollbarProps,
-		disabled,
 		focusableScrollButtons: focusableScrollbar,
 		nextButtonAriaLabel: downButtonAriaLabel,
 		onKeyDownButton: handleKeyDown,
@@ -442,7 +439,6 @@ const useScroll = (props) => {
 
 	assignProperties('horizontalScrollbarProps', {
 		...scrollbarProps,
-		disabled,
 		focusableScrollButtons: focusableScrollbar,
 		nextButtonAriaLabel: rightButtonAriaLabel,
 		onKeyDownButton: handleKeyDown,

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -267,6 +267,7 @@ const useScroll = (props) => {
 			'data-spotlight-container': spotlightContainer,
 			'data-spotlight-container-disabled': spotlightContainerDisabled,
 			'data-spotlight-id': spotlightId,
+			disabled,
 			focusableScrollbar,
 			preventBubblingOnKeyDown,
 			scrollDownAriaLabel,
@@ -387,6 +388,7 @@ const useScroll = (props) => {
 		assignProperties,
 		noScrollByDrag: !platform.touchscreen,
 		addEventListeners,
+		disabled,
 		handleResizeWindow,
 		horizontalScrollbarHandle,
 		onDragEnd: handleDragEnd,
@@ -429,6 +431,7 @@ const useScroll = (props) => {
 
 	assignProperties('verticalScrollbarProps', {
 		...scrollbarProps,
+		disabled,
 		focusableScrollButtons: focusableScrollbar,
 		nextButtonAriaLabel: downButtonAriaLabel,
 		onKeyDownButton: handleKeyDown,
@@ -439,6 +442,7 @@ const useScroll = (props) => {
 
 	assignProperties('horizontalScrollbarProps', {
 		...scrollbarProps,
+		disabled,
 		focusableScrollButtons: focusableScrollbar,
 		nextButtonAriaLabel: rightButtonAriaLabel,
 		onKeyDownButton: handleKeyDown,


### PR DESCRIPTION

Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn <jeonghee27.ahn@lge.com>

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There is render prop pattern left in agate/useScroll/ScrollbarButtons.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove render prop pattern in agate/ScrollbarButtons
 - Convert ScrollButtons React Component to useScroll hook function.
 - Fix minor bug about horizontal scroller width. ( horizontal thumb was rendered to very small width.)

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
PLAT-104513

### Comments
