### PR TITLE
PLAT-122911: Added more component views for screenshot test - set 3

### DIFF
--- a/tests/screenshot/apps/AgateComponents.js
+++ b/tests/screenshot/apps/AgateComponents.js
@@ -1,6 +1,9 @@
 import {generateTestData} from '@enact/ui-test-utils/utils';
 
+import BodyText from './components/BodyText';
 import Button from './components/Button';
+import ColorPicker from './components/ColorPicker';
+import DatePicker from './components/DatePicker';
 import DateTimePicker from './components/DateTimePicker';
 import Heading from './components/Heading';
 import IncrementSlider from './components/IncrementSlider';
@@ -9,16 +12,23 @@ import Icon from './components/Icon';
 import Item from './components/Item';
 import LabeledIcon from './components/LabeledIcon';
 import LabeledIconButton from './components/LabeledIconButton';
+import MediaPlayer from './components/MediaPlayer';
 import ProgressBar from './components/ProgressBar';
 import Popup from './components/Popup';
 import Picker from './components/Picker';
 import RadioItem from './components/RadioItem';
+import RangePicker from './components/RangePicker';
 import Slider from './components/Slider';
+import SliderButton from './components/SliderButton';
 import SwitchItem from './components/SwitchItem';
+import TimePicker from './components/TimePicker';
 import ToggleButton from './components/ToggleButton';
 
 const agateComponents = {
+	BodyText,
 	Button,
+	ColorPicker,
+	DatePicker,
 	DateTimePicker,
 	Heading,
 	IncrementSlider,
@@ -27,12 +37,16 @@ const agateComponents = {
 	Item,
 	LabeledIcon,
 	LabeledIconButton,
+	MediaPlayer,
 	ProgressBar,
 	Popup,
 	Picker,
 	RadioItem,
+	RangePicker,
 	Slider,
+	SliderButton,
 	SwitchItem,
+	TimePicker,
 	ToggleButton
 };
 

--- a/tests/screenshot/apps/components/BodyText.js
+++ b/tests/screenshot/apps/components/BodyText.js
@@ -1,0 +1,10 @@
+import BodyText from '../../../../BodyText';
+import React from 'react';
+
+const BodyTextTests = [
+	<BodyText>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</BodyText>,
+	<BodyText centered>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</BodyText>,
+	<BodyText noWrap>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</BodyText>
+];
+
+export default BodyTextTests;

--- a/tests/screenshot/apps/components/Button.js
+++ b/tests/screenshot/apps/components/Button.js
@@ -4,7 +4,7 @@ import React from 'react';
 const ButtonTests = [
 	<Button>click me</Button>,
 	<Button selected>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Button>,
-	<Button>Not Selected. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Button>
+	<Button highlighted size="small">Not Selected. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</Button>
 ];
 
 export default ButtonTests;

--- a/tests/screenshot/apps/components/ColorPicker.js
+++ b/tests/screenshot/apps/components/ColorPicker.js
@@ -1,0 +1,9 @@
+import ColorPicker from '../../../../ColorPicker';
+import React from 'react';
+
+const ColorPickerTests = [
+	<ColorPicker>{[]}</ColorPicker>,
+	<ColorPicker open>{[]}</ColorPicker>
+];
+
+export default ColorPickerTests;

--- a/tests/screenshot/apps/components/ColorPicker.js
+++ b/tests/screenshot/apps/components/ColorPicker.js
@@ -3,7 +3,8 @@ import React from 'react';
 
 const ColorPickerTests = [
 	<ColorPicker>{[]}</ColorPicker>,
-	<ColorPicker open>{[]}</ColorPicker>
+	<ColorPicker open>{[]}</ColorPicker>,
+	<ColorPicker extended>{[]}</ColorPicker>
 ];
 
 export default ColorPickerTests;

--- a/tests/screenshot/apps/components/DatePicker.js
+++ b/tests/screenshot/apps/components/DatePicker.js
@@ -2,7 +2,8 @@ import DatePicker from '../../../../DatePicker';
 import React from 'react';
 
 const DatePickerTests = [
-	<DatePicker />
+	<DatePicker />,
+	<DatePicker disabled />
 ];
 
 export default DatePickerTests;

--- a/tests/screenshot/apps/components/DatePicker.js
+++ b/tests/screenshot/apps/components/DatePicker.js
@@ -1,0 +1,8 @@
+import DatePicker from '../../../../DatePicker';
+import React from 'react';
+
+const DatePickerTests = [
+	<DatePicker />
+];
+
+export default DatePickerTests;

--- a/tests/screenshot/apps/components/DateTimePicker.js
+++ b/tests/screenshot/apps/components/DateTimePicker.js
@@ -2,7 +2,8 @@ import DateTimePicker from '../../../../DateTimePicker';
 import React from 'react';
 
 const DateTimePickerTests = [
-	<DateTimePicker />
+	<DateTimePicker />,
+	<DateTimePicker disabled />
 ];
 
 export default DateTimePickerTests;

--- a/tests/screenshot/apps/components/MediaPlayer.js
+++ b/tests/screenshot/apps/components/MediaPlayer.js
@@ -2,7 +2,9 @@ import MediaPlayer from '../../../../MediaPlayer';
 import React from 'react';
 
 const MediaPlayerTests = [
-	<MediaPlayer />
+	<MediaPlayer />,
+	<MediaPlayer paused />,
+	<MediaPlayer shuffle />
 ];
 
 export default MediaPlayerTests;

--- a/tests/screenshot/apps/components/MediaPlayer.js
+++ b/tests/screenshot/apps/components/MediaPlayer.js
@@ -2,9 +2,15 @@ import MediaPlayer from '../../../../MediaPlayer';
 import React from 'react';
 
 const MediaPlayerTests = [
-	<MediaPlayer />,
-	<MediaPlayer paused />,
-	<MediaPlayer shuffle />
+	<MediaPlayer>
+		<source src="https://sampleswap.org/mp3/artist/254731/BossPlayer_Your-Right-Here-160.mp3" type="audio/mp3" />
+	</MediaPlayer>,
+	<MediaPlayer paused>
+		<source src="https://sampleswap.org/mp3/artist/254731/BossPlayer_Your-Right-Here-160.mp3" type="audio/mp3" />
+	</MediaPlayer>,
+	<MediaPlayer shuffle>
+		<source src="https://sampleswap.org/mp3/artist/254731/BossPlayer_Your-Right-Here-160.mp3" type="audio/mp3" />
+	</MediaPlayer>
 ];
 
 export default MediaPlayerTests;

--- a/tests/screenshot/apps/components/MediaPlayer.js
+++ b/tests/screenshot/apps/components/MediaPlayer.js
@@ -1,0 +1,8 @@
+import MediaPlayer from '../../../../MediaPlayer';
+import React from 'react';
+
+const MediaPlayerTests = [
+	<MediaPlayer />
+];
+
+export default MediaPlayerTests;

--- a/tests/screenshot/apps/components/Picker.js
+++ b/tests/screenshot/apps/components/Picker.js
@@ -2,7 +2,9 @@ import Picker from '../../../../Picker';
 import React from 'react';
 
 const PickerTests = [
-	<Picker>{[]}</Picker>
+	<Picker>{[]}</Picker>,
+	<Picker disabled>{[]}</Picker>,
+	<Picker orientation="horizontal">{[]}</Picker>
 ];
 
 export default PickerTests;

--- a/tests/screenshot/apps/components/ProgressBar.js
+++ b/tests/screenshot/apps/components/ProgressBar.js
@@ -3,7 +3,8 @@ import React from 'react';
 
 const ProgressBarTests = [
 	<ProgressBar />,
-	<ProgressBar orientation="vertical" />
+	<ProgressBar orientation="vertical" />,
+	<ProgressBar progress={0.75} size="small" />
 ];
 
 export default ProgressBarTests;

--- a/tests/screenshot/apps/components/RangePicker.js
+++ b/tests/screenshot/apps/components/RangePicker.js
@@ -2,7 +2,9 @@ import RangePicker from '../../../../RangePicker';
 import React from 'react';
 
 const RangePickerTests = [
-	<RangePicker />
+	<RangePicker />,
+	<RangePicker orientation="horizontal"/>,
+	<RangePicker min={0} max={20} step={5}/>
 ];
 
 export default RangePickerTests;

--- a/tests/screenshot/apps/components/RangePicker.js
+++ b/tests/screenshot/apps/components/RangePicker.js
@@ -3,8 +3,8 @@ import React from 'react';
 
 const RangePickerTests = [
 	<RangePicker />,
-	<RangePicker orientation="horizontal"/>,
-	<RangePicker min={0} max={20} step={5}/>
+	<RangePicker orientation="horizontal" />,
+	<RangePicker min={0} max={20} step={5} />
 ];
 
 export default RangePickerTests;

--- a/tests/screenshot/apps/components/RangePicker.js
+++ b/tests/screenshot/apps/components/RangePicker.js
@@ -1,0 +1,8 @@
+import RangePicker from '../../../../RangePicker';
+import React from 'react';
+
+const RangePickerTests = [
+	<RangePicker />
+];
+
+export default RangePickerTests;

--- a/tests/screenshot/apps/components/Slider.js
+++ b/tests/screenshot/apps/components/Slider.js
@@ -2,7 +2,9 @@ import Slider from '../../../../Slider';
 import React from 'react';
 
 const SliderTests = [
-	<Slider />
+	<Slider />,
+	<Slider active />,
+	<Slider min={0} max={20} progressAnchor={0.4}/>
 ];
 
 export default SliderTests;

--- a/tests/screenshot/apps/components/Slider.js
+++ b/tests/screenshot/apps/components/Slider.js
@@ -4,7 +4,7 @@ import React from 'react';
 const SliderTests = [
 	<Slider />,
 	<Slider active />,
-	<Slider min={0} max={20} progressAnchor={0.4}/>
+	<Slider min={0} max={20} progressAnchor={0.4} />
 ];
 
 export default SliderTests;

--- a/tests/screenshot/apps/components/SliderButton.js
+++ b/tests/screenshot/apps/components/SliderButton.js
@@ -1,0 +1,8 @@
+import SliderButton from '../../../../SliderButton';
+import React from 'react';
+
+const SliderButtonTests = [
+	<SliderButton>{[]}</SliderButton>
+];
+
+export default SliderButtonTests;

--- a/tests/screenshot/apps/components/SliderButton.js
+++ b/tests/screenshot/apps/components/SliderButton.js
@@ -2,7 +2,8 @@ import SliderButton from '../../../../SliderButton';
 import React from 'react';
 
 const SliderButtonTests = [
-	<SliderButton>{[]}</SliderButton>
+	<SliderButton>{[]}</SliderButton>,
+	<SliderButton disabled>{[]}</SliderButton>
 ];
 
 export default SliderButtonTests;

--- a/tests/screenshot/apps/components/SliderButton.js
+++ b/tests/screenshot/apps/components/SliderButton.js
@@ -2,8 +2,8 @@ import SliderButton from '../../../../SliderButton';
 import React from 'react';
 
 const SliderButtonTests = [
-	<SliderButton>{[]}</SliderButton>,
-	<SliderButton disabled>{[]}</SliderButton>
+	<SliderButton>{['First', 'Second', 'Third']}</SliderButton>,
+	<SliderButton disabled>{['First', 'Second', 'Third']}</SliderButton>
 ];
 
 export default SliderButtonTests;

--- a/tests/screenshot/apps/components/TimePicker.js
+++ b/tests/screenshot/apps/components/TimePicker.js
@@ -2,7 +2,9 @@ import TimePicker from '../../../../TimePicker';
 import React from 'react';
 
 const TimePickerTests = [
-	<TimePicker />
+	<TimePicker />,
+	<TimePicker disabled />,
+	<TimePicker value={new Date()} />
 ];
 
 export default TimePickerTests;

--- a/tests/screenshot/apps/components/TimePicker.js
+++ b/tests/screenshot/apps/components/TimePicker.js
@@ -1,0 +1,8 @@
+import TimePicker from '../../../../TimePicker';
+import React from 'react';
+
+const TimePickerTests = [
+	<TimePicker />
+];
+
+export default TimePickerTests;

--- a/tests/screenshot/apps/components/ToggleButton.js
+++ b/tests/screenshot/apps/components/ToggleButton.js
@@ -2,7 +2,9 @@ import ToggleButton from '../../../../ToggleButton';
 import React from 'react';
 
 const ToggleButtonTests = [
-	<ToggleButton />
+	<ToggleButton>Click me!</ToggleButton>,
+	<ToggleButton underline>Click me!</ToggleButton>,
+	<ToggleButton size="small">Click me!</ToggleButton>
 ];
 
 export default ToggleButtonTests;

--- a/tests/screenshot/apps/importer.js
+++ b/tests/screenshot/apps/importer.js
@@ -1,4 +1,7 @@
+import BodyText from '../../../BodyText';
 import Button from '../../../Button';
+import ColorPicker from '../../../ColorPicker';
+import DatePicker from '../../../DatePicker';
 import DateTimePicker from '../../../DateTimePicker';
 import Heading from '../../../Heading';
 import IncrementSlider from '../../../IncrementSlider';
@@ -7,16 +10,23 @@ import Icon from '../../../Icon';
 import Item from '../../../Item';
 import LabeledIcon from '../../../LabeledIcon';
 import LabeledIconButton from '../../../LabeledIconButton';
+import MediaPlayer from '../../../MediaPlayer';
 import ProgressBar from '../../../ProgressBar';
 import Popup from '../../../Popup';
 import Picker from '../../../Picker';
 import RadioItem from '../../../RadioItem';
+import RangePicker from '../../../RangePicker';
 import Slider from '../../../Slider';
+import SliderButton from '../../../SliderButton';
 import SwitchItem from '../../../SwitchItem';
+import TimePicker from '../../../TimePicker';
 import ToggleButton from '../../../ToggleButton';
 
 const AgateExports = {
+	BodyText,
 	Button,
+	ColorPicker,
+	DatePicker,
 	DateTimePicker,
 	Heading,
 	IncrementSlider,
@@ -25,12 +35,16 @@ const AgateExports = {
 	Item,
 	LabeledIcon,
 	LabeledIconButton,
+	MediaPlayer,
 	ProgressBar,
 	Popup,
 	Picker,
 	RadioItem,
+	RangePicker,
 	Slider,
+	SliderButton,
 	SwitchItem,
+	TimePicker,
 	ToggleButton
 };
 


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Agate - added more component views for screenshot test (new: BodyText, ColorPicker, DatePicker, MediaPlayer, RangePicker, SliderButton, TimePicker; modified: ToggleButton)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
* Root Cause
=> There were only 16 component views for screenshot test in https://github.com/enactjs/agate/tree/develop/tests/screenshot/apps/components. But there are 45 public ui components.
 Solution -> Added more component views for screenshot test

### Links
[//]: # (Related issues, references)
PLAT-122911

### Comments