### PR TITLE
PLAT-132783: Fix ui-test fail on LabeledIconButton

### DIFF
--- a/tests/ui/apps/LabeledIconButton/LabeledIconButton-View.js
+++ b/tests/ui/apps/LabeledIconButton/LabeledIconButton-View.js
@@ -1,79 +1,83 @@
 import LabeledIconButton from '../../../../LabeledIconButton';
-import Scroller from '../../../../Scroller';
 import ThemeDecorator from '../../../../ThemeDecorator';
 import spotlight from '@enact/spotlight';
-import {scaleToRem} from '@enact/ui/resolution';
 import React from 'react';
+
+const style = {
+	main: {
+		display: 'grid',
+		'gridTemplateColumns': 'repeat(3, 1fr)',
+		'gridGap': '6px'
+	}
+};
 
 // NOTE: Forcing pointer mode off so we can be sure that regardless of webOS pointer mode the app
 // runs the same way
 spotlight.setPointerMode(false);
 
 const app = (props) => <div {...props}>
-	<div>
-		<Scroller style={{height: scaleToRem(900)}}>
-			<LabeledIconButton
-				id="labeledIconButtonDefault"
-				icon="temperature"
-			>
-				LabeledIconButton default
-			</LabeledIconButton>
-			<LabeledIconButton
-				id="labeledIconButtonCustomIcon"
-				icon="happyface"
-			>
-				LabeledIconButton custom icon
-			</LabeledIconButton>
-			<LabeledIconButton
-				id="labeledIconButtonSelected"
-				icon="temperature"
-				selected
-			>
-				LabeledIconButton selected
-			</LabeledIconButton>
-			<LabeledIconButton
-				id="labeledIconButtonHighlighted"
-				icon="temperature"
-				highlighted
-			>
-				LabeledIconButton highlighted
-			</LabeledIconButton>
-			<LabeledIconButton
-				id="labeledIconButtonTransparent"
-				backgroundOpacity="transparent"
-				icon="temperature"
-			>
-				LabeledIconButton backgroundOpacity transparent
-			</LabeledIconButton>
-			<LabeledIconButton
-				id="labeledIconButtonSmallest"
-				icon="temperature"
-				size="smallest"
-			>
-				LabeledIconButton smallest
-			</LabeledIconButton>
-			<LabeledIconButton
-				id="labeledIconButtonSmall"
-				icon="temperature"
-				size="small"
-			>
-				LabeledIconButton small
-			</LabeledIconButton>
-			<LabeledIconButton
-				id="labeledIconButtonHuge"
-				icon="temperature"
-				size="huge"
-			>
-				LabeledIconButton huge
-			</LabeledIconButton>
-			<LabeledIconButton
-				id="labeledIconButtonDisabled"
-				icon="temperature"
-				disabled
-			>
-				LabeledIconButton disabled
-			</LabeledIconButton>
-		</Scroller>
+	<div style={style.main}>
+		<LabeledIconButton
+			id="labeledIconButtonDefault"
+			icon="temperature"
+		>
+			LabeledIconButton default
+		</LabeledIconButton>
+		<LabeledIconButton
+			id="labeledIconButtonCustomIcon"
+			icon="happyface"
+		>
+			LabeledIconButton custom icon
+		</LabeledIconButton>
+		<LabeledIconButton
+			id="labeledIconButtonSelected"
+			icon="temperature"
+			selected
+		>
+			LabeledIconButton selected
+		</LabeledIconButton>
+		<LabeledIconButton
+			id="labeledIconButtonHighlighted"
+			icon="temperature"
+			highlighted
+		>
+			LabeledIconButton highlighted
+		</LabeledIconButton>
+		<LabeledIconButton
+			id="labeledIconButtonTransparent"
+			backgroundOpacity="transparent"
+			icon="temperature"
+		>
+			LabeledIconButton backgroundOpacity transparent
+		</LabeledIconButton>
+		<LabeledIconButton
+			id="labeledIconButtonSmallest"
+			icon="temperature"
+			size="smallest"
+		>
+			LabeledIconButton smallest
+		</LabeledIconButton>
+		<LabeledIconButton
+			id="labeledIconButtonSmall"
+			icon="temperature"
+			size="small"
+		>
+			LabeledIconButton small
+		</LabeledIconButton>
+		<LabeledIconButton
+			id="labeledIconButtonHuge"
+			icon="temperature"
+			size="huge"
+		>
+			LabeledIconButton huge
+		</LabeledIconButton>
+		<LabeledIconButton
+			id="labeledIconButtonDisabled"
+			icon="temperature"
+			disabled
+		>
+			LabeledIconButton disabled
+		</LabeledIconButton>
 	</div>
 </div>;
 

--- a/tests/ui/specs/LabeledIconButton/LabeledIconButton-specs.js
+++ b/tests/ui/specs/LabeledIconButton/LabeledIconButton-specs.js
@@ -23,7 +23,7 @@ describe('LabeledIconButton', function () {
 		describe('5-way', function () {
 			it('should focus the labeled icon button with 5-way Up', function () {
 				Page.components.LabeledIconButtonCustom.focus();
-				Page.spotlightUp();
+				Page.spotlightLeft();
 
 				expect(labeledIconButton.self.isFocused()).to.be.true();
 			});
@@ -51,7 +51,7 @@ describe('LabeledIconButton', function () {
 		describe('5-way', function () {
 			it('should focus the labeled icon button with 5-way Down', function () {
 				Page.components.LabeledIconButtonDefault.focus();
-				Page.spotlightDown();
+				Page.spotlightRight();
 
 				expect(labeledIconButton.self.isFocused()).to.be.true();
 			});
@@ -83,7 +83,7 @@ describe('LabeledIconButton', function () {
 		describe('5-way', function () {
 			it('should focus the labeled icon button with 5-way Down', function () {
 				Page.components.LabeledIconButtonCustom.focus();
-				Page.spotlightDown();
+				Page.spotlightRight();
 
 				expect(labeledIconButton.self.isFocused()).to.be.true();
 			});
@@ -114,7 +114,7 @@ describe('LabeledIconButton', function () {
 
 		describe('5-way', function () {
 			it('should focus the labeled icon button with 5-way Down', function () {
-				Page.components.LabeledIconButtonSelected.focus();
+				Page.components.LabeledIconButtonDefault.focus();
 				Page.spotlightDown();
 
 				expect(labeledIconButton.self.isFocused()).to.be.true();
@@ -146,7 +146,7 @@ describe('LabeledIconButton', function () {
 
 		describe('5-way', function () {
 			it('should focus the labeled icon button with 5-way Down', function () {
-				Page.components.LabeledIconButtonHighlighted.focus();
+				Page.components.LabeledIconButtonCustom.focus();
 				Page.spotlightDown();
 
 				expect(labeledIconButton.self.isFocused()).to.be.true();
@@ -178,9 +178,16 @@ describe('LabeledIconButton', function () {
 
 		describe('5-way', function () {
 			it('should focus the labeled icon button with 5-way Down', function () {
-				Page.components.LabeledIconButtonTransparent.focus();
+				Page.components.LabeledIconButtonSelected.focus();
 				Page.spotlightDown();
 
+				expect(labeledIconButton.self.isFocused()).to.be.true();
+			});
+		});
+
+		describe('pointer', function () {
+			it('should focus the labeled icon button when hovered', function () {
+				labeledIconButton.hover();
 				expect(labeledIconButton.self.isFocused()).to.be.true();
 			});
 		});
@@ -203,9 +210,16 @@ describe('LabeledIconButton', function () {
 
 		describe('5-way', function () {
 			it('should focus the labeled icon button with 5-way Down', function () {
-				Page.components.LabeledIconButtonSmallest.focus();
+				Page.components.LabeledIconButtonHighlighted.focus();
 				Page.spotlightDown();
 
+				expect(labeledIconButton.self.isFocused()).to.be.true();
+			});
+		});
+
+		describe('pointer', function () {
+			it('should focus the labeled icon button when hovered', function () {
+				labeledIconButton.hover();
 				expect(labeledIconButton.self.isFocused()).to.be.true();
 			});
 		});
@@ -228,9 +242,16 @@ describe('LabeledIconButton', function () {
 
 		describe('5-way', function () {
 			it('should focus the labeled icon button with 5-way Down', function () {
-				Page.components.LabeledIconButtonSmall.focus();
+				Page.components.LabeledIconButtonTransparent.focus();
 				Page.spotlightDown();
 
+				expect(labeledIconButton.self.isFocused()).to.be.true();
+			});
+		});
+
+		describe('pointer', function () {
+			it('should focus the labeled icon button when hovered', function () {
+				labeledIconButton.hover();
 				expect(labeledIconButton.self.isFocused()).to.be.true();
 			});
 		});
@@ -253,9 +274,16 @@ describe('LabeledIconButton', function () {
 
 		describe('5-way', function () {
 			it('should focus the labeled icon button with 5-way Down', function () {
-				Page.components.LabeledIconButtonDisabled.focus();
+				Page.components.LabeledIconButtonSmallest.focus();
 				Page.spotlightDown();
 
+				expect(labeledIconButton.self.isFocused()).to.be.true();
+			});
+		});
+
+		describe('pointer', function () {
+			it('should focus the labeled icon button when hovered', function () {
+				labeledIconButton.hover();
 				expect(labeledIconButton.self.isFocused()).to.be.true();
 			});
 		});


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remover Scroller from LabeledIconButton-View. Change view layout, updated failed tests. 
The reason was that having the buttons wrapped in Scroller caused this bug. The test that failed intermittently was regarding the first LabeledIconButton that did not fit into the view and to which you had to scroll down to see. I removed the Scroller and positioned buttons with grid layout.

### Links
[//]: # (Related issues, references)
PLAT-132783

### Comments