### PR TITLE
PLAT-127764: Fix Keypad, MediaPlayer, and ToggleButton to have proper width

### DIFF
--- a/Button/Button.js
+++ b/Button/Button.js
@@ -317,7 +317,6 @@ const IconButtonDecorator = hoc((config, Wrapped) => {
 		},
 
 		render: (props) => {
-			console.log(props.iconOnly);
 			return (
 				<Wrapped {...props} />
 			);

--- a/Button/Button.js
+++ b/Button/Button.js
@@ -275,7 +275,7 @@ const ButtonBase = kind({
 			'--agate-button-animation-delay': animationDelay,
 			'--agate-button-badge-bg-color': badgeColor
 		}),
-		minWidth: ({iconOnly, minWidth}) => ((minWidth != null) ? minWidth : !iconOnly)
+		minWidth: ({minWidth}) => ((minWidth != null) ? minWidth : false)
 	},
 
 	render: ({css, ...rest}) => {
@@ -317,6 +317,7 @@ const IconButtonDecorator = hoc((config, Wrapped) => {
 		},
 
 		render: (props) => {
+			console.log(props.iconOnly);
 			return (
 				<Wrapped {...props} />
 			);

--- a/Button/Button.js
+++ b/Button/Button.js
@@ -275,7 +275,7 @@ const ButtonBase = kind({
 			'--agate-button-animation-delay': animationDelay,
 			'--agate-button-badge-bg-color': badgeColor
 		}),
-		minWidth: ({minWidth}) => ((minWidth != null) ? minWidth : false)
+		minWidth: ({iconOnly, minWidth}) => ((minWidth != null) ? minWidth : !iconOnly)
 	},
 
 	render: ({css, ...rest}) => {

--- a/Button/Button.module.less
+++ b/Button/Button.module.less
@@ -133,6 +133,12 @@
 				.bg {
 					border-radius: @agate-button-icon-border-radius;
 				}
+
+				&.minWidth {
+					.bg {
+						border-radius: @agate-button-border-radius;
+					}
+				}
 			}
 		}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ The following is a curated list of changes in the Enact agate module, newest cha
 - `agate/Keypad`, `agate/MediaPlayer`, and `agate/ToggleButton` to have buttons with proper width
 - `agate/LabeledIconButton` max-width so that huge sized icon will not be cut off
 - `agate/MediaPlayer` play function on handleNext and handlePrevious to handle events asynchronously
-- `agate/MediaPlayer` to have buttons with proper width
 - `agate/Panels` to show close button properly for night mode
 - `agate/Picker` picker item width in horizontal for silicon
 - `agate/PopupMenu` to display distinguishable title
@@ -38,7 +37,6 @@ The following is a curated list of changes in the Enact agate module, newest cha
 - `agate/Spinner` to support `transparent` prop properly
 - `agate/SwitchItem` icon position for all skins RTL locale and Electro/Titanium both LTR and RTL locale
 - `agate/TemperatureControl` to not be draggable when it's disabled
-- `agate/ToggleButton` to have Button with proper width
 
 ## [1.0.0] - 2020-10-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,10 @@ The following is a curated list of changes in the Enact agate module, newest cha
 - `agate/IncrementSlider` button color for Gallium skin
 - `agate/Input` run time error when using `dismissOnEnter`
 - `agate/Keypad` to not show console error in sampler
-- `agate/Keypad` to have buttons with `minWidth` false
+- `agate/Keypad` to have buttons with proper width
 - `agate/LabeledIconButton` max-width so that huge sized icon will not be cut off
 - `agate/MediaPlayer` play function on handleNext and handlePrevious to handle events asynchronously
-- `agate/MediaPlayer` to have buttons with `minWidth` false
+- `agate/MediaPlayer` to have buttons with proper width
 - `agate/Panels` to show close button properly for night mode
 - `agate/Picker` picker item width in horizontal for silicon
 - `agate/PopupMenu` to display distinguishable title
@@ -38,7 +38,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 - `agate/Spinner` to support `transparent` prop properly
 - `agate/SwitchItem` icon position for all skins RTL locale and Electro/Titanium both LTR and RTL locale
 - `agate/TemperatureControl` to not be draggable when it's disabled
-- `agate/ToggleButton` to use `Button` with `minWidth` false
+- `agate/ToggleButton` to have Button with proper width
 
 ## [1.0.0] - 2020-10-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,15 +19,16 @@ The following is a curated list of changes in the Enact agate module, newest cha
 
 - `agate/Button` to marquee when focused
 - `agate/Button` to show a tooltip when hovered
-- `agate/Button` to correctly compute `minWidth`
 - `agate/DateTimePicker` returned value by onChange event
 - `agate/FanSpeedControl` to center text when there is no icon
 - `agate/Heading` to support `spacing` for Gallium and Silicon
 - `agate/IncrementSlider` button color for Gallium skin
 - `agate/Input` run time error when using `dismissOnEnter`
 - `agate/Keypad` to not show console error in sampler
+- `agate/Keypad` to have buttons with `minWidth` false
 - `agate/LabeledIconButton` max-width so that huge sized icon will not be cut off
 - `agate/MediaPlayer` play function on handleNext and handlePrevious to handle events asynchronously
+- `agate/MediaPlayer` to have buttons with `minWidth` false
 - `agate/Panels` to show close button properly for night mode
 - `agate/Picker` picker item width in horizontal for silicon
 - `agate/PopupMenu` to display distinguishable title
@@ -37,6 +38,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 - `agate/Spinner` to support `transparent` prop properly
 - `agate/SwitchItem` icon position for all skins RTL locale and Electro/Titanium both LTR and RTL locale
 - `agate/TemperatureControl` to not be draggable when it's disabled
+- `agate/ToggleButton` to use `Button` with `minWidth` false
 
 ## [1.0.0] - 2020-10-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 - `agate/IncrementSlider` button color for Gallium skin
 - `agate/Input` run time error when using `dismissOnEnter`
 - `agate/Keypad` to not show console error in sampler
-- `agate/Keypad` to have buttons with proper width
+- `agate/Keypad`, `agate/MediaPlayer`, and `agate/ToggleButton` to have buttons with proper width
 - `agate/LabeledIconButton` max-width so that huge sized icon will not be cut off
 - `agate/MediaPlayer` play function on handleNext and handlePrevious to handle events asynchronously
 - `agate/MediaPlayer` to have buttons with proper width

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 
 - `agate/Button` to marquee when focused
 - `agate/Button` to show a tooltip when hovered
+- `agate/Button` to correctly compute `minWidth`
 - `agate/DateTimePicker` returned value by onChange event
 - `agate/FanSpeedControl` to center text when there is no icon
 - `agate/Heading` to support `spacing` for Gallium and Silicon

--- a/Keypad/Keypad.js
+++ b/Keypad/Keypad.js
@@ -110,6 +110,7 @@ const Key = kind({
 					{...rest}
 					css={css}
 					icon={children}
+					minWidth={false}
 					role={null}
 					size="large"
 				>

--- a/MediaPlayer/MediaControls.js
+++ b/MediaPlayer/MediaControls.js
@@ -231,6 +231,7 @@ const MediaControls = kind({
 					backgroundOpacity="transparent"
 					className={css.playPauseButton}
 					css={css}
+					minWidth={false}
 					onClick={paused ? onPlay : onPause}
 					size="large"
 				>

--- a/ToggleButton/ToggleButton.js
+++ b/ToggleButton/ToggleButton.js
@@ -162,6 +162,7 @@ const ToggleButtonBase = kind({
 				{...props}
 				aria-pressed={props.selected}
 				css={css}
+				minWidth={false}
 			/>
 		);
 	}

--- a/ToggleButton/ToggleButton.module.less
+++ b/ToggleButton/ToggleButton.module.less
@@ -96,7 +96,7 @@
 			min-width: @agate-togglebutton-smallest-min-width;
 		}
 
-		&.minWidth {
+		&.iconOnly {
 			&,
 			&.huge,
 			&.small,


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Daniel Stoian daniel.stoian@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Added `minwidth=false` for the Buttons inside Keypad, Mediaplayer and ToggleButton
- added different border radius if Button has iconOnly, but minWidth=true
- changed style in ToggleButton from .minWidth to .iconOnly due to the latest architecture change in Button.

### Links
[//]: # (Related issues, references)
PLAT-127764

### Comments