### PR TITLE
PLAT-124541: Fixed close button position for Panels

### DIFF
--- a/styles/variables-base.less
+++ b/styles/variables-base.less
@@ -414,12 +414,12 @@
 // Panels
 // ---------------------------------------
 @agate-panel-v-padding: @agate-app-keepout;
-@agate-panel-h-padding: inherit;
+@agate-panel-h-padding: 50px;
 @agate-panels-partial-height: auto;
 @agate-panels-partial-width: 50%;
 @agate-panels-breadcrumb-height: 100%;
 @agate-panels-breadcrumb-width: 100px;
-@agate-panels-controls-top: inherit;
+@agate-panels-controls-top: 48px;
 @agate-panels-controls-padding-start: inherit;
 @agate-panels-panel-padding: inherit;
 @agate-panels-panel-header-padding: @agate-panels-panel-padding;

--- a/styles/variables-base.less
+++ b/styles/variables-base.less
@@ -419,7 +419,7 @@
 @agate-panels-partial-width: 50%;
 @agate-panels-breadcrumb-height: 100%;
 @agate-panels-breadcrumb-width: 100px;
-@agate-panels-controls-top: 48px;
+@agate-panels-controls-top: (@agate-component-spacing + 36px);
 @agate-panels-controls-padding-start: inherit;
 @agate-panels-panel-padding: inherit;
 @agate-panels-panel-header-padding: @agate-panels-panel-padding;

--- a/styles/variables-base.less
+++ b/styles/variables-base.less
@@ -414,7 +414,7 @@
 // Panels
 // ---------------------------------------
 @agate-panel-v-padding: @agate-app-keepout;
-@agate-panel-h-padding: 50px;
+@agate-panel-h-padding: 51px;
 @agate-panels-partial-height: auto;
 @agate-panels-partial-width: 50%;
 @agate-panels-breadcrumb-height: 100%;

--- a/styles/variables-carbon.less
+++ b/styles/variables-carbon.less
@@ -40,6 +40,8 @@
 
 // Panels
 // ---------------------------------------
+@agate-panel-h-padding: 99px;
+@agate-panels-controls-top: 6px;
 @agate-panels-partial-height: 50%;
 @agate-panels-partial-width: auto;
 @agate-panels-tab-margin: 0;

--- a/styles/variables-carbon.less
+++ b/styles/variables-carbon.less
@@ -41,7 +41,7 @@
 // Panels
 // ---------------------------------------
 @agate-panel-h-padding: 99px;
-@agate-panels-controls-top: 6px;
+@agate-panels-controls-top: (@agate-component-spacing - 6px);
 @agate-panels-partial-height: 50%;
 @agate-panels-partial-width: auto;
 @agate-panels-tab-margin: 0;

--- a/styles/variables-electro.less
+++ b/styles/variables-electro.less
@@ -64,7 +64,7 @@
 
 // Panels
 // ---------------------------------------
-@agate-panels-controls-top: 33px;
+@agate-panels-controls-top: (@agate-component-spacing + 21px);
 @agate-panels-panel-padding: @agate-component-spacing;
 @agate-panels-tab-bar-margin: 0;
 @agate-panels-tab-bg-position: 0;

--- a/styles/variables-electro.less
+++ b/styles/variables-electro.less
@@ -64,6 +64,7 @@
 
 // Panels
 // ---------------------------------------
+@agate-panels-controls-top: 33px;
 @agate-panels-panel-padding: @agate-component-spacing;
 @agate-panels-tab-bar-margin: 0;
 @agate-panels-tab-bg-position: 0;

--- a/styles/variables-gallium.less
+++ b/styles/variables-gallium.less
@@ -160,12 +160,12 @@
 // Panels
 // ---------------------------------------
 // @agate-panel-h-padding: (@agate-app-keepout - @agate-spotlight-outset);
+@agate-panels-panel-padding: 51px 60px 51px 39px;
 @agate-panel-h-padding: extract(@agate-panels-panel-padding, 2);
 @agate-panels-partial-width: 890px;
 @agate-panels-breadcrumb-width: 105px;
 @agate-panels-controls-top: (extract(@agate-panels-panel-padding, 1) - 3px);
 @agate-panels-controls-padding-start: 18px;
-@agate-panels-panel-padding: 51px 60px 51px 39px;
 @agate-panels-panel-header-padding: 0;
 @agate-panels-panel-body-padding: 0;
 @agate-panels-tab-margin: 0;

--- a/styles/variables-gallium.less
+++ b/styles/variables-gallium.less
@@ -163,9 +163,9 @@
 @agate-panel-h-padding: extract(@agate-panels-panel-padding, 2);
 @agate-panels-partial-width: 890px;
 @agate-panels-breadcrumb-width: 105px;
-@agate-panels-controls-top: (extract(@agate-panels-panel-padding, 1) - 2px);
+@agate-panels-controls-top: (extract(@agate-panels-panel-padding, 1) - 3px);
 @agate-panels-controls-padding-start: 18px;
-@agate-panels-panel-padding: 50px 60px 50px 40px;
+@agate-panels-panel-padding: 51px 60px 51px 39px;
 @agate-panels-panel-header-padding: 0;
 @agate-panels-panel-body-padding: 0;
 @agate-panels-tab-margin: 0;

--- a/styles/variables-gallium.less
+++ b/styles/variables-gallium.less
@@ -163,7 +163,7 @@
 @agate-panel-h-padding: extract(@agate-panels-panel-padding, 2);
 @agate-panels-partial-width: 890px;
 @agate-panels-breadcrumb-width: 105px;
-@agate-panels-controls-top: (extract(@agate-panels-panel-padding, 1) + 41px);
+@agate-panels-controls-top: (extract(@agate-panels-panel-padding, 1) - 2px);
 @agate-panels-controls-padding-start: 18px;
 @agate-panels-panel-padding: 50px 60px 50px 40px;
 @agate-panels-panel-header-padding: 0;

--- a/styles/variables-silicon.less
+++ b/styles/variables-silicon.less
@@ -232,7 +232,7 @@
 @agate-panel-h-padding: extract(@agate-panels-panel-padding, 2);
 @agate-panels-partial-width: 890px;
 @agate-panels-breadcrumb-width: 105px;
-@agate-panels-controls-top: (extract(@agate-panels-panel-padding, 1) + 41px);
+@agate-panels-controls-top: (extract(@agate-panels-panel-padding, 1) - 17px);
 @agate-panels-controls-padding-start: 18px;
 @agate-panels-panel-padding: 50px 60px 50px 40px;
 @agate-panels-panel-header-padding: 0;

--- a/styles/variables-silicon.less
+++ b/styles/variables-silicon.less
@@ -229,12 +229,12 @@
 // Panels
 // ---------------------------------------
 // @agate-panel-h-padding: (@agate-app-keepout - @agate-spotlight-outset);
+@agate-panels-panel-padding: 51px 60px 51px 39px;
 @agate-panel-h-padding: extract(@agate-panels-panel-padding, 2);
 @agate-panels-partial-width: 888px;
 @agate-panels-breadcrumb-width: 105px;
 @agate-panels-controls-top: (extract(@agate-panels-panel-padding, 1) - 15px);
 @agate-panels-controls-padding-start: 18px;
-@agate-panels-panel-padding: 51px 60px 51px 39px;
 @agate-panels-panel-header-padding: 0;
 @agate-panels-panel-body-padding: 0;
 @agate-panels-tab-margin: 0;

--- a/styles/variables-silicon.less
+++ b/styles/variables-silicon.less
@@ -230,11 +230,11 @@
 // ---------------------------------------
 // @agate-panel-h-padding: (@agate-app-keepout - @agate-spotlight-outset);
 @agate-panel-h-padding: extract(@agate-panels-panel-padding, 2);
-@agate-panels-partial-width: 890px;
+@agate-panels-partial-width: 888px;
 @agate-panels-breadcrumb-width: 105px;
-@agate-panels-controls-top: (extract(@agate-panels-panel-padding, 1) - 17px);
+@agate-panels-controls-top: (extract(@agate-panels-panel-padding, 1) - 15px);
 @agate-panels-controls-padding-start: 18px;
-@agate-panels-panel-padding: 50px 60px 50px 40px;
+@agate-panels-panel-padding: 51px 60px 51px 39px;
 @agate-panels-panel-header-padding: 0;
 @agate-panels-panel-body-padding: 0;
 @agate-panels-tab-margin: 0;


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Adrian Cocoara adrian.cocoara@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Issue: Close button for every sampler is overlapped with the component

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Solution: Modified the `top` property of panel's controls to move a little bit more to the top

### Links
[//]: # (Related issues, references)
PLAT-124541

### Comments