### PR TITLE
PLAT-122734: Reverted incrementSlider button color for Gallium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The following is a curated list of changes in the Enact sandstone module, newest
 ## [unreleased]
  
 ### Fixed
+- `agate/IncrementSlider` button color for Gallium skin
 - `agate/Panels` to show close button properly for night mode
 
 ## [1.0.0] - 2020-10-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The following is a curated list of changes in the Enact sandstone module, newest changes on the top.
 
+## [unreleased]
+ 
+### Fixed
+- `agate/Panels` to show close button properly for night mode
+
 ## [1.0.0] - 2020-10-14
 
 Initial release.

--- a/Panels/Panels.module.less
+++ b/Panels/Panels.module.less
@@ -14,7 +14,6 @@
 	.controls {
 		position: absolute;
 		z-index: 1;
-		.remove-margin-on-edge-children();
 	}
 
 	&.breadcrumbPanels {
@@ -60,6 +59,7 @@
 			top: @agate-panels-controls-top;
 			.position-start-end(auto, @agate-panel-h-padding);
 			.padding-start-end(@agate-panels-controls-padding-start, initial);
+			.remove-margin-on-edge-children();
 		}
 
 		.partial {

--- a/styles/colors-base.less
+++ b/styles/colors-base.less
@@ -351,7 +351,7 @@
 // IncrementSlider
 // ---------------------------------------
 @agate-incrementslider-button-bg-color: @agate-button-bg-color;
-@agate-incrementslider-button-color: @agate-button-color;
+@agate-incrementslider-button-color: inherit;
 @agate-incrementslider-color: inherit;
 @agate-incrementslider-horizontal-button-decrement-border-color: inherit;
 @agate-incrementslider-horizontal-button-decrement-bg-color: @agate-slider-bg-color;

--- a/styles/colors-carbon.less
+++ b/styles/colors-carbon.less
@@ -187,7 +187,6 @@
 
 // IncrementSlider
 // ---------------------------------------
-@agate-incrementslider-button-color: inherit;
 @agate-incrementslider-horizontal-button-decrement-border-color: @agate-button-border-color;
 @agate-incrementslider-horizontal-button-decrement-bg-color: @agate-button-bg-color;
 @agate-incrementslider-horizontal-button-decrement-bg-image: @agate-button-bg-image;

--- a/styles/colors-electro.less
+++ b/styles/colors-electro.less
@@ -202,7 +202,6 @@
 
 // IncrementSlider
 // ---------------------------------------
-@agate-incrementslider-button-color: inherit;
 @agate-incrementslider-horizontal-button-decrement-border-color: @agate-button-border-color;
 @agate-incrementslider-horizontal-button-decrement-bg-color: @agate-slider-knob-bg-color;
 @agate-incrementslider-horizontal-button-decrement-bg-image: @agate-slider-knob-bg-image;

--- a/styles/colors-silicon-day.less
+++ b/styles/colors-silicon-day.less
@@ -289,6 +289,7 @@
 // IncrementSlider
 // ---------------------------------------
 @agate-incrementslider-color: @agate-foreground;
+@agate-incrementslider-button-color: @agate-button-color;
 @agate-incrementslider-horizontal-button-decrement-border-color: @agate-button-border-color;
 @agate-incrementslider-horizontal-button-decrement-bg-color: @agate-button-bg-color;
 @agate-incrementslider-horizontal-button-decrement-bg-image: @agate-button-bg-image;

--- a/styles/colors-titanium.less
+++ b/styles/colors-titanium.less
@@ -187,7 +187,6 @@
 
 // IncrementSlider
 // ---------------------------------------
-@agate-incrementslider-button-color: inherit;
 @agate-incrementslider-horizontal-button-decrement-border-color: transparent;
 @agate-incrementslider-horizontal-button-decrement-bg-color: @agate-slider-bg-color;
 @agate-incrementslider-horizontal-button-decrement-bg-image: @agate-slider-bg-image;


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Daniel Stoian daniel.stoian@lgepartner.com

**Checklist**
 I have read and understand the contribution guide
 A CHANGELOG entry is included

**Issue Resolved / Feature Added**
Agate - Reverted incrementSlider button color for Gallium. It was altered when developing IncrementSlider for Silicon in  #286 and this issue was highlighted in the screenshot tests.

**Links**
PLAT-122734