### PR TITLE
PLAT-107982: Added default size prop for LabeledIconButton

### DIFF
--- a/LabeledIconButton/LabeledIconButton.js
+++ b/LabeledIconButton/LabeledIconButton.js
@@ -163,6 +163,10 @@ const LabeledIconButtonBase = kind({
 		// TODO: spriteCount prop bleeds!  Is this cruft?
 	},
 
+	defaultProps: {
+		size: 'large'
+	},
+
 	styles: {
 		css: componentCss,
 		className: 'labeledIconButton',

--- a/samples/sampler/stories/default/LabeledIconButton.js
+++ b/samples/sampler/stories/default/LabeledIconButton.js
@@ -3,11 +3,11 @@ import {boolean, select, text} from '@enact/storybook-utils/addons/knobs';
 import {LabeledIconBase as UiLabeledIconBase, LabeledIcon as UiLabeledIcon} from '@enact/ui/LabeledIcon';
 import {storiesOf} from '@storybook/react';
 
-import LabeledIconButton from '@enact/agate/LabeledIconButton';
+import {LabeledIconButtonBase, LabeledIconButton} from '@enact/agate/LabeledIconButton';
 
 import iconNames from './icons';
 
-const Config = mergeComponentMetadata('LabeledIconButton', UiLabeledIconBase, UiLabeledIcon, LabeledIconButton);
+const Config = mergeComponentMetadata('LabeledIconButton', UiLabeledIconBase, UiLabeledIcon, LabeledIconButtonBase, LabeledIconButton);
 Config.displayName = 'LabeledIconButton';
 
 storiesOf('Agate', module)


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
https://github.com/enactjs/enact/pull/2902 brought `agate/LabeledIconButton` lost its default size "large" value.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added default size prop "large" for LabeledIconButton

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-107982

### Comments
