### PR TITLE
PLAT-120786: Exclude enact-fit css class optionally

### DIFF
--- a/ThemeDecorator/ThemeDecorator.js
+++ b/ThemeDecorator/ThemeDecorator.js
@@ -250,11 +250,10 @@ const ThemeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			const allClassNames = classnames(
 				className,
 				'enact-unselectable',
-				bgClassName,
-				[bgClassName]: !float,
 				css.root,
 				{
 					[customizableSkinClassName]: customSkin,
+					[bgClassName]: !float,
 					'enact-fit': !disableFullscreen
 				}
 			);

--- a/ThemeDecorator/ThemeDecorator.js
+++ b/ThemeDecorator/ThemeDecorator.js
@@ -39,6 +39,15 @@ const defaultConfig = /** @lends agate/ThemeDecorator.ThemeDecorator.defaultConf
 	customSkin: true,
 
 	/**
+	 * Disables use of full screen.
+	 *
+	 * @type {Boolean}
+	 * @default false
+	 * @public
+	 */
+	disableFullscreen: false,
+
+	/**
 	 * Enables a floating layer for popup components.
 	 *
 	 * If `false`, app will be responsible for applying the decorator.
@@ -203,7 +212,7 @@ const CustomizableSkinStyle = kind({
  */
 const ThemeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 	// TODO: Document props passable to hoc ()
-	const {customSkin, float, i18n, noAutoFocus, overlay, ri, skin, spotlight} = config;
+	const {customSkin, float, i18n, noAutoFocus, overlay, ri, skin, spotlight, disableFullscreen} = config;
 
 	const bgClassName = classnames(
 		'enact-fit',
@@ -242,8 +251,12 @@ const ThemeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				className,
 				'enact-unselectable',
 				bgClassName,
+				[bgClassName]: !float,
 				css.root,
-				{[customizableSkinClassName]: customSkin}
+				{
+					[customizableSkinClassName]: customSkin,
+					'enact-fit': !disableFullscreen
+				}
 			);
 
 			return (


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Jeongran Jang <jeongran.jang@lge.com>

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
For FloatingLayerDecorator does not always need to be flowed by `.enact-fit` class.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add `disableFullscreen` config prop in ThemeDecorator component to disable `.enact-fit` optionally.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
PLAT-120786

### Comments