### PR TITLE
FORTECH-102: Fixed focus on dropdown activator after selection

### DIFF
--- a/Dropdown/Dropdown.js
+++ b/Dropdown/Dropdown.js
@@ -18,6 +18,7 @@
 import {handle, forward, forProp} from '@enact/core/handle';
 import kind from '@enact/core/kind';
 import {extractAriaProps} from '@enact/core/util';
+import Spotlight from '@enact/spotlight';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import Changeable from '@enact/ui/Changeable';
 import Group from '@enact/ui/Group';
@@ -39,6 +40,14 @@ import componentCss from './Dropdown.module.less';
 
 const ContainerDiv = SpotlightContainerDecorator({enterTo: 'last-focused'}, 'div');
 const isSelectedValid = ({children, selected}) => Array.isArray(children) && children[selected] != null;
+
+const onTransitionHide = () => {
+	const current = Spotlight.getCurrent();
+
+	if (!Spotlight.isPaused() && current && document.querySelector(`.${componentCss.dropdownList}`).contains(current)) {
+		Spotlight.focus(`.${componentCss.dropdown}`);
+	}
+};
 
 /**
  * A stateless Dropdown component.
@@ -232,6 +241,7 @@ const DropdownBase = kind({
 						className={transitionContainerClassname}
 						visible={opened}
 						direction={transitionDirection}
+						onHide={onTransitionHide}
 					>
 						<ContainerDiv className={dropdownListClassname} spotlightDisabled={!open} spotlightRestrict="self-only">
 							<Scroller skinVariants={skinVariants} className={css.scroller}>

--- a/Dropdown/Dropdown.js
+++ b/Dropdown/Dropdown.js
@@ -41,11 +41,12 @@ import componentCss from './Dropdown.module.less';
 const ContainerDiv = SpotlightContainerDecorator({enterTo: 'last-focused'}, 'div');
 const isSelectedValid = ({children, selected}) => Array.isArray(children) && children[selected] != null;
 
-const onTransitionHide = () => {
+const handleTransitionHide = (containerId) => () => {
+	const containerSelector = `[data-spotlight-id='${containerId}']`;
 	const current = Spotlight.getCurrent();
 
-	if (!Spotlight.isPaused() && current && document.querySelector(`.${componentCss.dropdownList}`).contains(current)) {
-		Spotlight.focus(`.${componentCss.dropdown}`);
+	if (!Spotlight.isPaused() && current && document.querySelector(`${containerSelector} .${componentCss.dropdownList}`).contains(current)) {
+		Spotlight.focus(`${containerSelector} .${componentCss.dropdown}`);
 	}
 };
 
@@ -223,6 +224,7 @@ const DropdownBase = kind({
 			{},
 			{childComponent: Item, itemProps: {size: 'small'}}
 		];
+		const onTransitionHide = handleTransitionHide(rest['data-spotlight-id']);
 
 		return (
 			<div {...calcAriaProps} {...rest}>

--- a/Dropdown/Dropdown.js
+++ b/Dropdown/Dropdown.js
@@ -208,10 +208,8 @@ const DropdownBase = kind({
 		}
 	},
 
-	render: ({'aria-label': ariaLabel, ariaLabelledBy, buttonClassName, children, css, dropdownButtonClassname, dropdownListClassname, disabled, hasChildren, onClose, onOpen, onSelect, open, selected, skin, transitionContainerClassname, transitionDirection, title, ...rest}) => {
+	render: ({buttonClassName, children, css, dropdownButtonClassname, dropdownListClassname, disabled, hasChildren, onClose, onOpen, onSelect, open, selected, skin, transitionContainerClassname, transitionDirection, title, ...rest}) => {
 		const ariaProps = extractAriaProps(rest);
-		const calcAriaProps = ((ariaLabel != null) ? null : {role: 'region', 'aria-labelledby': ariaLabelledBy});
-
 		const opened = !disabled && open;
 		const [DropDownButton, wrapperProps, skinVariants, groupProps] = (skin === 'silicon') ? [
 			Button,
@@ -227,7 +225,7 @@ const DropdownBase = kind({
 		const onTransitionHide = handleTransitionHide(rest['data-spotlight-id']);
 
 		return (
-			<div {...calcAriaProps} {...rest}>
+			<div {...rest}>
 				<div {...wrapperProps}>
 					<DropDownButton
 						className={buttonClassName}


### PR DESCRIPTION
### The Issue
After making a selection from a dropdown menu, focus would be lost and unrecoverable.

### The Solution
Upon closing (hiding) the menu, the focus would remain inside the dropdown list menu popup, and since the list container was set to "self-only", spotlight wasn't allowed to leave that container. However, the container was only hidden, not destroyed, so the normal flow couldn't happen, causing Spotlight to just be stuck in an invisible box, like a real-life mime.

From @germboy:
> I added a `Spotlight.focus()`  bit in the dropdown transition component’s `onHide` method that will set focus back to the dropdown button/item when it closes.

I added several other aria props and ID from Sandstone to help with accessibility.