### PR TITLE
PLAT-115993: Updated a11y readout of SwitchItem

### DIFF
--- a/SwitchItem/SwitchItem.js
+++ b/SwitchItem/SwitchItem.js
@@ -130,10 +130,21 @@ const SwitchItemBase = kind({
 	render: ({children, css, icon, offText, onText, selected, ...rest}) => {
 
 		return (
-			<Item aria-checked={selected} role="checkbox" {...rest} css={css} label={selected ? onText : offText} labelPosition="after">
+			<Item
+				aria-pressed={selected}
+				role="button"
+				{...rest}
+				css={css}
+				label={selected ? onText : offText}
+				labelPosition="after"
+			>
 				{icon}
 				{children}
-				<Switch slot="slotAfter" selected={selected} className={css.switchIcon} />
+				<Switch
+					className={css.switchIcon}
+					selected={selected}
+					slot="slotAfter"
+				/>
 			</Item>
 		);
 	}


### PR DESCRIPTION
SwitchItem reads checking status (checked/unchecked) along with a toggled status (on/off) but we just need a toggled status. To fix this, updated aria role from 'checkbox' to 'button'.

Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)