### PR TITLE
PLAT-119661: Fix Button's Icon component cannot get silicon skin

### DIFF
--- a/Button/Button.js
+++ b/Button/Button.js
@@ -21,14 +21,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import compose from 'ramda/src/compose';
 
-import {IconBase} from '../Icon';
+import Icon from '../Icon';
 // import {MarqueeDecorator} from '../Marquee';
 import Skinnable from '../Skinnable';
 
 import componentCss from './Button.module.less';
-
-// Make a basic Icon in case we need it later. This cuts `Pure` out of icon for a small gain.
-const Icon = Skinnable(IconBase);
 
 /**
  * A button component.

--- a/samples/sampler/stories/default/Button.js
+++ b/samples/sampler/stories/default/Button.js
@@ -6,8 +6,9 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 
 import Button, {ButtonBase} from '@enact/agate/Button';
+import Skinnable from '@enact/agate/Skinnable';
 
-import icons from './icons';
+import iconList, {iconListSilicon} from './icons';
 
 Button.displayName = 'Button';
 const Config = mergeComponentMetadata('Button', UiButton, ButtonBase, Button);
@@ -16,15 +17,17 @@ const Config = mergeComponentMetadata('Button', UiButton, ButtonBase, Button);
 const prop = {
 	casing: ['preserve', 'sentence', 'word', 'upper'],
 	colors: ['', '#E6444B', '#FDC902', '#986AAD', '#4E75E1', '#30CC83', '#44C8D5', '#47439B', '#2D32A6', '#4E75E1'],
-	icons: ['', ...icons],
 	joinedPosition: ['', 'left', 'center', 'right']
 };
 
-storiesOf('Agate', module)
-	.add(
-		'Button',
-		() => (
+const SkinnedButton = Skinnable(
+	{prop: 'skin'},
+	({skin, ...rest}) => {
+		let icons = skin === 'silicon' ? ['', ...iconListSilicon] :  ['', ...iconList];
+
+		return (
 			<Button
+				{...rest}
 				animateOnRender={boolean('animateOnRender', Config)}
 				animationDelay={number('animationDelay', Config)}
 				backgroundOpacity={select('backgroundOpacity', ['opaque', 'lightOpaque', 'transparent'], Config)}
@@ -32,7 +35,7 @@ storiesOf('Agate', module)
 				badgeColor={select('badgeColor', prop.colors, Config)}
 				disabled={boolean('disabled', Config)}
 				highlighted={boolean('highlighted', Config)}
-				icon={select('icon', prop.icons, Config)}
+				icon={select('icon', icons, Config)}
 				joinedPosition={select('joinedPosition', prop.joinedPosition, Config)}
 				onClick={action('onClick')}
 				selected={boolean('selected', Config)}
@@ -41,6 +44,15 @@ storiesOf('Agate', module)
 			>
 				{text('children', Button, 'Click me')}
 			</Button>
+		);
+	}
+);
+
+storiesOf('Agate', module)
+	.add(
+		'Button',
+		() => (
+			<SkinnedButton />
 		),
 		{
 			text: 'The basic Button'


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn <jeonghee27.ahn@lge.com>

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Button's Icon component cannot get silicon skin

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
-Refer the latest Icon component in Button to apply the extended icon list.
-Provide silicon icon list in the Button sampler.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
PLAT-119661

### Comments