### PR TITLE
PLAT-123186: Heading -  Added `spacing`  support for Gallium and Silicon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 ## [unreleased]
  
 ### Fixed
+- `agate/Heading` to support `spacing` gor Gallium and Silicon
 - `agate/IncrementSlider` button color for Gallium skin
 - `agate/Panels` to show close button properly for night mode
 - `agate/LabeledIconButton` max-width so that huge sized icon will not be cut off

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 ## [unreleased]
  
 ### Fixed
-- `agate/Heading` to support `spacing` gor Gallium and Silicon
+- `agate/Heading` to support `spacing` for Gallium and Silicon
 - `agate/IncrementSlider` button color for Gallium skin
 - `agate/Panels` to show close button properly for night mode
 - `agate/LabeledIconButton` max-width so that huge sized icon will not be cut off

--- a/samples/sampler/stories/default/Heading.js
+++ b/samples/sampler/stories/default/Heading.js
@@ -39,9 +39,6 @@ storiesOf('Agate', module)
 						This <a href="https://enactjs.com/docs/modules/ui/BodyText/">BodyText</a> component is rendered immediately after the Heading component and is<br />
 						meant to provide a visual indicator of the effects of changing the <code>spacing</code> prop.
 						<span className={css.spacingNote}>
-							<br />
-							<strong>Note</strong>: The <code>spacing</code> prop will have no effect when using the Gallium or Silicon skin.
-							<br />
 							Choose a different skin from the Global Knobs to see!
 						</span>
 						{(knobProps.size === 'title' || typeof knobProps.color === 'undefined') ? null : (

--- a/samples/sampler/stories/default/Heading.js
+++ b/samples/sampler/stories/default/Heading.js
@@ -40,7 +40,7 @@ storiesOf('Agate', module)
 						meant to provide a visual indicator of the effects of changing the <code>spacing</code> prop.
 						<span className={css.spacingNote}>
 							<br />
-							<strong>Note</strong>: The <code>spacing</code> prop will have no effect when using the Gallium skin.
+							<strong>Note</strong>: The <code>spacing</code> prop will have no effect when using the Gallium or Silicon skin.
 							<br />
 							Choose a different skin from the Global Knobs to see!
 						</span>

--- a/styles/colors-electro.less
+++ b/styles/colors-electro.less
@@ -8,7 +8,7 @@
 @agate-accent-s: var(--agate-accent-s, 98%);
 @agate-accent-l: var(--agate-accent-l, 48%);
 @agate-highlight: var(--agate-highlight-color, #ff8100);
-@agate-background: @agate-white;
+@agate-background: transparent;
 @agate-foreground: ~"hsla(var(--agate-accent-h, 0), var(--agate-accent-s, 0), var(--agate-accent-l, 0), 0.8)";
 @agate-background-active: ~"hsla(var(--agate-accent-h, 0), var(--agate-accent-s, 0), var(--agate-accent-l, 0), 0.5)";
 @agate-foreground-active: @agate-foreground;
@@ -126,7 +126,6 @@
 
 // Panels
 // ---------------------------------------
-@agate-panels-bg-color:               @agate-background;
 @agate-panels-partial-bg-color:       @agate-bg-color;
 @agate-panels-tab-separator-border-color: transparent;
 @agate-panels-tab-color:              @agate-text-color;

--- a/styles/colors-electro.less
+++ b/styles/colors-electro.less
@@ -8,7 +8,7 @@
 @agate-accent-s: var(--agate-accent-s, 98%);
 @agate-accent-l: var(--agate-accent-l, 48%);
 @agate-highlight: var(--agate-highlight-color, #ff8100);
-@agate-background: transparent;
+@agate-background: @agate-white;
 @agate-foreground: ~"hsla(var(--agate-accent-h, 0), var(--agate-accent-s, 0), var(--agate-accent-l, 0), 0.8)";
 @agate-background-active: ~"hsla(var(--agate-accent-h, 0), var(--agate-accent-s, 0), var(--agate-accent-l, 0), 0.5)";
 @agate-foreground-active: @agate-foreground;
@@ -126,6 +126,7 @@
 
 // Panels
 // ---------------------------------------
+@agate-panels-bg-color:               @agate-background;
 @agate-panels-partial-bg-color:       @agate-bg-color;
 @agate-panels-tab-separator-border-color: transparent;
 @agate-panels-tab-color:              @agate-text-color;

--- a/styles/variables-base.less
+++ b/styles/variables-base.less
@@ -242,9 +242,9 @@
 @agate-heading-margin: 0 @agate-spotlight-outset (1.5 * @agate-spotlight-outset) @agate-spotlight-outset;
 @agate-heading-padding: 0;
 @agate-heading-spacing-title: 0;
-@agate-heading-spacing-medium: 18px;
-@agate-heading-spacing-small: 12px;
-@agate-heading-spacing-large: 24px;
+@agate-heading-spacing-small: @agate-component-spacing;
+@agate-heading-spacing-medium: @agate-component-spacing + 6px;
+@agate-heading-spacing-large: @agate-component-spacing + 12px;
 @agate-heading-text-transform: none;
 @agate-heading-showline-padding: 12px;
 @agate-heading-letter-spacing: normal;

--- a/styles/variables-base.less
+++ b/styles/variables-base.less
@@ -243,8 +243,8 @@
 @agate-heading-padding: 0;
 @agate-heading-spacing-title: 0;
 @agate-heading-spacing-small: @agate-component-spacing;
-@agate-heading-spacing-medium: @agate-component-spacing + 6px;
-@agate-heading-spacing-large: @agate-component-spacing + 12px;
+@agate-heading-spacing-medium: (@agate-component-spacing + 6px);
+@agate-heading-spacing-large: (@agate-component-spacing + 12px);
 @agate-heading-text-transform: none;
 @agate-heading-showline-padding: 12px;
 @agate-heading-letter-spacing: normal;

--- a/styles/variables-base.less
+++ b/styles/variables-base.less
@@ -242,9 +242,9 @@
 @agate-heading-margin: 0 @agate-spotlight-outset (1.5 * @agate-spotlight-outset) @agate-spotlight-outset;
 @agate-heading-padding: 0;
 @agate-heading-spacing-title: 0;
-@agate-heading-spacing-medium: @agate-component-spacing;
-@agate-heading-spacing-small: inherit;
-@agate-heading-spacing-large: inherit;
+@agate-heading-spacing-medium: 18px;
+@agate-heading-spacing-small: 12px;
+@agate-heading-spacing-large: 24px;
 @agate-heading-text-transform: none;
 @agate-heading-showline-padding: 12px;
 @agate-heading-letter-spacing: normal;

--- a/styles/variables-carbon.less
+++ b/styles/variables-carbon.less
@@ -30,9 +30,6 @@
 
 // Heading
 // ---------------------------------------
-@agate-heading-spacing-large: 24px;
-@agate-heading-spacing-medium: 24px;
-@agate-heading-spacing-small: 12px;
 @agate-heading-title-decoration-height: 28px;
 @agate-heading-title-decoration-width: auto;
 @agate-heading-title-decoration-positions: auto 0 0.5em 100px;

--- a/styles/variables-cobalt.less
+++ b/styles/variables-cobalt.less
@@ -38,9 +38,6 @@
 
 // Heading
 // ---------------------------------------
-@agate-heading-spacing-large: 24px;
-@agate-heading-spacing-medium: 24px;
-@agate-heading-spacing-small: 12px;
 @agate-heading-title-padding: @agate-heading-padding 50px;
 @agate-heading-title-decoration-height: 28px;
 @agate-heading-title-decoration-width: auto;

--- a/styles/variables-copper.less
+++ b/styles/variables-copper.less
@@ -44,9 +44,6 @@
 
 // Heading
 // ---------------------------------------
-@agate-heading-spacing-large: 24px;
-@agate-heading-spacing-medium: 24px;
-@agate-heading-spacing-small: 12px;
 @agate-heading-title-padding: @agate-heading-padding 50px;
 @agate-heading-title-decoration-height: 28px;
 @agate-heading-title-decoration-width: auto;

--- a/styles/variables-electro.less
+++ b/styles/variables-electro.less
@@ -53,9 +53,6 @@
 
 // Heading
 // ---------------------------------------
-@agate-heading-spacing-large: 24px;
-@agate-heading-spacing-medium: 24px;
-@agate-heading-spacing-small: 12px;
 @agate-heading-title-padding: @agate-heading-padding 50px;
 @agate-heading-title-decoration-height: 28px;
 @agate-heading-title-decoration-width: auto;

--- a/styles/variables-gallium.less
+++ b/styles/variables-gallium.less
@@ -75,9 +75,6 @@
 // ---------------------------------------
 @agate-heading-padding: 3px 0;
 @agate-heading-medium-font-size: 30px;
-@agate-heading-spacing-large: 0;
-@agate-heading-spacing-medium: 0;
-@agate-heading-spacing-small: 0;
 @agate-heading-title-padding: @agate-heading-padding 25px;
 @agate-heading-title-decoration-height: 28px;
 @agate-heading-title-decoration-width: auto;

--- a/styles/variables-silicon.less
+++ b/styles/variables-silicon.less
@@ -120,9 +120,6 @@
 // ---------------------------------------
 @agate-heading-padding: 3px 0;
 @agate-heading-medium-font-size: 30px;
-@agate-heading-spacing-large: 0;
-@agate-heading-spacing-medium: 0;
-@agate-heading-spacing-small: 0;
 @agate-heading-title-padding: @agate-heading-padding 25px;
 @agate-heading-title-decoration-height: 28px;
 @agate-heading-title-decoration-width: auto;

--- a/styles/variables-titanium.less
+++ b/styles/variables-titanium.less
@@ -32,9 +32,6 @@
 
 // Heading
 // ---------------------------------------
-@agate-heading-spacing-large: 24px;
-@agate-heading-spacing-medium: 24px;
-@agate-heading-spacing-small: 12px;
 @agate-heading-title-padding: @agate-heading-padding 50px;
 @agate-heading-title-decoration-height: 28px;
 @agate-heading-title-decoration-width: auto;


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Daniel Stoian daniel.stoian@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Agate - In the Heading story, the 'spacing' prop had no effect for Silicon and Gallium skin. 
Added support for spacing for these 2 skins


### Links
[//]: # (Related issues, references)
PLAT-123186

### Comments