### PR TITLE
PLAT-129803: Fix LabeledIconButton shape to circular

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 - `agate/Keypad` to not show console error in sampler
 - `agate/Keypad`, `agate/MediaPlayer`, and `agate/ToggleButton` to have buttons with proper width
 - `agate/LabeledIconButton` max-width so that huge sized icon will not be cut off
+- `agate/LabeledIconButton` button shape to circular
 - `agate/MediaPlayer` play function on handleNext and handlePrevious to handle events asynchronously
 - `agate/Panels` to show close button properly for night mode
 - `agate/Picker` picker item width in horizontal for silicon

--- a/LabeledIconButton/LabeledIconButton.js
+++ b/LabeledIconButton/LabeledIconButton.js
@@ -83,6 +83,14 @@ const LabeledIconButtonBase = kind({
 		 */
 		iconComponent: EnactPropTypes.component,
 
+		/**
+		 * True if button is an icon only button.
+		 *
+		 * @type {Boolean}
+		 * @private
+		 */
+		iconOnly: PropTypes.bool,
+
 		// forwarded from Spottable
 		pressed: PropTypes.bool,
 
@@ -122,6 +130,8 @@ const LabeledIconButtonBase = kind({
 		spriteCount,
 		...rest
 	}) => {
+		delete rest.iconOnly;
+
 		return UiLabeledIconBase.inline({
 			role: 'button',
 			...rest,
@@ -130,6 +140,7 @@ const LabeledIconButtonBase = kind({
 					backgroundOpacity={backgroundOpacity}
 					icon={icon}
 					iconComponent={iconComponent}
+					iconOnly
 					highlighted={highlighted}
 					pressed={pressed}
 					selected={selected}


### PR DESCRIPTION
This PR fixes LabledIconButton shape to circular.
And the warning saying 
```
Warning: React does not recognize the `iconOnly` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `icononly` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)