### PR TITLE
PLAT-114355: Adjust Dropdown direction to display properly at the bottom

### DIFF
--- a/Dropdown/Dropdown.js
+++ b/Dropdown/Dropdown.js
@@ -228,7 +228,7 @@ const DropdownBase = kind({
 		}
 	},
 
-	render: ({adjustedDirection, buttonClassName, children, css, dropdownListClassname, disabled, hasChildren, onClose, onOpen, onSelect, open, selected, skin, styler, transitionDirection, title, ...rest}) => {
+	render: ({adjustedDirection, buttonClassName, children, css, dropdownListClassname, disabled, hasChildren, onClose, onOpen, onSelect, open, selected, skin, styler, title, ...rest}) => {
 		const ariaProps = extractAriaProps(rest);
 		const dropdownButtonClassname = styler.join(css.dropdownButton, {upDropdownButton: adjustedDirection === 'up'});
 		const opened = !disabled && open;

--- a/Dropdown/Dropdown.js
+++ b/Dropdown/Dropdown.js
@@ -26,6 +26,7 @@ import IdProvider from '@enact/ui/internal/IdProvider';
 import ri from '@enact/ui/resolution';
 import Toggleable from '@enact/ui/Toggleable';
 import Transition from '@enact/ui/Transition';
+import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
 import React from 'react';
@@ -79,6 +80,15 @@ const DropdownBase = kind({
 		 * @private
 		 */
 		css: PropTypes.object,
+
+		/**
+		 * This is passed onto the wrapped component to allow
+		 * it to customize the spotlight container for its use case.
+		 *
+		 * @type {String}
+		 * @private
+		 */
+		'data-spotlight-id': PropTypes.string,
 
 		/**
 		 * The direction where the dropdown list appears.
@@ -228,11 +238,11 @@ const DropdownBase = kind({
 		}
 	},
 
-	render: ({adjustedDirection, buttonClassName, children, css, dropdownListClassname, disabled, hasChildren, onClose, onOpen, onSelect, open, selected, skin, styler, title, ...rest}) => {
+	render: ({adjustedDirection, buttonClassName, children, css, dropdownListClassname, disabled, hasChildren, onClose, onOpen, onSelect, open, selected, skin, title, ...rest}) => {
 		const ariaProps = extractAriaProps(rest);
-		const dropdownButtonClassname = styler.join(css.dropdownButton, {upDropdownButton: adjustedDirection === 'up'});
+		const dropdownButtonClassname = classnames(css.dropdownButton, {[css.upDropdownButton]: adjustedDirection === 'up'});
 		const opened = !disabled && open;
-		const transitionContainerClassname = styler.join(css.transitionContainer, {openTransitionContainer: open, upTransitionContainer: adjustedDirection === 'up'});
+		const transitionContainerClassname = classnames(css.transitionContainer, {[css.openTransitionContainer]: open, [css.upTransitionContainer]: adjustedDirection === 'up'});
 		const [DropDownButton, wrapperProps, skinVariants, groupProps] = (skin === 'silicon') ? [
 			Button,
 			{className: dropdownButtonClassname},

--- a/Dropdown/Dropdown.js
+++ b/Dropdown/Dropdown.js
@@ -196,11 +196,14 @@ const DropdownBase = kind({
 	computed: {
 		buttonClassName: ({open, styler}) => styler.append({open}),
 		adjustedDirection: ({direction, 'data-spotlight-id': containerId}) => {
-			const calcOverflow = (container, client) => {
+			const calcOverflow = (container, client, wrapper) => {
 				const KEEPOUT = ri.scale(24); // keep out distance on the edge of the screen
+				const wrapperTop = (wrapper && wrapper.top) || 0;
+				const wrapperBottom = (wrapper && wrapper.bottom) || window.innerHeight;
+
 				const overflow = {
-					isOverTop: client.top - container.height - KEEPOUT < 0,
-					isOverBottom: client.bottom + container.height + KEEPOUT > window.innerHeight
+					isOverTop: client.top - container.height - KEEPOUT < wrapperTop,
+					isOverBottom: client.bottom + container.height + KEEPOUT > wrapperBottom
 				};
 
 				return overflow;
@@ -220,11 +223,13 @@ const DropdownBase = kind({
 			const containerSelector = `[data-spotlight-id='${containerId}']`;
 			const containerNode = document.querySelector(`${containerSelector} .${componentCss.dropdownList}`);
 			const clientNode = document.querySelector(`${containerSelector} .${componentCss.dropdown}`);
+			const wrapperNode = clientNode && clientNode.closest('div[style*=overflow]');
 
 			if (containerNode && clientNode) {
 				const containerNodeRect = containerNode.getBoundingClientRect();
 				const clientNodeRect = clientNode.getBoundingClientRect();
-				return adjustDirection(calcOverflow(containerNodeRect, clientNodeRect));
+				const wrapperNodeRect = wrapperNode && wrapperNode.getBoundingClientRect();
+				return adjustDirection(calcOverflow(containerNodeRect, clientNodeRect, wrapperNodeRect));
 			}
 
 			return direction;

--- a/Dropdown/Dropdown.js
+++ b/Dropdown/Dropdown.js
@@ -198,6 +198,7 @@ const DropdownBase = kind({
 					isOverTop: client.top - container.height - KEEPOUT < 0,
 					isOverBottom: client.bottom + container.height + KEEPOUT > window.innerHeight
 				};
+
 				return overflow;
 			};
 
@@ -205,9 +206,10 @@ const DropdownBase = kind({
 				let adjustedDirection = direction;
 				if (overflow.isOverTop && !overflow.isOverBottom && direction === 'up') {
 					adjustedDirection = 'down';
-				} else if (overflow.isOverBottom && !overflow.isOverTop) {
+				} else if (overflow.isOverBottom && !overflow.isOverTop && direction === 'down') {
 					adjustedDirection = 'up';
 				}
+
 				return adjustedDirection;
 			};
 
@@ -224,7 +226,7 @@ const DropdownBase = kind({
 			return direction;
 		},
 
-		dropdownListClassname: ({children, css, styler}) => styler.join(css.dropdownList, {dropdownListWithScroller: children.length > 4}),
+		dropdownListClassName: ({children, css, styler}) => styler.join(css.dropdownList, {dropdownListWithScroller: children.length > 4}),
 		title: ({children, selected, title}) => {
 			if (isSelectedValid({children, selected})) {
 				const child = children[selected];
@@ -238,14 +240,14 @@ const DropdownBase = kind({
 		}
 	},
 
-	render: ({adjustedDirection, buttonClassName, children, css, dropdownListClassname, disabled, hasChildren, onClose, onOpen, onSelect, open, selected, skin, title, ...rest}) => {
+	render: ({adjustedDirection, buttonClassName, children, css, dropdownListClassName, disabled, hasChildren, onClose, onOpen, onSelect, open, selected, skin, title, ...rest}) => {
 		const ariaProps = extractAriaProps(rest);
-		const dropdownButtonClassname = classnames(css.dropdownButton, {[css.upDropdownButton]: adjustedDirection === 'up'});
+		const dropdownButtonClassName = classnames(css.dropdownButton, {[css.upDropdownButton]: adjustedDirection === 'up'});
 		const opened = !disabled && open;
-		const transitionContainerClassname = classnames(css.transitionContainer, {[css.openTransitionContainer]: open, [css.upTransitionContainer]: adjustedDirection === 'up'});
+		const transitionContainerClassName = classnames(css.transitionContainer, {[css.openTransitionContainer]: open, [css.upTransitionContainer]: adjustedDirection === 'up'});
 		const [DropDownButton, wrapperProps, skinVariants, groupProps] = (skin === 'silicon') ? [
 			Button,
-			{className: dropdownButtonClassname},
+			{className: dropdownButtonClassName},
 			{'night': false},
 			{childComponent: RadioItem, itemProps: {size: 'small', className: css.dropDownListItem, css}, selectedProp: 'selected'}
 		] : [
@@ -270,12 +272,12 @@ const DropdownBase = kind({
 						{title}
 					</DropDownButton>
 					<Transition
-						className={transitionContainerClassname}
+						className={transitionContainerClassName}
 						visible={opened}
 						direction={oppositeDirection[adjustedDirection]}
 						onHide={onTransitionHide}
 					>
-						<ContainerDiv className={dropdownListClassname} spotlightDisabled={!open} spotlightRestrict="self-only">
+						<ContainerDiv className={dropdownListClassName} spotlightDisabled={!open} spotlightRestrict="self-only">
 							<Scroller skinVariants={skinVariants} className={css.scroller}>
 								<Group
 									className={css.group}

--- a/Dropdown/Dropdown.js
+++ b/Dropdown/Dropdown.js
@@ -225,7 +225,6 @@ const DropdownBase = kind({
 
 			return direction;
 		},
-
 		dropdownListClassName: ({children, css, styler}) => styler.join(css.dropdownList, {dropdownListWithScroller: children.length > 4}),
 		title: ({children, selected, title}) => {
 			if (isSelectedValid({children, selected})) {

--- a/Dropdown/Dropdown.js
+++ b/Dropdown/Dropdown.js
@@ -260,7 +260,7 @@ const DropdownBase = kind({
 				};
 			});
 		},
-		dropdownListClassname: ({children, css, styler}) => styler.join(css.dropdownList, {dropdownListWithScroller: children.length > 4}),
+		dropdownListClassName: ({children, css, styler}) => styler.join(css.dropdownList, {dropdownListWithScroller: children.length > 4}),
 		title: ({children, selected, title}) => {
 			if (isSelectedValid({children, selected})) {
 				const child = children[selected];

--- a/Dropdown/Dropdown.js
+++ b/Dropdown/Dropdown.js
@@ -195,7 +195,7 @@ const DropdownBase = kind({
 			const calcOverflow = (container, client) => {
 				const KEEPOUT = ri.scale(24); // keep out distance on the edge of the screen
 				const overflow = {
-					isOverTop: client.top - container.height  - KEEPOUT < 0,
+					isOverTop: client.top - container.height - KEEPOUT < 0,
 					isOverBottom: client.bottom + container.height + KEEPOUT > window.innerHeight
 				};
 				return overflow;

--- a/samples/sampler/stories/default/Dropdown.js
+++ b/samples/sampler/stories/default/Dropdown.js
@@ -84,7 +84,7 @@ storiesOf('Agate QA.Dropdown', module)
 			text: 'The basic Dropdown'
 		}
 	).add(
-		'groups in Scroller',
+		'group in Scroller',
 		() => {
 			const itemCount = number('items', Config, {range: true, min: 0, max: 50}, 5);
 			const items = (new Array(itemCount)).fill().map((i, index) => `Option ${index + 1}`);

--- a/samples/sampler/stories/default/Dropdown.js
+++ b/samples/sampler/stories/default/Dropdown.js
@@ -5,6 +5,7 @@ import {storiesOf} from '@storybook/react';
 import React from 'react';
 
 import Dropdown, {DropdownBase} from '@enact/agate/Dropdown';
+import Scroller from '@enact/agate/Scroller';
 import ri from '@enact/ui/resolution';
 
 const Config = mergeComponentMetadata('Dropdown', Dropdown, DropdownBase);
@@ -76,6 +77,58 @@ storiesOf('Agate QA.Dropdown', module)
 						{items}
 					</Dropdown>
 				</>
+			);
+		},
+		{
+			text: 'The basic Dropdown'
+		}
+	).add(
+		'in Scroller with wrong direction',
+		() => {
+			const itemCount = number('items', Config, {range: true, min: 0, max: 50}, 5);
+			const items = (new Array(itemCount)).fill().map((i, index) => `Option ${index + 1}`);
+
+			return (
+				<Scroller>
+					<Dropdown
+						direction="up"
+						onSelect={action('onSelect')}
+						title="Up dropdown"
+					>
+						{items}
+					</Dropdown>
+					<div style={{marginTop: ri.scaleToRem(600)}}>
+						Mauris blandit sollicitudin mattis. Fusce commodo arcu vitae risus consectetur sollicitudin. Aliquam eget posuere orci. Cras pellentesque lobortis sapien non lacinia.
+					</div>
+					<Dropdown
+						onSelect={action('onSelect')}
+						title="default dropdown"
+					>
+						{items}
+					</Dropdown>
+					<div style={{marginTop: ri.scaleToRem(600)}}>
+						Mauris blandit sollicitudin mattis. Fusce commodo arcu vitae risus consectetur sollicitudin. Aliquam eget posuere orci. Cras pellentesque lobortis sapien non lacinia.
+					</div>
+					<Dropdown
+						onSelect={action('onSelect')}
+						title="Down dropdown"
+					>
+						{items}
+					</Dropdown>
+					<Dropdown
+						onSelect={action('onSelect')}
+						title="Down dropdown"
+					>
+						{items}
+					</Dropdown>
+					<Dropdown
+						direction="down"
+						onSelect={action('onSelect')}
+						title="Down dropdown"
+					>
+						{items}
+					</Dropdown>
+				</Scroller>
 			);
 		},
 		{

--- a/samples/sampler/stories/default/Dropdown.js
+++ b/samples/sampler/stories/default/Dropdown.js
@@ -6,6 +6,7 @@ import React from 'react';
 
 import Dropdown, {DropdownBase} from '@enact/agate/Dropdown';
 import Scroller from '@enact/agate/Scroller';
+import Group from '@enact/ui/Group';
 import ri from '@enact/ui/resolution';
 
 const Config = mergeComponentMetadata('Dropdown', Dropdown, DropdownBase);
@@ -83,51 +84,25 @@ storiesOf('Agate QA.Dropdown', module)
 			text: 'The basic Dropdown'
 		}
 	).add(
-		'in Scroller with wrong direction',
+		'groups in Scroller',
 		() => {
 			const itemCount = number('items', Config, {range: true, min: 0, max: 50}, 5);
 			const items = (new Array(itemCount)).fill().map((i, index) => `Option ${index + 1}`);
+			const dropdowns = [];
+
+			for (let i = 0; i < 30; i++) {
+				dropdowns.push({children: items, title: text('title', Config, 'Please select'), key: i});
+			}
 
 			return (
 				<Scroller>
-					<Dropdown
-						direction="up"
+					<Group
+						childComponent={Dropdown}
+						style={{position: 'absolute', top: 0, width:'50%'}}
 						onSelect={action('onSelect')}
-						title="Up dropdown"
 					>
-						{items}
-					</Dropdown>
-					<div style={{marginTop: ri.scaleToRem(600)}}>
-						Mauris blandit sollicitudin mattis. Fusce commodo arcu vitae risus consectetur sollicitudin. Aliquam eget posuere orci. Cras pellentesque lobortis sapien non lacinia.
-					</div>
-					<Dropdown
-						onSelect={action('onSelect')}
-						title="default dropdown"
-					>
-						{items}
-					</Dropdown>
-					<div style={{marginTop: ri.scaleToRem(600)}}>
-						Mauris blandit sollicitudin mattis. Fusce commodo arcu vitae risus consectetur sollicitudin. Aliquam eget posuere orci. Cras pellentesque lobortis sapien non lacinia.
-					</div>
-					<Dropdown
-						onSelect={action('onSelect')}
-						title="Down dropdown"
-					>
-						{items}
-					</Dropdown>
-					<Dropdown
-						onSelect={action('onSelect')}
-						title="Down dropdown"
-					>
-						{items}
-					</Dropdown>
-					<Dropdown
-						direction="down"
-						onSelect={action('onSelect')}
-						title="Down dropdown"
-					>
-						{items}
-					</Dropdown>
+						{dropdowns}
+					</Group>
 				</Scroller>
 			);
 		},


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn <jeonghee27.ahn@lge.com>

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
[PDM App: Not able to select Dropdown options for the displays at the bottom.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
 - Adjust Dropdown direction by checking the overflow status.
 - If there is a parent node with `overflow` property like `Scroller`, the space is calculated by this node.
 - Add qa-sampler for checking the behavior 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
PLAT-114355

### Comments
