### PR TITLE
PLAT-130739: Fix previous button to work properly when media paused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 - `agate/Dropdown` to show focused icon color for Silicon skin
 - `agate/LabeledIconButton` to display label text on multiple lines (removed marquee)
 - `agate/LabeledIconButton` `max-width` to display huge sized icon correctly
+- `agate/MediaPlayer` previous button functionality to play media from the beginning after being paused
 - `agate/TimePicker` transition direction for meridiem when hour is changed
 
 ## [1.1.1] - 2020-12-23

--- a/MediaPlayer/MediaPlayer.js
+++ b/MediaPlayer/MediaPlayer.js
@@ -583,6 +583,7 @@ const MediaPlayerBehaviorDecorator = hoc((config, Wrapped) => { // eslint-disabl
 				this.setState(() => {
 					return ({sourceIndex: currentIndex});
 				}, () => {
+					this.media.currentTime = 0;
 					this.play();
 				});
 			} else {


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Issue: Initial focus is needed when opening dropdown with 5-way key.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Solution: Set current time to 0 when pressing previous button in order to play media from the beginning after being paused.

### Links
[//]: # (Related issues, references)
PLAT-130739

### Comments