### PR TITLE
PLAT-130875: qa-a11y> Prevent menu inner DOM elements to handle events

### DIFF
--- a/samples/qa-a11y/src/App/App.module.less
+++ b/samples/qa-a11y/src/App/App.module.less
@@ -33,6 +33,7 @@ h2 {
 	margin: 0;
 
 	& > div {
+		pointer-events: none;
 		font-size: 21px;
 	}
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A CHANGELOG entry is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)

When tapping a menu in qa-a11y sample, the menu below the menu being tapped is selected.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

The menu inner DOM element is bigger than the the menu outer DOM element and overlaps over other menus.
For example, a `Dropdown` menu overlaps a `Drawer` menu.
![image](https://user-images.githubusercontent.com/4239873/103591841-a0d2df00-4f34-11eb-8e79-0a4cd7d49c3f.png)

By applying `ponter-events: none` to inner DOM element in the menu,
the `Drorpdown` menu doesn't overlaps the `Drawer` menu anymore.

![image](https://user-images.githubusercontent.com/4239873/103591786-73863100-4f34-11eb-8522-b7fc5e229589.png)


### Links
[//]: # (Related issues, references)
PLAT-130875

### Comments

Enact-DCO-1.0-Signed-off-by: YB Sung (yb.sung@lge.com)