### PR TITLE
PLAT-124529: Fixed title in PopupMenu to be distinguishable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 - `agate/Heading` to support `spacing` for Gallium and Silicon
 - `agate/IncrementSlider` button color for Gallium skin
 - `agate/Panels` to show close button properly for night mode
+- `agate/PopupMenu` to display distinguishable title
 - `agate/LabeledIconButton` max-width so that huge sized icon will not be cut off
 - `agate/Spinner` to pause the animation when `paused` prop is true
 - `agate/Picker` picker item width in horizontal for silicon

--- a/Heading/Heading.js
+++ b/Heading/Heading.js
@@ -83,7 +83,8 @@ const HeadingBase = kind({
 
 	styles: {
 		css: componentCss,
-		className: 'heading'
+		className: 'heading',
+		publicClassNames: true
 	},
 
 	computed: {

--- a/PopupMenu/PopupMenu.js
+++ b/PopupMenu/PopupMenu.js
@@ -85,7 +85,7 @@ const PopupMenuBase = kind({
 			>
 				<Layout orientation="vertical" align="center center" role="alert" {...rest}>
 					<Cell className={css.title} shrink>
-						<Heading size="title">{title}</Heading>
+						<Heading css={css} size="title">{title}</Heading>
 					</Cell>
 					<Cell shrink className={css.body} align="stretch">
 						<Scroller direction={orientation} horizontalScrollbar="hidden" verticalScrollbar="hidden">

--- a/PopupMenu/PopupMenu.module.less
+++ b/PopupMenu/PopupMenu.module.less
@@ -12,6 +12,10 @@
 
 		.title {
 			margin: @agate-popupmenu-title-margin;
+
+			.heading {
+				color: @agate-popupmenu-title-color;
+			}
 		}
 
 		&.horizontal .body {

--- a/styles/colors-base.less
+++ b/styles/colors-base.less
@@ -303,6 +303,7 @@
 // ---------------------------------------
 @agate-popupmenu-bg-color: inherit;
 @agate-popupmenu-bg-image: inherit;
+@agate-popupmenu-title-color: @agate-white;
 
 // ProgressBar
 // ---------------------------------------

--- a/tests/screenshot/apps/components/PopupMenu.js
+++ b/tests/screenshot/apps/components/PopupMenu.js
@@ -2,9 +2,9 @@ import PopupMenu from '../../../../PopupMenu';
 import React from 'react';
 
 const PopupMenuTests = [
-	<PopupMenu open>PopupMenu!</PopupMenu>,
-	<PopupMenu closeButton open>PopupMenu!</PopupMenu>,
-	<PopupMenu open scrimType="transparent">PopupMenu!</PopupMenu>
+	<PopupMenu open title="Title">PopupMenu!</PopupMenu>,
+	<PopupMenu closeButton open title="Title">PopupMenu!</PopupMenu>,
+	<PopupMenu open scrimType="transparent" title="Title">PopupMenu!</PopupMenu>
 ];
 
 export default PopupMenuTests;


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Adrian Cocoara adrian.cocoara@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Issue: The title in `PopupMenu` is not distinguishable

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Solution: Added `publicClassNames` in `Heading` component so I can overwrite the style for color in `PopupMenu` component

### Links
[//]: # (Related issues, references)
PLAT-124529

### Comments