### PR TITLE
PLAT-118160: Fix Checked message cut off in Dropdown

### DIFF
--- a/Dropdown/Dropdown.js
+++ b/Dropdown/Dropdown.js
@@ -45,7 +45,7 @@ const ContainerDiv = SpotlightContainerDecorator({enterTo: 'last-focused'}, 'div
 const MarqueeButton = MarqueeDecorator({className: componentCss.marquee}, Button);
 const isSelectedValid = ({children, selected}) => Array.isArray(children) && children[selected] != null;
 
-const handleTransitionHide = (containerId) => () => {
+const handleTransitionHide = (ev, {'data-spotlight-id': containerId}) => {
 	const containerSelector = `[data-spotlight-id='${containerId}']`;
 	const current = Spotlight.getCurrent();
 
@@ -170,7 +170,8 @@ const DropdownBase = kind({
 	handlers: {
 		onSelect: handle(
 			forward('onSelect'),
-			forward('onClose')
+			forward('onClose'),
+			handleTransitionHide
 		),
 		onOpen: handle(
 			forProp('open', false),
@@ -257,7 +258,6 @@ const DropdownBase = kind({
 			[<Icon slot="slotAfter" key="icon" className={css.icon} size="small">{open ? 'arrowlargeup' : 'arrowlargedown'}</Icon>]
 
 		];
-		const onTransitionHide = handleTransitionHide(rest['data-spotlight-id']);
 
 		return (
 			<div {...rest}>
@@ -278,7 +278,6 @@ const DropdownBase = kind({
 						className={transitionContainerClassname}
 						visible={opened}
 						direction={transitionDirection}
-						onHide={onTransitionHide}
 					>
 						<ContainerDiv className={dropdownListClassname} spotlightDisabled={!open} spotlightRestrict="self-only">
 							<Scroller skinVariants={skinVariants} className={css.scroller}>


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn <jeonghee27.ahn@lge.com>

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
[Agate a11y]  Checked message cut off in Dropdown
When select a option of dropdown, the a11y message is different depending on the timing.

Expected Result: Provides a consistent A11y.. Read out `Option 2 checked Option 2 Button` or Read out `Option 2 Button` Always
Actual Result: Sometime Read out `Option 2 Button`. And Sometime `Option 2 checked Option 2 Button`

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Sandstone is always read out  `Option 2 Button` . 
**So I fix the focus timing to onClose rather than onHide.**
This is also the same as Sandstone's implementation.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
PLAT-118160

### Comments