### PR TITLE
PLAT-125453: Replace TabbedPanels with Scroller for qa-a11y menu

### DIFF
--- a/samples/qa-a11y/src/App/App.js
+++ b/samples/qa-a11y/src/App/App.js
@@ -1,6 +1,5 @@
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import Item from '@enact/agate/Item';
-import {Panel, TabbedPanels} from '@enact/agate/Panels';
 import ThemeDecorator from '@enact/agate/ThemeDecorator';
 import Spotlight from '@enact/spotlight';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
@@ -114,13 +113,6 @@ const views = [
 	{title: 'WindDirectionControl', view: WindDirectionControl}
 ];
 
-const tabTitles = [
-	{title: 'A-G'},
-	{title: 'H-N'},
-	{title: 'O-S'},
-	{title: 'T-Z'}
-];
-
 class AppBase extends React.Component {
 	static propTypes = {
 		rtl: PropTypes.bool,
@@ -135,33 +127,6 @@ class AppBase extends React.Component {
 			jumpToView: '',
 			selected: 0
 		};
-
-		this.viewItems = [];
-		this.viewItems.length = tabTitles.length;
-
-		views.forEach((view, indexInViews) => {
-			const item = (
-				<Item
-					aria-label={view.title}
-					className={appCss.navItem}
-					data-menu={indexInViews}
-					key={indexInViews}
-					onClick={this.handleChangeView(indexInViews)}
-					slotBefore={<div className={appCss.slotBefore}>{('00' + indexInViews).slice(-2)}</div>}
-				>
-					{view.title}
-				</Item>
-			);
-
-			const indexInPanels = indexInViews < 2 ?
-				0 :
-				tabTitles.findIndex(({title}) => {
-					return view.title[0] <= title[title.length - 1];
-				});
-
-			this.viewItems[indexInPanels] = this.viewItems[indexInPanels] || [];
-			this.viewItems[indexInPanels].push(item);
-		});
 	}
 
 	componentDidMount () {
@@ -216,14 +181,18 @@ class AppBase extends React.Component {
 				<Layout {...rest} className={appCss.layout}>
 					<Cell component={Menu} id="menu" size="20%" spotlightId="menu">
 						<div className={appCss.jumpToView}>Jump To, View: {jumpToView}</div>
-						<TabbedPanels
-							noAnimation
-							noCloseButton
-							orientation="vertical"
-							tabs={tabTitles}
-						>
-							{this.viewItems.map((items, index) => <Panel key={index} style={{padding: 0}}>{items}</Panel>)}
-						</TabbedPanels>
+						{views.map((view, i) => (
+							<Item
+								aria-label={view.title}
+								className={appCss.navItem}
+								data-menu={i}
+								key={i}
+								onClick={this.handleChangeView(i)}
+								slotBefore={('00' + i).slice(-2)}
+							>
+								{view.title}
+							</Item>
+						))}
 					</Cell>
 					<Cell component={ViewManager} index={selected}>
 						{views.map((view, i) => (

--- a/samples/qa-a11y/src/App/App.js
+++ b/samples/qa-a11y/src/App/App.js
@@ -1,5 +1,6 @@
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import Item from '@enact/agate/Item';
+import Scroller from '@enact/agate/Scroller';
 import ThemeDecorator from '@enact/agate/ThemeDecorator';
 import Spotlight from '@enact/spotlight';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
@@ -41,7 +42,7 @@ import ProgressBar from '../views/ProgressBar';
 import RadioItem from '../views/RadioItem';
 import RangePicker from '../views/RangePicker';
 import ReadAlert from '../views/ReadAlert';
-import Scroller from '../views/Scroller';
+import ScrollerView from '../views/Scroller';
 import Slider from '../views/Slider';
 import SliderButton from '../views/SliderButton';
 import Spinner from '../views/Spinner';
@@ -96,7 +97,7 @@ const views = [
 	{title: 'RadioItem', view: RadioItem},
 	{title: 'RangePicker', view: RangePicker},
 	{title: 'ReadAlert', view: ReadAlert},
-	{isHeader: false, title: 'Scroller', view: Scroller},
+	{isHeader: false, title: 'Scroller', view: ScrollerView},
 	{title: 'Slider', view: Slider},
 	{title: 'SliderButton', view: SliderButton},
 	{title: 'Spinner', view: Spinner},
@@ -172,6 +173,18 @@ class AppBase extends React.Component {
 		const {className, ...rest} = this.props;
 		const {isDebugMode, jumpToView, selected} = this.state;
 		const debugAriaClass = isDebugMode ? 'aria debug' : null;
+		const menu = views.map((view, i) => (
+			<Item
+				aria-label={view.title}
+				className={appCss.navItem}
+				data-menu={i}
+				key={i}
+				onClick={this.handleChangeView(i)}
+				slotBefore={('00' + i).slice(-2)}
+			>
+				{view.title}
+			</Item>
+		));
 
 		delete rest.rtl;
 		delete rest.updateLocale;
@@ -180,19 +193,10 @@ class AppBase extends React.Component {
 			<div className={classnames(className, debugAriaClass, appCss.app)}>
 				<Layout {...rest} className={appCss.layout}>
 					<Cell component={Menu} id="menu" size="20%" spotlightId="menu">
-						<div className={appCss.jumpToView}>Jump To, View: {jumpToView}</div>
-						{views.map((view, i) => (
-							<Item
-								aria-label={view.title}
-								className={appCss.navItem}
-								data-menu={i}
-								key={i}
-								onClick={this.handleChangeView(i)}
-								slotBefore={('00' + i).slice(-2)}
-							>
-								{view.title}
-							</Item>
-						))}
+						<div className={appCss.jumpToView}>Jump To View: {jumpToView}</div>
+						<Scroller className={appCss.scroller}>
+							{menu}
+						</Scroller>
 					</Cell>
 					<Cell component={ViewManager} index={selected}>
 						{views.map((view, i) => (

--- a/samples/qa-a11y/src/App/App.module.less
+++ b/samples/qa-a11y/src/App/App.module.less
@@ -20,6 +20,10 @@ h2 {
 	font-size: 36px;
 }
 
+.scroller {
+	height: calc(100% - 60px)
+}
+
 .layout {
 	height: 100%;
 }

--- a/samples/qa-a11y/src/App/App.module.less
+++ b/samples/qa-a11y/src/App/App.module.less
@@ -16,9 +16,6 @@ h2 {
 }
 
 .jumpToView {
-	position: absolute;
-	bottom: 0;
-	z-index: 1;
 	height: 60px;
 	font-size: 36px;
 }
@@ -28,13 +25,16 @@ h2 {
 }
 
 .navItem {
-	height: 60px;
+	height: 36px;
+	margin: 0;
+
 	& > div {
-		font-size: 24px;
+		font-size: 21px;
 	}
 
-	.slotBefore {
-		width: 40px;
+	& > div:first-child {
+		position: absolute;
+		left: 1px;
 	}
 }
 


### PR DESCRIPTION
Replace TabbedPanels with Scroller for qa-a11y menu because it is better to search and select a menu.

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)