### PR TITLE
PLAT-122750: Include Silicon skin in screenshot tests

### DIFF
--- a/tests/screenshot/apps/AgateComponents.js
+++ b/tests/screenshot/apps/AgateComponents.js
@@ -9,7 +9,6 @@ import Icon from './components/Icon';
 import Item from './components/Item';
 import LabeledIcon from './components/LabeledIcon';
 import LabeledIconButton from './components/LabeledIconButton';
-import LabeledItem from './components/LabeledItem';
 import ProgressBar from './components/ProgressBar';
 import Popup from './components/Popup';
 import Picker from './components/Picker';
@@ -28,7 +27,6 @@ const agateComponents = {
 	Item,
 	LabeledIcon,
 	LabeledIconButton,
-	LabeledItem,
 	ProgressBar,
 	Popup,
 	Picker,

--- a/tests/screenshot/apps/components/LabeledItem.js
+++ b/tests/screenshot/apps/components/LabeledItem.js
@@ -1,8 +1,0 @@
-import LabeledItem from '../../../../LabeledItem';
-import React from 'react';
-
-const LabeledItemTests = [
-	<LabeledItem />
-];
-
-export default LabeledItemTests;

--- a/tests/screenshot/apps/importer.js
+++ b/tests/screenshot/apps/importer.js
@@ -7,7 +7,6 @@ import Icon from '../../../Icon';
 import Item from '../../../Item';
 import LabeledIcon from '../../../LabeledIcon';
 import LabeledIconButton from '../../../LabeledIconButton';
-import LabeledItem from '../../../LabeledItem';
 import ProgressBar from '../../../ProgressBar';
 import Popup from '../../../Popup';
 import Picker from '../../../Picker';
@@ -26,7 +25,6 @@ const AgateExports = {
 	Item,
 	LabeledIcon,
 	LabeledIconButton,
-	LabeledItem,
 	ProgressBar,
 	Popup,
 	Picker,

--- a/tests/screenshot/specs/AgateSilicon-specs.js
+++ b/tests/screenshot/specs/AgateSilicon-specs.js
@@ -1,0 +1,8 @@
+const {runTest} = require('@enact/ui-test-utils/utils');
+const Page = require('./AgatePage');
+
+runTest({
+	testName: 'Agate Silicon',
+	Page: Page,
+	skin: 'silicon'
+});

--- a/tests/screenshot/specs/AgateSiliconNight-specs.js
+++ b/tests/screenshot/specs/AgateSiliconNight-specs.js
@@ -1,0 +1,9 @@
+const {runTest} = require('@enact/ui-test-utils/utils');
+const Page = require('./AgatePage');
+
+runTest({
+	testName: 'Agate Silicon Night',
+	Page: Page,
+	skin: 'silicon',
+	skinVariants: '"night"'
+});


### PR DESCRIPTION
Silicon skin has been included in screenshot tests.
In addition, A `LabeledItem` component screenshot tests has been removed in all skins because it will be deprecated.

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)