### PR TITLE
PLAT-118165: Add a11y support to MediaPlayer

### DIFF
--- a/MediaPlayer/MediaPlayer.js
+++ b/MediaPlayer/MediaPlayer.js
@@ -412,9 +412,10 @@ const MediaPlayerBehaviorDecorator = hoc((config, Wrapped) => { // eslint-disabl
 		};
 
 		onSliderChange = ({value}) => {
-			this.media.currentTime = value * this.state.duration;
+			const currentTime = value * this.state.duration;
+			const seconds = Math.floor(currentTime);
 
-			const seconds = Math.floor(value * this.state.duration);
+			this.media.currentTime = currentTime;
 
 			if (!isNaN(seconds)) {
 				const knobTime = secondsToTime(seconds, getDurFmt(this.props.locale), {includeHour: true});


### PR DESCRIPTION
This PR adds a11y support to MediaPlayer.
If you move the knob on the slider, it will read "Jump to x minutes x seconds".

Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)