### PR TITLE
PLAT-129910: Fixed dropdown button arrow color for Silicon skin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 
 ### Fixed
 
-- `agate/Dropdown` icon color for Silicon skin
+- `agate/Dropdown` to show focused icon color for Silicon skin
 
 ## [1.1.1] - 2020-12-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The following is a curated list of changes in the Enact agate module, newest cha
 - `agate/ArcSlider` prop `aria-valuetext` to override `aria-valuetext` for it
 - `agate/Button` prop `iconOnly`, `iconPosition` and `minWidth`
 
+### Fixed
+
+- `agate/Dropdown` icon color for Silicon skin
+
 ## [1.1.1] - 2020-12-23
 
 ### Fixed

--- a/Dropdown/Dropdown.module.less
+++ b/Dropdown/Dropdown.module.less
@@ -104,6 +104,12 @@
 				.marquee {
 					margin-right: @agate-dropdown-button-marquee-margin-right;
 				}
+
+				.focus({
+					.icon {
+						color: @agate-dropdown-button-icon-focus-color;
+					}
+				});
 			}
 
 			.transitionContainer {

--- a/styles/colors-base.less
+++ b/styles/colors-base.less
@@ -147,6 +147,7 @@
 @agate-dropdown-button-border-color: inherit;
 @agate-dropdown-button-client-color: inherit;
 @agate-dropdown-button-icon-color: inherit;
+@agate-dropdown-button-icon-focus-color: inherit;
 @agate-dropdown-button-open-border-color: inherit;
 @agate-dropdown-up-button-open-border-bottom-color: inherit;
 @agate-dropdown-list-bg-color: @agate-white;

--- a/styles/colors-silicon-day.less
+++ b/styles/colors-silicon-day.less
@@ -131,7 +131,7 @@
 @agate-dropdown-button-bg-color: @silicon-gray;
 @agate-dropdown-button-border-color: transparent;
 @agate-dropdown-button-client-color: @agate-black;
-@agate-dropdown-button-icon-color: @agate-accent;
+@agate-dropdown-button-icon-focus-color: @agate-accent;
 @agate-dropdown-button-open-border-color: fade(@agate-black, 25%);
 @agate-dropdown-up-button-open-border-bottom-color: transparent;
 @agate-dropdown-selected-color: @agate-black;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A CHANGELOG entry is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Issue: agate/Dropdown: The current Silicon Dropdown arrow mark is always red. The user can not see if the dropdown is focused or not with 5-way key.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Solution: Made the dropdown arrow color to have accent color only on focus

### Links
[//]: # (Related issues, references)
PLAT-129910

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian daniel.stoian@lgepartner.com