### PR TITLE
PLAT-123127: Fix to flip next and previous icons in RTL in TabbedPanels

### DIFF
--- a/samples/sampler/stories/default/TabbedPanels.js
+++ b/samples/sampler/stories/default/TabbedPanels.js
@@ -2,6 +2,7 @@ import {action} from '@enact/storybook-utils/addons/actions';
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {boolean, number, select} from '@enact/storybook-utils/addons/knobs';
 import React from 'react';
+import PropTypes from 'prop-types';
 import {storiesOf} from '@storybook/react';
 
 import Button from '@enact/agate/Button';
@@ -16,7 +17,7 @@ import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 const Config = mergeComponentMetadata('TabbedPanels', TabbedPanelsBase);
 // `paddingBottom: '56.25%'` is a trick to impose 16:9 aspect ratio on the component, since padding percentage is based on the width, not the height.
 
-const TabbpedPanelsBase = ({rtl}) => {
+const I18nTabbpedPanelsBase = ({rtl}) => {
 	const [panelIndex, setIndex] = React.useState(Config.defaultProps.index || 0);
 	const onSelect = (e) => {
 		setIndex(e.index);
@@ -48,7 +49,7 @@ const TabbpedPanelsBase = ({rtl}) => {
 				<beforeTabs>
 					<Button
 						aria-label={$L('Previous Tab')}
-						icon={rtl ? "arrowlargeright" : "arrowlargeleft"}
+						icon={rtl ? 'arrowlargeright' : 'arrowlargeleft'}
 						onClick={onBeforeTabs} // eslint-disable-line react/jsx-no-bind
 						size="small"
 						type="grid"
@@ -57,7 +58,7 @@ const TabbpedPanelsBase = ({rtl}) => {
 				<afterTabs>
 					<Button
 						aria-label={$L('Next Tab')}
-						icon={rtl ? "arrowlargeleft" : "arrowlargeright"}
+						icon={rtl ? 'arrowlargeleft' : 'arrowlargeright'}
 						onClick={onAfterTabs} // eslint-disable-line react/jsx-no-bind
 						size="small"
 						type="grid"
@@ -87,13 +88,17 @@ const TabbpedPanelsBase = ({rtl}) => {
 	);
 };
 
-const TabbpedPanels = I18nContextDecorator({rtlProp: 'rtl'}, TabbpedPanelsBase);
+I18nTabbpedPanelsBase.propTypes = {
+	rtl: PropTypes.bool
+};
+
+const I18nTabbpedPanels = I18nContextDecorator({rtlProp: 'rtl'}, I18nTabbpedPanelsBase);
 
 storiesOf('Agate', module)
-.add(
-	'TabbedPanels',
+	.add(
+		'TabbedPanels',
 		() => {
-			return <TabbpedPanels />
+			return <I18nTabbpedPanels />;
 		},
 		{
 			text: 'The basic TabbedPanels'

--- a/samples/sampler/stories/default/TabbedPanels.js
+++ b/samples/sampler/stories/default/TabbedPanels.js
@@ -17,7 +17,7 @@ import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 const Config = mergeComponentMetadata('TabbedPanels', TabbedPanelsBase);
 // `paddingBottom: '56.25%'` is a trick to impose 16:9 aspect ratio on the component, since padding percentage is based on the width, not the height.
 
-const I18nTabbpedPanelsBase = ({rtl}) => {
+const I18nTabbedPanelsBase = ({rtl}) => {
 	const [panelIndex, setIndex] = React.useState(Config.defaultProps.index || 0);
 	const onSelect = (e) => {
 		setIndex(e.index);
@@ -88,17 +88,17 @@ const I18nTabbpedPanelsBase = ({rtl}) => {
 	);
 };
 
-I18nTabbpedPanelsBase.propTypes = {
+I18nTabbedPanelsBase.propTypes = {
 	rtl: PropTypes.bool
 };
 
-const I18nTabbpedPanels = I18nContextDecorator({rtlProp: 'rtl'}, I18nTabbpedPanelsBase);
+const I18nTabbedPanels = I18nContextDecorator({rtlProp: 'rtl'}, I18nTabbedPanelsBase);
 
 storiesOf('Agate', module)
 	.add(
 		'TabbedPanels',
 		() => {
-			return <I18nTabbpedPanels />;
+			return <I18nTabbedPanels />;
 		},
 		{
 			text: 'The basic TabbedPanels'

--- a/samples/sampler/stories/default/TabbedPanels.js
+++ b/samples/sampler/stories/default/TabbedPanels.js
@@ -29,6 +29,7 @@ const I18nTabbedPanelsBase = ({rtl}) => {
 	const onAfterTabs = () => {
 		setIndex(Math.min(panelIndex + 1, 2));
 	};
+	const orientation = select('orientation', ['vertical', 'horizontal'], Config, 'vertical');
 
 	return (
 		<div style={{paddingBottom: '56.25%'}}>
@@ -38,7 +39,7 @@ const I18nTabbedPanelsBase = ({rtl}) => {
 				index={panelIndex}
 				noCloseButton={boolean('noCloseButton', Config)}
 				onSelect={onSelect} // eslint-disable-line react/jsx-no-bind
-				orientation={select('orientation', ['vertical', 'horizontal'], Config, 'vertical')}
+				orientation={orientation}
 				tabPosition={select('tabPosition', ['before', 'after'], Config, 'before')}
 				tabs={[
 					{title: 'Button', icon: 'netbook'},
@@ -49,7 +50,7 @@ const I18nTabbedPanelsBase = ({rtl}) => {
 				<beforeTabs>
 					<Button
 						aria-label={$L('Previous Tab')}
-						icon={rtl ? 'arrowlargeright' : 'arrowlargeleft'}
+						icon={orientation === 'vertical' ? (rtl && 'arrowlargeright' || 'arrowlargeleft') : 'arrowlargeup'}
 						onClick={onBeforeTabs} // eslint-disable-line react/jsx-no-bind
 						size="small"
 						type="grid"
@@ -58,7 +59,7 @@ const I18nTabbedPanelsBase = ({rtl}) => {
 				<afterTabs>
 					<Button
 						aria-label={$L('Next Tab')}
-						icon={rtl ? 'arrowlargeleft' : 'arrowlargeright'}
+						icon={orientation === 'vertical' ? (rtl && 'arrowlargeleft' || 'arrowlargeright') : 'arrowlargedown'}
 						onClick={onAfterTabs} // eslint-disable-line react/jsx-no-bind
 						size="small"
 						type="grid"

--- a/samples/sampler/stories/default/TabbedPanels.js
+++ b/samples/sampler/stories/default/TabbedPanels.js
@@ -98,9 +98,7 @@ const I18nTabbedPanels = I18nContextDecorator({rtlProp: 'rtl'}, I18nTabbedPanels
 storiesOf('Agate', module)
 	.add(
 		'TabbedPanels',
-		() => {
-			return <I18nTabbedPanels />;
-		},
+		() => (<I18nTabbedPanels />),
 		{
 			text: 'The basic TabbedPanels'
 		}

--- a/samples/sampler/stories/default/TabbedPanels.js
+++ b/samples/sampler/stories/default/TabbedPanels.js
@@ -11,81 +11,89 @@ import LabeledIconButton from '@enact/agate/LabeledIconButton';
 import {Panel, TabbedPanels} from '@enact/agate/Panels';
 import {TabbedPanelsBase} from '@enact/agate/Panels/TabbedPanels';
 import $L from '@enact/i18n/$L';
+import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 
 const Config = mergeComponentMetadata('TabbedPanels', TabbedPanelsBase);
 // `paddingBottom: '56.25%'` is a trick to impose 16:9 aspect ratio on the component, since padding percentage is based on the width, not the height.
 
-storiesOf('Agate', module)
-	.add(
-		'TabbedPanels',
-		() => {
-			const [panelIndex, setIndex] = React.useState(Config.defaultProps.index || 0);
-			const onSelect = (e) => {
-				setIndex(e.index);
-				action('onSelect')(e);
-			};
-			const onBeforeTabs = () => {
-				setIndex(Math.max(panelIndex - 1, 0));
-			};
-			const onAfterTabs = () => {
-				setIndex(Math.min(panelIndex + 1, 2));
-			};
-			return (
-				<div style={{paddingBottom: '56.25%'}}>
-					<TabbedPanels
-						duration={number('duration', Config, 500)}
-						onClick={action('onClick')}
-						index={panelIndex}
-						noCloseButton={boolean('noCloseButton', Config)}
-						onSelect={onSelect} // eslint-disable-line react/jsx-no-bind
-						orientation={select('orientation', ['vertical', 'horizontal'], Config, 'vertical')}
-						tabPosition={select('tabPosition', ['before', 'after'], Config, 'before')}
-						tabs={[
-							{title: 'Button', icon: 'netbook'},
-							{title: 'Item', icon: 'aircirculation'},
-							{title: 'LabeledIconButton', icon: 'temperature'}
-						]}
+const TabbpedPanelsBase = ({rtl}) => {
+	const [panelIndex, setIndex] = React.useState(Config.defaultProps.index || 0);
+	const onSelect = (e) => {
+		setIndex(e.index);
+		action('onSelect')(e);
+	};
+	const onBeforeTabs = () => {
+		setIndex(Math.max(panelIndex - 1, 0));
+	};
+	const onAfterTabs = () => {
+		setIndex(Math.min(panelIndex + 1, 2));
+	};
+
+	return (
+		<div style={{paddingBottom: '56.25%'}}>
+			<TabbedPanels
+				duration={number('duration', Config, 500)}
+				onClick={action('onClick')}
+				index={panelIndex}
+				noCloseButton={boolean('noCloseButton', Config)}
+				onSelect={onSelect} // eslint-disable-line react/jsx-no-bind
+				orientation={select('orientation', ['vertical', 'horizontal'], Config, 'vertical')}
+				tabPosition={select('tabPosition', ['before', 'after'], Config, 'before')}
+				tabs={[
+					{title: 'Button', icon: 'netbook'},
+					{title: 'Item', icon: 'aircirculation'},
+					{title: 'LabeledIconButton', icon: 'temperature'}
+				]}
+			>
+				<beforeTabs>
+					<Button
+						aria-label={$L('Previous Tab')}
+						icon={rtl ? "arrowlargeright" : "arrowlargeleft"}
+						onClick={onBeforeTabs} // eslint-disable-line react/jsx-no-bind
+						size="small"
+						type="grid"
+					/>
+				</beforeTabs>
+				<afterTabs>
+					<Button
+						aria-label={$L('Next Tab')}
+						icon={rtl ? "arrowlargeleft" : "arrowlargeright"}
+						onClick={onAfterTabs} // eslint-disable-line react/jsx-no-bind
+						size="small"
+						type="grid"
+					/>
+				</afterTabs>
+				<Panel>
+					<Button icon="netbook">Click me!</Button>
+				</Panel>
+				<Panel>
+					<Item label="label" labelPosition="before" slotBefore={<Icon>aircirculation</Icon>}>Hello Item</Item>
+				</Panel>
+				<Panel className="enact-fit">
+					<LabeledIconButton
+						labelPosition="after"
+						icon="temperature"
 					>
-						<beforeTabs>
-							<Button
-								aria-label={$L('Previous Tab')}
-								icon="arrowlargeleft"
-								onClick={onBeforeTabs} // eslint-disable-line react/jsx-no-bind
-								size="small"
-								type="grid"
-							/>
-						</beforeTabs>
-						<afterTabs>
-							<Button
-								aria-label={$L('Next Tab')}
-								icon="arrowlargeright"
-								onClick={onAfterTabs} // eslint-disable-line react/jsx-no-bind
-								size="small"
-								type="grid"
-							/>
-						</afterTabs>
-						<Panel>
-							<Button icon="netbook">Click me!</Button>
-						</Panel>
-						<Panel>
-							<Item label="label" labelPosition="before" slotBefore={<Icon>aircirculation</Icon>}>Hello Item</Item>
-						</Panel>
-						<Panel className="enact-fit">
-							<LabeledIconButton
-								labelPosition="after"
-								icon="temperature"
-							>
-								Hello LabeledIconButton
-							</LabeledIconButton>
-						</Panel>
-						<Panel>
-							<div>
-								A simple view with no associated tab
-							</div>
-						</Panel>
-					</TabbedPanels>
-				</div>
-			);
+						Hello LabeledIconButton
+					</LabeledIconButton>
+				</Panel>
+				<Panel>
+					<div>
+						A simple view with no associated tab
+					</div>
+				</Panel>
+			</TabbedPanels>
+		</div>
+	);
+};
+
+const TabbpedPanels = I18nContextDecorator({rtlProp: 'rtl'}, TabbpedPanelsBase);
+
+storiesOf('Agate', module)
+.add(
+	'TabbedPanels',
+		() => {
+			return <TabbpedPanels />
 		},
 		{
 			text: 'The basic TabbedPanels'


### PR DESCRIPTION
Depending on the `rtl` prop from `I18nContextDecorator` and the `orientation` prop in TabbedPanels, the next and previous icons shows properly in it.

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)