### PR TITLE
PLAT-122792: LabeledIconButton: Huge Icon is cut off.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
  
 ### Fixed
 - `agate/Panels` to show close button properly for night mode
+- `LabeledIconButton` max-width so that huge sized icon will not be cut off
 
 ## [1.0.0] - 2020-10-14
 

--- a/LabeledIconButton/LabeledIconButton.module.less
+++ b/LabeledIconButton/LabeledIconButton.module.less
@@ -16,6 +16,8 @@
 	}
 
 	.applySkins({
+		max-width: fit-content;
+
 		.label {
 			margin-top: @agate-labelediconbutton-label-margin;
 			color: @agate-labelediconbutton-label-color;


### PR DESCRIPTION
Fixed bug in LabeledIconButton component so that Icon in huge size is not cut off any longer.

Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com