### PR TITLE
PLAT-116224: Fix TabbedPanels Sampler to work

### DIFF
--- a/Panels/TabbedPanels.js
+++ b/Panels/TabbedPanels.js
@@ -40,6 +40,11 @@ const TabbedPanelsBase = kind({
 		tabPosition: PropTypes.string,
 		tabs: PropTypes.array
 	},
+	defaultProps: {
+		index: 0,
+		noCloseButton: false,
+		tabPosition: 'before'
+	},
 	styles: {
 		css: componentCss,
 		className: 'tabbedPanels enact-fit'
@@ -127,12 +132,6 @@ const TabbedPanels = Slottable(
 		Skinnable(TabbedPanelsBase)
 	)
 );
-
-TabbedPanels.defaultProps = {
-	index: 0,
-	noCloseButton: false,
-	tabPosition: 'before'
-};
 
 export default TabbedPanels;
 export {

--- a/Panels/TabbedPanels.js
+++ b/Panels/TabbedPanels.js
@@ -7,6 +7,7 @@ import {shape} from '@enact/ui/ViewManager';
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import Skinnable from '../Skinnable';
 import TabGroup from '../TabGroup';
 
 import Panels from './Panels';
@@ -38,11 +39,6 @@ const TabbedPanelsBase = kind({
 		orientation: PropTypes.oneOf(['horizontal', 'vertical']),
 		tabPosition: PropTypes.string,
 		tabs: PropTypes.array
-	},
-	defaultProps: {
-		index: 0,
-		noCloseButton: false,
-		tabPosition: 'before'
 	},
 	styles: {
 		css: componentCss,
@@ -128,9 +124,15 @@ const TabbedPanels = Slottable(
 	{slots: ['tabs', 'afterTabs', 'beforeTabs']},
 	Changeable(
 		{prop: 'index', change: 'onSelect'},
-		TabbedPanelsBase
+		Skinnable(TabbedPanelsBase)
 	)
 );
+
+TabbedPanels.defaultProps = {
+	index: 0,
+	noCloseButton: false,
+	tabPosition: 'before'
+};
 
 export default TabbedPanels;
 export {

--- a/TabGroup/TabGroup.js
+++ b/TabGroup/TabGroup.js
@@ -55,7 +55,6 @@ const TabBase = kind({
 					<div className={css.labeledIcon}>
 						<ToggleButton
 							icon={icon}
-							inline={inline}
 							selected={selected}
 						/>
 						{children}

--- a/samples/sampler/stories/default/TabbedPanels.js
+++ b/samples/sampler/stories/default/TabbedPanels.js
@@ -23,6 +23,12 @@ storiesOf('Agate', module)
 				setIndex(e.index);
 				action('onSelect')(e);
 			};
+			const onBeforeTabs = () => {
+				setIndex(Math.max(panelIndex - 1, 0));
+			};
+			const onAfterTabs = () => {
+				setIndex(Math.min(panelIndex + 1, 2));
+			};
 			return (
 				<div style={{paddingBottom: '56.25%'}}>
 					<TabbedPanels
@@ -40,10 +46,20 @@ storiesOf('Agate', module)
 						]}
 					>
 						<beforeTabs>
-							<Button size="small" type="grid" icon="arrowlargeleft" />
+							<Button
+								size="small"
+								type="grid"
+								icon="arrowlargeleft"
+								onClick={onBeforeTabs} // eslint-disable-line react/jsx-no-bind
+							/>
 						</beforeTabs>
 						<afterTabs>
-							<Button size="small" type="grid" icon="arrowlargeright" />
+							<Button
+								size="small"
+								type="grid"
+								icon="arrowlargeright"
+								onClick={onAfterTabs} // eslint-disable-line react/jsx-no-bind
+							/>
 						</afterTabs>
 						<Panel>
 							<Button icon="netbook">Click me!</Button>

--- a/samples/sampler/stories/default/TabbedPanels.js
+++ b/samples/sampler/stories/default/TabbedPanels.js
@@ -47,18 +47,18 @@ storiesOf('Agate', module)
 					>
 						<beforeTabs>
 							<Button
-								size="small"
-								type="grid"
 								icon="arrowlargeleft"
 								onClick={onBeforeTabs} // eslint-disable-line react/jsx-no-bind
+								size="small"
+								type="grid"
 							/>
 						</beforeTabs>
 						<afterTabs>
 							<Button
-								size="small"
-								type="grid"
 								icon="arrowlargeright"
 								onClick={onAfterTabs} // eslint-disable-line react/jsx-no-bind
+								size="small"
+								type="grid"
 							/>
 						</afterTabs>
 						<Panel>

--- a/samples/sampler/stories/default/TabbedPanels.js
+++ b/samples/sampler/stories/default/TabbedPanels.js
@@ -8,8 +8,8 @@ import Button from '@enact/agate/Button';
 import Icon from '@enact/agate/Icon';
 import Item from '@enact/agate/Item';
 import LabeledIconButton from '@enact/agate/LabeledIconButton';
-import {Panel} from '@enact/agate/Panels';
-import {TabbedPanels, TabbedPanelsBase} from '@enact/agate/Panels/TabbedPanels';
+import {Panel, TabbedPanels} from '@enact/agate/Panels';
+import {TabbedPanelsBase} from '@enact/agate/Panels/TabbedPanels';
 
 const Config = mergeComponentMetadata('TabbedPanels', TabbedPanelsBase);
 // `paddingBottom: '56.25%'` is a trick to impose 16:9 aspect ratio on the component, since padding percentage is based on the width, not the height.

--- a/samples/sampler/stories/default/TabbedPanels.js
+++ b/samples/sampler/stories/default/TabbedPanels.js
@@ -1,4 +1,5 @@
 import {action} from '@enact/storybook-utils/addons/actions';
+import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {boolean, number, select} from '@enact/storybook-utils/addons/knobs';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
@@ -9,57 +10,64 @@ import Item from '@enact/agate/Item';
 import LabeledIconButton from '@enact/agate/LabeledIconButton';
 import {Panel, TabbedPanels} from '@enact/agate/Panels';
 
-TabbedPanels.displayName = 'TabbedPanels';
-
+const Config = mergeComponentMetadata('TabbedPanels', TabbedPanels);
 // `paddingBottom: '56.25%'` is a trick to impose 16:9 aspect ratio on the component, since padding percentage is based on the width, not the height.
 
 storiesOf('Agate', module)
 	.add(
 		'TabbedPanels',
-		() => (
-			<div style={{paddingBottom: '56.25%'}}>
-				<TabbedPanels
-					duration={number('duration', TabbedPanels)}
-					onClick={action('onClick')}
-					index={Number(select('index', ['0', '1', '2', '3'], TabbedPanels, '0'))}
-					noCloseButton={boolean('noCloseButton', TabbedPanels)}
-					onSelect={action('onSelect')}
-					orientation={select('orientation', ['vertical', 'horizontal'], TabbedPanels, 'vertical')}
-					tabPosition={select('tabPosition', ['before', 'after'], TabbedPanels, 'before')}
-					tabs={[
-						{title: 'Button', icon: 'netbook'},
-						{title: 'Item', icon: 'aircirculation'},
-						{title: 'LabeledIconButton', icon: 'temperature'}
-					]}
-				>
-					<beforeTabs>
-						<Button size="small" type="grid" icon="arrowlargeleft" />
-					</beforeTabs>
-					<afterTabs>
-						<Button size="small" type="grid" icon="arrowlargeright" />
-					</afterTabs>
-					<Panel>
-						<Button icon="netbook">Click me!</Button>
-					</Panel>
-					<Panel>
-						<Item label="label" labelPosition="before" slotBefore={<Icon>aircirculation</Icon>}>Hello Item</Item>
-					</Panel>
-					<Panel className="enact-fit">
-						<LabeledIconButton
-							labelPosition="after"
-							icon="temperature"
-						>
-							Hello LabeledIconButton
-						</LabeledIconButton>
-					</Panel>
-					<Panel>
-						<div>
-							A simple view with no associated tab
-						</div>
-					</Panel>
-				</TabbedPanels>
-			</div>
-		),
+		() => {
+			const initialState = Config.defaultProps.index || 0;
+			const [panelIndex, setIndex] = React.useState(initialState);
+			const onSelect = (e) => {
+				setIndex(e.index);
+				action('onSelect')(e);
+			};
+			return (
+				<div style={{paddingBottom: '56.25%'}}>
+					<TabbedPanels
+						duration={number('duration', Config, 500)}
+						onClick={action('onClick')}
+						index={panelIndex}
+						noCloseButton={boolean('noCloseButton', Config)}
+						onSelect={onSelect} // eslint-disable-line react/jsx-no-bind
+						orientation={select('orientation', ['vertical', 'horizontal'], Config, 'vertical')}
+						tabPosition={select('tabPosition', ['before', 'after'], Config, 'before')}
+						tabs={[
+							{title: 'Button', icon: 'netbook'},
+							{title: 'Item', icon: 'aircirculation'},
+							{title: 'LabeledIconButton', icon: 'temperature'}
+						]}
+					>
+						<beforeTabs>
+							<Button size="small" type="grid" icon="arrowlargeleft" />
+						</beforeTabs>
+						<afterTabs>
+							<Button size="small" type="grid" icon="arrowlargeright" />
+						</afterTabs>
+						<Panel>
+							<Button icon="netbook">Click me!</Button>
+						</Panel>
+						<Panel>
+							<Item label="label" labelPosition="before" slotBefore={<Icon>aircirculation</Icon>}>Hello Item</Item>
+						</Panel>
+						<Panel className="enact-fit">
+							<LabeledIconButton
+								labelPosition="after"
+								icon="temperature"
+							>
+								Hello LabeledIconButton
+							</LabeledIconButton>
+						</Panel>
+						<Panel>
+							<div>
+								A simple view with no associated tab
+							</div>
+						</Panel>
+					</TabbedPanels>
+				</div>
+			);
+		},
 		{
 			text: 'The basic TabbedPanels'
 		}

--- a/samples/sampler/stories/default/TabbedPanels.js
+++ b/samples/sampler/stories/default/TabbedPanels.js
@@ -8,17 +8,17 @@ import Button from '@enact/agate/Button';
 import Icon from '@enact/agate/Icon';
 import Item from '@enact/agate/Item';
 import LabeledIconButton from '@enact/agate/LabeledIconButton';
-import {Panel, TabbedPanels} from '@enact/agate/Panels';
+import {Panel} from '@enact/agate/Panels';
+import {TabbedPanels, TabbedPanelsBase} from '@enact/agate/Panels/TabbedPanels';
 
-const Config = mergeComponentMetadata('TabbedPanels', TabbedPanels);
+const Config = mergeComponentMetadata('TabbedPanels', TabbedPanelsBase);
 // `paddingBottom: '56.25%'` is a trick to impose 16:9 aspect ratio on the component, since padding percentage is based on the width, not the height.
 
 storiesOf('Agate', module)
 	.add(
 		'TabbedPanels',
 		() => {
-			const initialState = Config.defaultProps.index || 0;
-			const [panelIndex, setIndex] = React.useState(initialState);
+			const [panelIndex, setIndex] = React.useState(Config.defaultProps.index || 0);
 			const onSelect = (e) => {
 				setIndex(e.index);
 				action('onSelect')(e);


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn <jeonghee27.ahn@lge.com>

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Cannot change tab on Agate TabbedPanels sampler 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Fix `TabbedPannels` sampler to work.
- Move default props of `TabbedPanels` to be referenced when calling mergeComponentMetadata.
- Fix console error when change skin. Remove the wrong `inline` props to ToggleButton. 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
PLAT-116224

### Comments
