### PR TITLE
PLAT-121900: Fix to close expanded dropdown with back(escape) key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 - `agate/Button` to marquee when focused
 - `agate/Button` to show a tooltip when hovered
 - `agate/DateTimePicker` returned value by onChange event
+- `agate/Dropdown` to support close expanded dropdown with 5-way key
 - `agate/FanSpeedControl` to center text when there is no icon
 - `agate/Heading` to support `spacing` for Gallium and Silicon
 - `agate/IncrementSlider` button color for Gallium skin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 - `agate/Button` to marquee when focused
 - `agate/Button` to show a tooltip when hovered
 - `agate/DateTimePicker` returned value by onChange event
-- `agate/Dropdown` to support close expanded dropdown with 5-way key
+- `agate/Dropdown` to support closing dropdown with back key
 - `agate/FanSpeedControl` to center text when there is no icon
 - `agate/Heading` to support `spacing` for Gallium and Silicon
 - `agate/IncrementSlider` button color for Gallium skin

--- a/Dropdown/Dropdown.js
+++ b/Dropdown/Dropdown.js
@@ -15,8 +15,9 @@
  * @exports DropdownDecorator
  */
 import {on, off} from '@enact/core/dispatcher';
-import {handle, forward, forProp} from '@enact/core/handle';
+import {forKey, forward, forProp, handle} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
+import {add} from '@enact/core/keymap';
 import kind from '@enact/core/kind';
 import {extractAriaProps} from '@enact/core/util';
 import Spotlight from '@enact/spotlight';
@@ -59,6 +60,9 @@ const handleTransitionHide = (ev, {'data-spotlight-id': containerId}) => {
 		}
 	}
 };
+
+// Add keymap for escape key
+add('cancel', 27);
 
 /**
  * A stateless Dropdown component.
@@ -382,10 +386,6 @@ const DropDownExtended = hoc((config, Wrapped) => {
 
 		clickedOutsideDropdown = ({target}) => !this.node.contains(target);
 
-		escKeyPressed = (event) => {
-			return (event.keyCode === 27);
-		};
-
 		// If a click happened outside the component area close the dropdown by forwarding the onClick from Toggleable.
 		handleClick = handle(
 			this.clickedOutsideDropdown,
@@ -393,7 +393,7 @@ const DropDownExtended = hoc((config, Wrapped) => {
 		).bindAs(this, 'handleClick');
 
 		handleKeyDown = handle(
-			this.escKeyPressed,
+			forKey('cancel'),
 			forward('onClick')
 		).bindAs(this, 'handleKeyDown');
 

--- a/Dropdown/Dropdown.js
+++ b/Dropdown/Dropdown.js
@@ -357,6 +357,7 @@ const DropDownExtended = hoc((config, Wrapped) => {
 
 			if (this.props.open) {
 				on('click', this.handleClick);
+				on('keydown', this.handleKeyDown);
 			}
 		}
 
@@ -365,22 +366,34 @@ const DropDownExtended = hoc((config, Wrapped) => {
 
 			if (!prevProps.open && open) {
 				on('click', this.handleClick);
+				on('keydown', this.handleKeyDown);
 			} else if (prevProps.open && !open) {
 				off('click', this.handleClick);
+				off('keydown', this.handleKeyDown);
 			}
 		}
 
 		componentWillUnmount () {
 			off('click', this.handleClick);
+			off('keydown', this.handleKeyDown);
 		}
 
 		clickedOutsideDropdown = ({target}) => !this.node.contains(target);
+
+		escKeyPressed = (event) => {
+			return (event.keyCode === 27);
+		};
 
 		// If a click happened outside the component area close the dropdown by forwarding the onClick from Toggleable.
 		handleClick = handle(
 			this.clickedOutsideDropdown,
 			forward('onClick')
 		).bindAs(this, 'handleClick');
+
+		handleKeyDown = handle(
+			this.escKeyPressed,
+			forward('onClick')
+		).bindAs(this, 'handleKeyDown');
 
 		render () {
 			return (


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Issue: Expanded dropdown is not closed on Escape key press.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Solution: Added `escKeyPressed` function and `handleKeyDown` handler to forward onClick on Toggleable. Pressing Escape closes the dropdown.

### Links
[//]: # (Related issues, references)
PLAT-121900

### Comments