### PR TITLE
PLAT-141477: Copper skin text color is not clearly visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The following is a curated list of changes in the Enact agate module, newest cha
 - `agate/ImageItem` prop `sizing` to support image sizing
 - `agate/Drawer` `onShow`, `spotlightId`, and `spotlightRestrict` props to handle focus with 5-way navigation
 
+### Changed
+
+- `Copper` skin to use lighter color for text in order to be more visible
+
 ### Fixed
 
 - `agate/Checkbox` style to match latest design for Silicon skin

--- a/styles/colors-copper-day.less
+++ b/styles/colors-copper-day.less
@@ -25,7 +25,7 @@
 @agate-bg-color: @agate-light-gray;
 @agate-bg-image: radial-gradient(~"hsla(var(--agate-accent-h, 0), var(--agate-accent-s, 0), var(--agate-accent-l, 0), 0.2)", transparent 60%), linear-gradient(to bottom, @agate-bg-color 43%, @agate-white 90%);
 @agate-bg-image2: url(../assets/noise-black.png);
-@agate-text-color: @agate-darker-gray;
+@agate-text-color: @agate-gray;
 @agate-title-text-color: @agate-dark-gray;
 
 // Local copper variables
@@ -88,7 +88,7 @@
 
 // Heading
 // ---------------------------------------
-@agate-heading-text-color: @agate-darker-gray;
+@agate-heading-text-color: @agate-gray;
 @agate-heading-border-color: @agate-accent;
 
 // Icon


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When `Copper-day` skin is used in storybook, the text is barely visible, as it has almost the same color as background color. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Changed text color to be a lighter one. 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-141477

### Comments
