### PR TITLE
PLAT-115996: Support Audio Guidance in Drawer, Popup, PopupMenu

### DIFF
--- a/Drawer/Drawer.js
+++ b/Drawer/Drawer.js
@@ -47,15 +47,13 @@ const DrawerBase = kind({
 		// and the .closeButton CSS in the LESS file all relate to this functionality.
 		// onClose: PropTypes.func,
 		onHide: PropTypes.func,
-		open: PropTypes.bool,
-		role: PropTypes.string
+		open: PropTypes.bool
 	},
 
 	defaultProps: {
 		noAnimation: false,
 		open: false,
-		orientation: 'vertical',
-		role: 'alert'
+		orientation: 'vertical'
 	},
 
 	styles: {
@@ -76,6 +74,7 @@ const DrawerBase = kind({
 				css={css}
 			>
 				<Layout
+					role="alert"
 					{...rest}
 				>
 					{/* <Icon size="small" onClick={onClose} className={css.closeButton}>closex</Icon>*/}

--- a/Drawer/Drawer.js
+++ b/Drawer/Drawer.js
@@ -47,22 +47,20 @@ const DrawerBase = kind({
 		// and the .closeButton CSS in the LESS file all relate to this functionality.
 		// onClose: PropTypes.func,
 		onHide: PropTypes.func,
-		open: PropTypes.bool
+		open: PropTypes.bool,
+		role: PropTypes.string
 	},
 
 	defaultProps: {
 		noAnimation: false,
 		open: false,
-		orientation: 'vertical'
+		orientation: 'vertical',
+		role: 'alert'
 	},
 
 	styles: {
 		css: componentCss,
 		className: 'drawer'
-	},
-
-	computed: {
-		role: () => 'alert'
 	},
 
 	render: ({footer, children, css, noAnimation, onHide, open, header, ...rest}) => {

--- a/Drawer/Drawer.js
+++ b/Drawer/Drawer.js
@@ -61,6 +61,10 @@ const DrawerBase = kind({
 		className: 'drawer'
 	},
 
+	computed: {
+		role: () => 'alert'
+	},
+
 	render: ({footer, children, css, noAnimation, onHide, open, header, ...rest}) => {
 		return (
 			<Transition

--- a/Popup/Popup.js
+++ b/Popup/Popup.js
@@ -73,7 +73,6 @@ const PopupBase = kind({
 		 * @public
 		 */
 		position: PropTypes.oneOf(['center', 'top']),
-		role: PropTypes.string,
 		skin: PropTypes.string,
 		title: PropTypes.string
 	},
@@ -82,8 +81,7 @@ const PopupBase = kind({
 		closeButton: false,
 		noAnimation: false,
 		open: false,
-		position: 'center',
-		role: 'alert'
+		position: 'center'
 	},
 	styles: {
 		css: componentCss,
@@ -110,6 +108,7 @@ const PopupBase = kind({
 				css={css}
 			>
 				<div
+					role="alert"
 					{...rest}
 				>
 					{closeButton ? <Button

--- a/Popup/Popup.js
+++ b/Popup/Popup.js
@@ -73,6 +73,7 @@ const PopupBase = kind({
 		 * @public
 		 */
 		position: PropTypes.oneOf(['center', 'top']),
+
 		skin: PropTypes.string,
 		title: PropTypes.string
 	},

--- a/Popup/Popup.js
+++ b/Popup/Popup.js
@@ -73,7 +73,7 @@ const PopupBase = kind({
 		 * @public
 		 */
 		position: PropTypes.oneOf(['center', 'top']),
-
+		role: PropTypes.string,
 		skin: PropTypes.string,
 		title: PropTypes.string
 	},
@@ -82,7 +82,8 @@ const PopupBase = kind({
 		closeButton: false,
 		noAnimation: false,
 		open: false,
-		position: 'center'
+		position: 'center',
+		role: 'alert'
 	},
 	styles: {
 		css: componentCss,
@@ -91,8 +92,7 @@ const PopupBase = kind({
 	computed: {
 		className: ({centered, closeButton, position, styler, title}) => styler.append({top: position === 'top', withCloseButton: closeButton, withTitle: title, centered}),
 		transitionType : ({position}) => position === 'center' ? 'fade' : 'slide',
-		direction : ({position}) => position === 'center' ? 'down' : 'up',
-		role: () => 'alert'
+		direction : ({position}) => position === 'center' ? 'down' : 'up'
 	},
 	render: ({buttons, children, closeButton, css, direction, noAnimation, onClose, onHide, open, skin, title, transitionType, ...rest}) => {
 		const wideLayout = (skin === 'carbon');

--- a/Popup/Popup.js
+++ b/Popup/Popup.js
@@ -91,7 +91,8 @@ const PopupBase = kind({
 	computed: {
 		className: ({centered, closeButton, position, styler, title}) => styler.append({top: position === 'top', withCloseButton: closeButton, withTitle: title, centered}),
 		transitionType : ({position}) => position === 'center' ? 'fade' : 'slide',
-		direction : ({position}) => position === 'center' ? 'down' : 'up'
+		direction : ({position}) => position === 'center' ? 'down' : 'up',
+		role: () => 'alert'
 	},
 	render: ({buttons, children, closeButton, css, direction, noAnimation, onClose, onHide, open, skin, title, transitionType, ...rest}) => {
 		const wideLayout = (skin === 'carbon');

--- a/PopupMenu/PopupMenu.js
+++ b/PopupMenu/PopupMenu.js
@@ -47,6 +47,7 @@ const PopupMenuBase = kind({
 		onHide: PropTypes.func,
 		open: PropTypes.bool,
 		orientation: PropTypes.oneOf(['horizontal']),
+		role: PropTypes.string,
 		title: PropTypes.string
 	},
 
@@ -55,7 +56,8 @@ const PopupMenuBase = kind({
 		closeButtonLabel: $L('Cancel'),
 		noAnimation: false,
 		open: false,
-		orientation: 'horizontal'
+		orientation: 'horizontal',
+		role: 'alert'
 	},
 
 	styles: {
@@ -64,8 +66,7 @@ const PopupMenuBase = kind({
 	},
 
 	computed: {
-		className: ({orientation, styler}) => styler.append(orientation),
-		role: () => 'alert'
+		className: ({orientation, styler}) => styler.append(orientation)
 	},
 
 	render: ({children, closeButton, closeButtonLabel, css, noAnimation, onClose, onHide, open, orientation, title, ...rest}) => {

--- a/PopupMenu/PopupMenu.js
+++ b/PopupMenu/PopupMenu.js
@@ -47,7 +47,6 @@ const PopupMenuBase = kind({
 		onHide: PropTypes.func,
 		open: PropTypes.bool,
 		orientation: PropTypes.oneOf(['horizontal']),
-		role: PropTypes.string,
 		title: PropTypes.string
 	},
 
@@ -56,8 +55,7 @@ const PopupMenuBase = kind({
 		closeButtonLabel: $L('Cancel'),
 		noAnimation: false,
 		open: false,
-		orientation: 'horizontal',
-		role: 'alert'
+		orientation: 'horizontal'
 	},
 
 	styles: {
@@ -81,7 +79,7 @@ const PopupMenuBase = kind({
 				onHide={onHide}
 				css={css}
 			>
-				<Layout orientation="vertical" align="center center" {...rest}>
+				<Layout orientation="vertical" align="center center" role="alert" {...rest}>
 					<Cell className={css.title} shrink>
 						<Heading size="title">{title}</Heading>
 					</Cell>

--- a/PopupMenu/PopupMenu.js
+++ b/PopupMenu/PopupMenu.js
@@ -64,7 +64,8 @@ const PopupMenuBase = kind({
 	},
 
 	computed: {
-		className: ({orientation, styler}) => styler.append(orientation)
+		className: ({orientation, styler}) => styler.append(orientation),
+		role: () => 'alert'
 	},
 
 	render: ({children, closeButton, closeButtonLabel, css, noAnimation, onClose, onHide, open, orientation, title, ...rest}) => {

--- a/samples/sampler/stories/default/Drawer.js
+++ b/samples/sampler/stories/default/Drawer.js
@@ -7,12 +7,13 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 
 import Drawer, {DrawerBase} from '@enact/agate/Drawer';
-import Heading from '@enact/agate/Heading';
+import Heading, {HeadingBase} from '@enact/agate/Heading';
 
 import css from './Drawer.module.less';
 
 Drawer.displayName = 'Drawer';
 const Config = mergeComponentMetadata('Drawer', Drawer, DrawerBase);
+const HeadingConfig = mergeComponentMetadata('Heading', Heading, HeadingBase);
 
 const StoryOptions = {
 	groupId: 'Story Options'
@@ -68,10 +69,10 @@ storiesOf('Agate', module)
 					>
 						<header>
 							<Heading
-								color={select('Heading color', headingValues.colors, StoryOptions)}
-								showLine={boolean('Heading showLine', StoryOptions)}
-								size={select('Heading size', headingValues.sizes, StoryOptions)}
-								spacing={select('Heading spacing', headingValues.spacings, StoryOptions)}
+								color={select('Heading color', headingValues.colors, HeadingConfig, '')}
+								showLine={boolean('Heading showLine', HeadingConfig)}
+								size={select('Heading size', headingValues.sizes, HeadingConfig, '')}
+								spacing={select('Heading spacing', headingValues.spacings, HeadingConfig, '')}
 							>
 								{text('header', Config, '[insert witty header text]')}
 							</Heading>

--- a/samples/sampler/stories/default/Drawer.js
+++ b/samples/sampler/stories/default/Drawer.js
@@ -69,10 +69,10 @@ storiesOf('Agate', module)
 					>
 						<header>
 							<Heading
-								color={select('Heading color', headingValues.colors, HeadingConfig, '')}
-								showLine={boolean('Heading showLine', HeadingConfig)}
-								size={select('Heading size', headingValues.sizes, HeadingConfig, '')}
-								spacing={select('Heading spacing', headingValues.spacings, HeadingConfig, '')}
+								color={select('color', headingValues.colors, HeadingConfig, '')}
+								showLine={boolean('showLine', HeadingConfig)}
+								size={select('size', headingValues.sizes, HeadingConfig, '')}
+								spacing={select('spacing', headingValues.spacings, HeadingConfig, '')}
 							>
 								{text('header', Config, '[insert witty header text]')}
 							</Heading>


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn <jeonghee27.ahn@lge.com>

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
[Agate a11y] Support Audio Guidance in Drawer, Popup, PopupMenu

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
 - Add role:alert to `Drawer`, `Popup`, and `PopupMenu`
 - Fix prop error when select drawer open and `open cavas in new tab` button on `Drawer` sampler

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
PLAT-104513

### Comments
