### PR TITLE
PLAT-139512: Fixed misalignment of Dropdown and ContextualPopup on the edge of screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 
 - `agate/Checkbox` style to match latest design for Silicon skin
 - `agate/Drawer` `onShow`, `spotlightId`, and `spotlightRestrict` props to handle focus with 5-way navigation
+- `agate/Dropdown` horizontal alignment of Button and ContextualPopup
 - `agate/Item` to match the latest design for Silicon skin
 
 ## [2.0.0-alpha.2] - 2021-04-02

--- a/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -265,7 +265,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			this.MARGIN = noArrow ? 0 : ri.scale(9);
 			this.ARROW_WIDTH = noArrow ? 0 : ri.scale(30); // svg arrow width. used for arrow positioning
 			this.ARROW_OFFSET = noArrow ? 0 : ri.scale(18); // actual distance of the svg arrow displayed to offset overlaps with the container. Offset is when `noArrow` is false.
-			this.KEEPOUT = ri.scale(0); // keep out distance on the edge of the screen
+			this.KEEPOUT = ri.scale(12); // keep out distance on the edge of the screen
 
 			if (props.setApiProvider) {
 				props.setApiProvider(this);
@@ -504,8 +504,6 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 					client.right + this.KEEPOUT > window.innerWidth :
 					client.right + containerWidth + this.ARROW_OFFSET + this.MARGIN + this.KEEPOUT > window.innerWidth
 			};
-
-			console.log(client.left, containerWidth, this.ARROW_OFFSET, this.MARGIN, this.KEEPOUT)
 		}
 
 		adjustDirection () {

--- a/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -265,7 +265,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			this.MARGIN = noArrow ? 0 : ri.scale(9);
 			this.ARROW_WIDTH = noArrow ? 0 : ri.scale(30); // svg arrow width. used for arrow positioning
 			this.ARROW_OFFSET = noArrow ? 0 : ri.scale(18); // actual distance of the svg arrow displayed to offset overlaps with the container. Offset is when `noArrow` is false.
-			this.KEEPOUT = ri.scale(12); // keep out distance on the edge of the screen
+			this.KEEPOUT = ri.scale(0); // keep out distance on the edge of the screen
 
 			if (props.setApiProvider) {
 				props.setApiProvider(this);
@@ -504,6 +504,8 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 					client.right + this.KEEPOUT > window.innerWidth :
 					client.right + containerWidth + this.ARROW_OFFSET + this.MARGIN + this.KEEPOUT > window.innerWidth
 			};
+
+			console.log(client.left, containerWidth, this.ARROW_OFFSET, this.MARGIN, this.KEEPOUT)
 		}
 
 		adjustDirection () {

--- a/Dropdown/Dropdown.module.less
+++ b/Dropdown/Dropdown.module.less
@@ -11,6 +11,8 @@
 	}
 
 	.applySkins({
+		margin: @agate-dropdown-margin;
+
 		&.smallestWidth {
 			.button,
 			.item {

--- a/samples/sampler/stories/default/Dropdown.js
+++ b/samples/sampler/stories/default/Dropdown.js
@@ -16,19 +16,17 @@ export const _Dropdown = () => {
 	const items = (new Array(itemCount)).fill().map((i, index) => `Option ${index + 1}`);
 
 	return (
-		<div>
-			<Dropdown
-				direction={select('direction', ['above', 'below'], Config)}
-				disabled={boolean('disabled', Config)}
-				onClose={action('onClose')}
-				onOpen={action('onOpen')}
-				onSelect={action('onSelect')}
-				title={text('title', Config, 'Please select')}
-				width={select('width', ['smallest', 'small', 'medium', 'large', 'x-large', 'huge'], Config)}
-			>
-				{items}
-			</Dropdown>
-		</div>
+		<Dropdown
+			direction={select('direction', ['above', 'below'], Config)}
+			disabled={boolean('disabled', Config)}
+			onClose={action('onClose')}
+			onOpen={action('onOpen')}
+			onSelect={action('onSelect')}
+			title={text('title', Config, 'Please select')}
+			width={select('width', ['smallest', 'small', 'medium', 'large', 'x-large', 'huge'], Config)}
+		>
+			{items}
+		</Dropdown>
 	);
 };
 

--- a/samples/sampler/stories/default/Dropdown.js
+++ b/samples/sampler/stories/default/Dropdown.js
@@ -3,8 +3,6 @@ import {action} from '@enact/storybook-utils/addons/actions';
 import {boolean, number, text, select} from  '@enact/storybook-utils/addons/knobs';
 import Dropdown, {DropdownBase} from '@enact/agate/Dropdown';
 
-import css from './Dropdown.module.less';
-
 Dropdown.displayName = 'Dropdown';
 const Config = mergeComponentMetadata('Dropdown', Dropdown, DropdownBase);
 
@@ -18,7 +16,7 @@ export const _Dropdown = () => {
 	const items = (new Array(itemCount)).fill().map((i, index) => `Option ${index + 1}`);
 
 	return (
-		<div className={css.parentContainer}>
+		<div>
 			<Dropdown
 				direction={select('direction', ['above', 'below'], Config)}
 				disabled={boolean('disabled', Config)}

--- a/samples/sampler/stories/default/Dropdown.module.less
+++ b/samples/sampler/stories/default/Dropdown.module.less
@@ -1,5 +1,0 @@
-@import '~@enact/agate/styles/mixins.less';
-
-//.parentContainer {
-//	.margin-start-end(12px, 0);
-//}

--- a/samples/sampler/stories/default/Dropdown.module.less
+++ b/samples/sampler/stories/default/Dropdown.module.less
@@ -1,5 +1,5 @@
 @import '~@enact/agate/styles/mixins.less';
 
-.parentContainer {
-	.margin-start-end(12px, 0);
-}
+//.parentContainer {
+//	.margin-start-end(12px, 0);
+//}

--- a/styles/variables-base.less
+++ b/styles/variables-base.less
@@ -232,6 +232,7 @@
 @agate-dropdown-item-focus-border-color: @agate-item-focus-border-color;
 @agate-dropdown-list-height:  @agate-item-height * 4;
 @agate-dropdown-list-padding: initial;
+@agate-dropdown-margin: 0 @agate-component-spacing;
 @agate-dropdown-smallest-width: 321px;
 @agate-dropdown-small-width: 400px;
 @agate-dropdown-medium-width: 522px;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
 When the dropdown button is on the extreme left/right of the screen, the contextual popup was not horizontally aligned with the button

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added a margin for Dropdown, to allow the Button and ContextualPopup to be aligned

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-139512

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian daniel.stoian@lgepartner.com