### PR TITLE
PLAT-124521: Fix the text size in ArcPicker is smaller than the one in ArcSlider

### DIFF
--- a/ArcPicker/ArcPicker.module.less
+++ b/ArcPicker/ArcPicker.module.less
@@ -23,8 +23,8 @@
 	.applySkins({
 		.valueDisplay {
 			height: @agate-arc-picker-value-display-height;
-			font-size: @agate-arcpicker-font-size;
-			font-weight: @agate-arcpicker-font-weight;
+			font-size: @agate-arc-picker-font-size;
+			font-weight: @agate-arc-picker-font-weight;
 		}
 	})
 }

--- a/ArcPicker/ArcPicker.module.less
+++ b/ArcPicker/ArcPicker.module.less
@@ -22,9 +22,9 @@
 
 	.applySkins({
 		.valueDisplay {
-			height: @agate-arc-picker-value-display-height;
-			font-size: @agate-arc-picker-font-size;
-			font-weight: @agate-arc-picker-font-weight;
+			height: @agate-arcpicker-value-display-height;
+			font-size: @agate-arcpicker-font-size;
+			font-weight: @agate-arcpicker-font-weight;
 		}
 	})
 }

--- a/ArcPicker/ArcPicker.module.less
+++ b/ArcPicker/ArcPicker.module.less
@@ -23,6 +23,8 @@
 	.applySkins({
 		.valueDisplay {
 			height: @agate-arc-picker-value-display-height;
+			font-size: @agate-arcpicker-font-size;
+			font-weight: @agate-arcpicker-font-weight;
 		}
 	})
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
  
 ### Fixed
 
+- `agate/ArcPicker` to display correct `font-size` and `font-weight`
 - `agate/Button` to marquee when focused
 - `agate/Button` to show a tooltip when hovered
 - `agate/DateTimePicker` returned value by onChange event

--- a/FanSpeedControl/FanSpeedControl.module.less
+++ b/FanSpeedControl/FanSpeedControl.module.less
@@ -26,7 +26,6 @@
 		}
 
 		.fanValue {
-			font-size: @agate-fanspeedcontrol-font-size;
 			width: @agate-fanspeedcontrol-value-width;
 		}
 	});

--- a/styles/colors-base.less
+++ b/styles/colors-base.less
@@ -74,6 +74,10 @@
 @agate-spotlight-border-color:         inherit;
 @agate-spotlight-focus-bg-image:       inherit;
 
+// ArcPicker
+// ---------------------------------------
+@agate-fanspeedcontrol-color: @agate-text-color;
+
 // Button
 // ---------------------------------------
 @agate-button-color:          inherit;
@@ -161,10 +165,6 @@
 @agate-drawer-bg-image: inherit;
 @agate-drawer-border-color: @agate-popup-border-color;
 @agate-drawer-shadow: inherit;
-
-// ArcPicker
-// ---------------------------------------
-@agate-fanspeedcontrol-color: @agate-text-color;
 
 // FullscreenPopup
 // ---------------------------------------

--- a/styles/colors-base.less
+++ b/styles/colors-base.less
@@ -74,10 +74,6 @@
 @agate-spotlight-border-color:         inherit;
 @agate-spotlight-focus-bg-image:       inherit;
 
-// ArcPicker
-// ---------------------------------------
-@agate-fanspeedcontrol-color: @agate-text-color;
-
 // Button
 // ---------------------------------------
 @agate-button-color:          inherit;
@@ -165,6 +161,10 @@
 @agate-drawer-bg-image: inherit;
 @agate-drawer-border-color: @agate-popup-border-color;
 @agate-drawer-shadow: inherit;
+
+// FanSpeedControl
+// ---------------------------------------
+@agate-fanspeedcontrol-color: @agate-text-color;
 
 // FullscreenPopup
 // ---------------------------------------

--- a/styles/variables-base.less
+++ b/styles/variables-base.less
@@ -56,6 +56,8 @@
 // ArcPicker
 // ---------------------------------------
 @agate-arc-picker-value-display-height: inherit;
+@agate-arcpicker-font-size: inherit;
+@agate-arcpicker-font-weight: inherit;
 
 // Arc Slider
 // -------------------------------------------------

--- a/styles/variables-base.less
+++ b/styles/variables-base.less
@@ -56,8 +56,8 @@
 // ArcPicker
 // ---------------------------------------
 @agate-arc-picker-value-display-height: inherit;
-@agate-arcpicker-font-size: inherit;
-@agate-arcpicker-font-weight: inherit;
+@agate-arc-picker-font-size: inherit;
+@agate-arc-picker-font-weight: inherit;
 
 // Arc Slider
 // -------------------------------------------------

--- a/styles/variables-base.less
+++ b/styles/variables-base.less
@@ -55,9 +55,9 @@
 
 // ArcPicker
 // ---------------------------------------
-@agate-arc-picker-value-display-height: inherit;
-@agate-arc-picker-font-size: inherit;
-@agate-arc-picker-font-weight: inherit;
+@agate-arcpicker-value-display-height: inherit;
+@agate-arcpicker-font-size: inherit;
+@agate-arcpicker-font-weight: inherit;
 
 // ArcSlider
 // -------------------------------------------------

--- a/styles/variables-base.less
+++ b/styles/variables-base.less
@@ -59,7 +59,7 @@
 @agate-arc-picker-font-size: inherit;
 @agate-arc-picker-font-weight: inherit;
 
-// Arc Slider
+// ArcSlider
 // -------------------------------------------------
 @agate-arcslider-font-size: inherit;
 @agate-arcslider-font-weight: inherit;

--- a/styles/variables-base.less
+++ b/styles/variables-base.less
@@ -219,9 +219,8 @@
 @agate-drawer-border: @agate-popup-border;
 @agate-drawer-padding: @agate-popup-padding;
 
-// ArcPicker
+// FanSpeedControl
 // ---------------------------------------
-@agate-fanspeedcontrol-font-size:        inherit;
 @agate-fanspeedcontrol-icon-font-size:   inherit;
 @agate-fanspeedcontrol-icon-height:      inherit;
 @agate-fanspeedcontrol-value-width:      inherit;

--- a/styles/variables-gallium.less
+++ b/styles/variables-gallium.less
@@ -3,9 +3,9 @@
 
 // ArcPicker
 // ---------------------------------------
-@agate-arc-picker-value-display-height: 120px;
-@agate-arc-picker-font-size: 72px;
-@agate-arc-picker-font-weight: 300;
+@agate-arcpicker-value-display-height: 120px;
+@agate-arcpicker-font-size: 72px;
+@agate-arcpicker-font-weight: 300;
 
 // ArcSlider
 // -------------------------------------------------

--- a/styles/variables-gallium.less
+++ b/styles/variables-gallium.less
@@ -4,8 +4,8 @@
 // ArcPicker
 // ---------------------------------------
 @agate-arc-picker-value-display-height: 120px;
-@agate-arcpicker-font-size: 72px;
-@agate-arcpicker-font-weight: 300;
+@agate-arc-picker-font-size: 72px;
+@agate-arc-picker-font-weight: 300;
 
 // Arc Slider
 // -------------------------------------------------

--- a/styles/variables-gallium.less
+++ b/styles/variables-gallium.less
@@ -7,7 +7,7 @@
 @agate-arc-picker-font-size: 72px;
 @agate-arc-picker-font-weight: 300;
 
-// Arc Slider
+// ArcSlider
 // -------------------------------------------------
 @agate-arcslider-font-size: 72px;
 @agate-arcslider-font-weight: 300;

--- a/styles/variables-gallium.less
+++ b/styles/variables-gallium.less
@@ -58,9 +58,8 @@
 @agate-drawer-border: @agate-popup-border;
 @agate-drawer-padding: @agate-popup-padding;
 
-// ArcPicker
+// FanSpeedControl
 // ---------------------------------------
-@agate-fanspeedcontrol-font-size:        72px;
 @agate-fanspeedcontrol-icon-font-size:   120px;
 @agate-fanspeedcontrol-icon-height:      60px;
 @agate-fanspeedcontrol-value-width:      90px;

--- a/styles/variables-gallium.less
+++ b/styles/variables-gallium.less
@@ -4,6 +4,8 @@
 // ArcPicker
 // ---------------------------------------
 @agate-arc-picker-value-display-height: 120px;
+@agate-arcpicker-font-size: 72px;
+@agate-arcpicker-font-weight: 300;
 
 // Arc Slider
 // -------------------------------------------------

--- a/styles/variables-silicon.less
+++ b/styles/variables-silicon.less
@@ -27,8 +27,8 @@
 // ArcPicker
 // ---------------------------------------
 @agate-arc-picker-value-display-height: 120px;
-@agate-arcpicker-font-size: 72px;
-@agate-arcpicker-font-weight: 300;
+@agate-arc-picker-font-size: 72px;
+@agate-arc-picker-font-weight: 300;
 
 // Button
 // ---------------------------------------

--- a/styles/variables-silicon.less
+++ b/styles/variables-silicon.less
@@ -12,7 +12,13 @@
 // ---------------------------------------
 @agate-icon-font-family: "Silicon Icons";
 
-// Arc Slider
+// ArcPicker
+// ---------------------------------------
+@agate-arc-picker-value-display-height: 120px;
+@agate-arc-picker-font-size: 72px;
+@agate-arc-picker-font-weight: 300;
+
+// ArcSlider
 // -------------------------------------------------
 @agate-arcslider-font-size: 72px;
 @agate-arcslider-font-weight: 300;
@@ -23,12 +29,6 @@
 @agate-body-font-size: 28px;
 @agate-body-font-weight: normal;
 @agate-body-line-height: 1.5em;
-
-// ArcPicker
-// ---------------------------------------
-@agate-arc-picker-value-display-height: 120px;
-@agate-arc-picker-font-size: 72px;
-@agate-arc-picker-font-weight: 300;
 
 // Button
 // ---------------------------------------

--- a/styles/variables-silicon.less
+++ b/styles/variables-silicon.less
@@ -14,9 +14,9 @@
 
 // ArcPicker
 // ---------------------------------------
-@agate-arc-picker-value-display-height: 120px;
-@agate-arc-picker-font-size: 72px;
-@agate-arc-picker-font-weight: 300;
+@agate-arcpicker-value-display-height: 120px;
+@agate-arcpicker-font-size: 72px;
+@agate-arcpicker-font-weight: 300;
 
 // ArcSlider
 // -------------------------------------------------

--- a/styles/variables-silicon.less
+++ b/styles/variables-silicon.less
@@ -27,6 +27,8 @@
 // ArcPicker
 // ---------------------------------------
 @agate-arc-picker-value-display-height: 120px;
+@agate-arcpicker-font-size: 72px;
+@agate-arcpicker-font-weight: 300;
 
 // Button
 // ---------------------------------------

--- a/styles/variables-silicon.less
+++ b/styles/variables-silicon.less
@@ -103,9 +103,8 @@
 @agate-dropdown-list-height: @agate-button-small-height * 4;
 @agate-dropdown-list-padding: 15px 0 3px 0;
 
-// ArcPicker
+// FanSpeedControl
 // ---------------------------------------
-@agate-fanspeedcontrol-font-size:        72px;
 @agate-fanspeedcontrol-icon-font-size:   120px;
 @agate-fanspeedcontrol-icon-height:      60px;
 @agate-fanspeedcontrol-value-width:      90px;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
 - added `font-size` and `font-weight` to `ArcPicker` component to share the same styles as `ArcSlider`
 - removed `font-size` style from `FanSpeedControl` as now it inherits it from `ArcPicker`

### Links
[//]: # (Related issues, references)
PLAT-124521

### Comments

Enact-DCO-1.0-Signed-off-by: Adrian Cocoara adrian.cocoara@lgepartner.com