### PR TITLE
PLAT-122721: RadioItem: No `onChange` log in sampler Action tab

### DIFF
--- a/samples/sampler/stories/default/RadioItem.js
+++ b/samples/sampler/stories/default/RadioItem.js
@@ -1,4 +1,5 @@
 import {mergeComponentMetadata} from '@enact/storybook-utils';
+import {action} from '@enact/storybook-utils/addons/actions';
 import {boolean, select, text} from '@enact/storybook-utils/addons/knobs';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
@@ -18,6 +19,7 @@ storiesOf('Agate', module)
 				<RadioItem
 					disabled={boolean('disabled', Config)}
 					icon={select('icon', ['', ...iconNames], Config)}
+					onToggle={action('onToggle')}
 				>
 					{text('children', Config, 'Hello RadioItem')}
 				</RadioItem>


### PR DESCRIPTION
Added `onChange` log in sampler Action tab for Agate RadioItem component.

Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com