### PR TITLE
PLAT-119500: Preserve opacity and color when hovering disabled components

### DIFF
--- a/ThemeDecorator/ThemeDecorator.module.less
+++ b/ThemeDecorator/ThemeDecorator.module.less
@@ -46,12 +46,6 @@
 	.disabled({
 		.vendor-opacity(@agate-disabled-opacity);
 
-		// Focused and disabled, must restore their natural opacity, then assign the faded text/content color
-		.focus({
-			.vendor-opacity(1);
-			color: @agate-spotlight-disabled-text-color;
-		});
-
 		cursor: default;
 
 		// Disabled children of disabled components

--- a/styles/colors-base.less
+++ b/styles/colors-base.less
@@ -72,7 +72,6 @@
 @agate-spotlight-color:                inherit;
 @agate-spotlight-bg-color:             inherit;
 @agate-spotlight-border-color:         inherit;
-@agate-spotlight-disabled-text-color:  inherit;
 @agate-spotlight-focus-bg-image:       inherit;
 
 // Button

--- a/styles/colors-carbon.less
+++ b/styles/colors-carbon.less
@@ -35,7 +35,6 @@
 @agate-spotlight-color:                @agate-foreground-focus;
 @agate-spotlight-bg-color:             @agate-background-focus;
 @agate-spotlight-border-color:         transparent;
-@agate-spotlight-disabled-text-color:  fade(@agate-spotlight-color, 40%);
 @agate-spotlight-focus-bg-image: @agate-gradient;
 
 // Button

--- a/styles/colors-cobalt-day.less
+++ b/styles/colors-cobalt-day.less
@@ -45,7 +45,6 @@
 @agate-spotlight-color:                @agate-foreground-focus;
 @agate-spotlight-bg-color:             @agate-background-focus;
 @agate-spotlight-border-color:         transparent;
-@agate-spotlight-disabled-text-color:  fade(black, 40%);
 @agate-spotlight-focus-bg-image: none;
 
 // Button

--- a/styles/colors-cobalt.less
+++ b/styles/colors-cobalt.less
@@ -51,7 +51,6 @@
 @agate-spotlight-color:                @agate-foreground-focus;
 @agate-spotlight-bg-color:             @agate-background-focus;
 @agate-spotlight-border-color:         transparent;
-@agate-spotlight-disabled-text-color:  fade(@agate-spotlight-color, 40%); // ~"hsla(var(--agate-highlight-h, 0), var(--agate-highlight-s, 0), var(--agate-highlight-l, 0), 0.2)"; // @agate-spotlight-color; // fade(@agate-spotlight-color, 40%);
 @agate-spotlight-focus-bg-image: none;
 
 // Button

--- a/styles/colors-copper-day.less
+++ b/styles/colors-copper-day.less
@@ -45,7 +45,6 @@
 @agate-spotlight-color:                @agate-foreground-focus;
 @agate-spotlight-bg-color:             @agate-background-focus;
 @agate-spotlight-border-color:         transparent;
-@agate-spotlight-disabled-text-color:  fade(black, 40%);
 @agate-spotlight-focus-bg-image: none;
 
 // Button

--- a/styles/colors-copper.less
+++ b/styles/colors-copper.less
@@ -48,7 +48,6 @@
 @agate-spotlight-color:                @agate-foreground-focus;
 @agate-spotlight-bg-color:             @agate-background-focus;
 @agate-spotlight-border-color:         transparent;
-@agate-spotlight-disabled-text-color:  fade(@agate-spotlight-color, 40%); // ~"hsla(var(--agate-highlight-h, 0), var(--agate-highlight-s, 0), var(--agate-highlight-l, 0), 0.2)"; // @agate-spotlight-color; // fade(@agate-spotlight-color, 40%);
 @agate-spotlight-focus-bg-image: none;
 
 // Button

--- a/styles/colors-electro.less
+++ b/styles/colors-electro.less
@@ -47,7 +47,6 @@
 @agate-spotlight-color:                @agate-text-color;
 @agate-spotlight-bg-color:             @agate-background-focus;
 @agate-spotlight-border-color:         transparent;
-@agate-spotlight-disabled-text-color:  fade(@agate-spotlight-color, 40%);
 @agate-spotlight-focus-bg-image: @agate-gradient;
 
 // Button

--- a/styles/colors-gallium-day.less
+++ b/styles/colors-gallium-day.less
@@ -45,7 +45,6 @@
 @agate-spotlight-color:                @agate-foreground-focus;
 @agate-spotlight-bg-color:             @agate-background-focus;
 @agate-spotlight-border-color:         transparent;
-@agate-spotlight-disabled-text-color:  fade(@agate-spotlight-color, 40%);
 @agate-spotlight-focus-bg-image:       none;
 
 // Button

--- a/styles/colors-gallium-night.less
+++ b/styles/colors-gallium-night.less
@@ -17,7 +17,6 @@
 // ---------------------------------------
 @agate-spotlight-color:                @agate-foreground-focus;
 @agate-spotlight-bg-color:             @agate-background-focus;
-@agate-spotlight-disabled-text-color:  fade(@agate-spotlight-color, 40%);
 
 // Button
 // ---------------------------------------

--- a/styles/colors-silicon-day.less
+++ b/styles/colors-silicon-day.less
@@ -75,7 +75,6 @@
 @agate-spotlight-color:                @agate-foreground-focus;
 @agate-spotlight-bg-color:             @agate-background-focus;
 @agate-spotlight-border-color:         transparent;
-@agate-spotlight-disabled-text-color:  fade(@agate-spotlight-color, 40%);
 @agate-spotlight-focus-bg-image:       none;
 
 // Button

--- a/styles/colors-silicon-night.less
+++ b/styles/colors-silicon-night.less
@@ -29,7 +29,6 @@
 @agate-spotlight-color:                @agate-foreground-focus;
 @agate-spotlight-bg-color:             @agate-background-focus;
 @agate-spotlight-border-color:         transparent;
-@agate-spotlight-disabled-text-color:  fade(@agate-spotlight-color, 40%);
 @agate-spotlight-focus-bg-image:       none;
 
 // Button

--- a/styles/colors-titanium.less
+++ b/styles/colors-titanium.less
@@ -35,7 +35,6 @@
 @agate-spotlight-color:                @agate-foreground-focus;
 @agate-spotlight-bg-color:             @agate-background-focus;
 @agate-spotlight-border-color:         transparent;
-@agate-spotlight-disabled-text-color:  fade(@agate-spotlight-color, 40%); // ~"hsla(var(--agate-highlight-h, 0), var(--agate-highlight-s, 0), var(--agate-highlight-l, 0), 0.2)"; // @agate-spotlight-color; // fade(@agate-spotlight-color, 40%);
 @agate-spotlight-focus-bg-image: none;
 
 // Button


### PR DESCRIPTION
### Issues

When hovering a disabled Dropdown Button, the text on it disappears

### Resolution

When hovering the focused and disabled components, we restored their natural opacity, then assign the faded text/content color. But it occurred more problems in Agate because there are several text colors. For example, some text colors are white and another text colors are black. So the faded text/content color could be white or black, then one of them can't be seen.

The Dropdown Button color is white and the hovered disabled text color is white because assigning the faded text/content color as I mentioned before.

So I hope we hold the disabled opacity and color.

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)