### PR TITLE
PLAT-115999: Add a11y support to DateTimePicker

### DIFF
--- a/DatePicker/DatePickerBase.js
+++ b/DatePicker/DatePickerBase.js
@@ -2,6 +2,7 @@ import kind from '@enact/core/kind';
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import $L from '../internal/$L';
 import {DateComponentRangePicker} from '../internal/DateComponentPicker';
 import DateTime from '../internal/DateTime';
 
@@ -203,7 +204,9 @@ const DatePickerBase = kind({
 		yearAriaLabel,
 		...rest
 	}) => {
-
+		const dayAccessibilityHint = $L('day');
+		const monthAccessibilityHint = $L('month');
+		const yearAccessibilityHint = $L('year');
 		delete rest.rtl;
 
 		return (
@@ -213,6 +216,7 @@ const DatePickerBase = kind({
 						case 'd':
 							return (
 								<DateComponentRangePicker
+									accessibilityHint={dayAccessibilityHint}
 									aria-label={dayAriaLabel}
 									className={css.day}
 									disabled={disabled}
@@ -227,6 +231,7 @@ const DatePickerBase = kind({
 						case 'm':
 							return (
 								<DateComponentRangePicker
+									accessibilityHint={monthAccessibilityHint}
 									aria-label={monthAriaLabel}
 									className={css.month}
 									disabled={disabled}
@@ -241,6 +246,7 @@ const DatePickerBase = kind({
 						case 'y':
 							return (
 								<DateComponentRangePicker
+									accessibilityHint={yearAccessibilityHint}
 									aria-label={yearAriaLabel}
 									className={css.year}
 									disabled={disabled}

--- a/TimePicker/TimePickerBase.js
+++ b/TimePicker/TimePickerBase.js
@@ -2,6 +2,7 @@ import kind from '@enact/core/kind';
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import $L from '../internal/$L';
 import {DateComponentPicker, DateComponentRangePicker} from '../internal/DateComponentPicker';
 import DateTime from '../internal/DateTime';
 
@@ -229,6 +230,8 @@ const TimePickerBase = kind({
 		order,
 		...rest
 	}) => {
+		const hourAccessibilityHint = $L('hour');
+		const minuteAccessibilityHint = $L('minute');
 
 		delete rest.rtl;
 
@@ -241,6 +244,7 @@ const TimePickerBase = kind({
 							return (
 								<React.Fragment key="hour-picker">
 									<HourPicker
+										accessibilityHint={hourAccessibilityHint}
 										aria-label={hourAriaLabel}
 										className={css.hourPicker}
 										disabled={disabled}
@@ -254,6 +258,7 @@ const TimePickerBase = kind({
 						case 'm':
 							return (
 								<DateComponentRangePicker
+									accessibilityHint={minuteAccessibilityHint}
 									aria-label={minuteAriaLabel}
 									className={css.minutePicker}
 									disabled={disabled}

--- a/internal/DateComponentPicker/DateComponentPicker.js
+++ b/internal/DateComponentPicker/DateComponentPicker.js
@@ -37,7 +37,25 @@ const DateComponentPickerBase = kind({
 		 * @required
 		 * @public
 		 */
-		value: PropTypes.number.isRequired
+		value: PropTypes.number.isRequired,
+
+		/**
+		 * Sets the hint string read when focusing the picker.
+		 *
+		 * @type {String}
+		 * @public
+		 */
+		accessibilityHint: PropTypes.string,
+
+		/**
+		 * Overrides the `aria-valuetext` for the picker. By default, `aria-valuetext` is set
+		 * to the current selected child and accessibilityHint text.
+		 *
+		 * @type {String}
+		 * @memberof sandstone/internal/DateComponentPicker.DateComponentPickerBase.prototype
+		 * @public
+		 */
+		'aria-valuetext': PropTypes.string
 	},
 
 	styles: {
@@ -52,9 +70,11 @@ const DateComponentPickerBase = kind({
 		max: ({children}) => React.Children.count(children) - 1
 	},
 
-	render: ({children, max, value, ...rest}) => (
+	render: ({'aria-valuetext': ariaValuetext, accessibilityHint, children, max, value, ...rest}) => (
 		<Picker
 			{...rest}
+			accessibilityHint={accessibilityHint}
+			aria-valuetext={(accessibilityHint == null) ? ariaValuetext : null}
 			css={css}
 			index={value}
 			max={max}

--- a/internal/Picker/Picker.js
+++ b/internal/Picker/Picker.js
@@ -76,6 +76,17 @@ const PickerBase = kind({
 		min: PropTypes.number.isRequired,
 
 		/**
+		 * Accessibility hint
+		 *
+		 * For example, `hour`, `year`, and `meridiem`
+		 *
+		 * @type {String}
+		 * @default ''
+		 * @public
+		 */
+		accessibilityHint: PropTypes.string,
+
+		/**
 		 * Overrides the `aria-valuetext` for the picker. By default, `aria-valuetext` is set
 		 * to the current value. This should only be used when the parent controls the value of
 		 * the picker directly through the props.
@@ -101,6 +112,14 @@ const PickerBase = kind({
 		 * @public
 		 */
 		className: PropTypes.string,
+
+		/**
+		 * Customize component style
+		 *
+		 * @type {Object}
+		 * @private
+		 */
+		css: PropTypes.object,
 
 		/**
 		 * Sets the hint string read when focusing the decrement button.
@@ -188,6 +207,9 @@ const PickerBase = kind({
 	},
 
 	defaultProps: {
+		accessibilityHint: '',
+		decrementAriaLabel: $L('previous item'),
+		incrementAriaLabel: $L('next item'),
 		orientation: 'vertical',
 		step: 1,
 		value: 0
@@ -217,27 +239,26 @@ const PickerBase = kind({
 	computed: {
 		activeClassName: ({styler}) => styler.join('active', 'item'),
 		className: ({orientation, styler}) => styler.append(orientation),
-		currentValueText: ({'aria-valuetext': valueText, children: values, value}) => {
-			if (Array.isArray(values)) {
-				return `${typeof valueText !== 'undefined' ? valueText : values[value]}`;
-			} else {
-				return `${typeof valueText !== 'undefined' ? valueText : value}`;
-			}
-		},
-		decrementAriaLabel: ({'aria-valuetext': valueText, children: values, decrementAriaLabel = $L('previous item'), value}) => {
-			if (Array.isArray(values)) {
-				return `${valueText != null ? valueText : values[value]} ${decrementAriaLabel}`;
-			} else {
-				return `${valueText != null ? valueText : value} ${decrementAriaLabel}`;
+		currentValueText: ({accessibilityHint, 'aria-valuetext': ariaValueText, children, value}) => {
+			if (ariaValueText != null) {
+				return ariaValueText;
 			}
 
-		},
-		incrementAriaLabel: ({'aria-valuetext': valueText, children: values, incrementAriaLabel = $L('next item'), value}) => {
-			if (Array.isArray(values)) {
-				return `${valueText != null ? valueText : values[value]} ${incrementAriaLabel}`;
-			} else {
-				return `${valueText != null ? valueText : value} ${incrementAriaLabel}`;
+			let valueText = value;
+
+			if (children && Array.isArray(children)) {
+				if (children[value] && children[value].props) {
+					valueText = children[value].props.children;
+				} else {
+					valueText = children[value];
+				}
 			}
+
+			if (accessibilityHint) {
+				valueText = `${valueText} ${accessibilityHint}`;
+			}
+
+			return valueText;
 		},
 		valueId: ({id}) => `${id}_value`
 	},
@@ -247,13 +268,13 @@ const PickerBase = kind({
 			activeClassName,
 			children: values,
 			currentValueText,
-			decrementAriaLabel,
+			decrementAriaLabel: decAriaLabel,
 			handleDecrement,
 			handleFlick,
 			handleIncrement,
 			handleSecondaryDecrement,
 			handleSecondaryIncrement,
-			incrementAriaLabel,
+			incrementAriaLabel: incAriaLabel,
 			min,
 			max,
 			skin,
@@ -271,6 +292,11 @@ const PickerBase = kind({
 		const isLast = value >= max;
 		const isSecond = value <= min + step;
 		const isPenultimate = value >= max - step;
+		const decrementAriaLabel = `${currentValueText} ${decAriaLabel}`;
+		const incrementAriaLabel = `${currentValueText} ${incAriaLabel}`;
+
+		delete rest.accessibilityHint;
+		delete rest['aria-valuetext'];
 
 		return (
 			<PickerRoot {...rest} onFlick={handleFlick}>


### PR DESCRIPTION
Requires https://github.com/enactjs/agate/pull/321.
Please do not merge this branch before the above PR merged.
I'll rebase after the PR got merged.

This PR adds a11y support to DateTimePicker.
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)
