### PR TITLE
PLAT-141479: Fixed text size for ArcSlider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The following is a curated list of changes in the Enact agate module, newest cha
 
 - `Noto Sans` font as the default font
 
+### Fixed
+
+- `agate/ArcSlider` text size be the same on all skins
+
 ## [2.0.0-alpha.3] - 2021-04-26
 
 ### Added

--- a/styles/variables-base.less
+++ b/styles/variables-base.less
@@ -63,8 +63,8 @@
 // ArcSlider
 // -------------------------------------------------
 @agate-arcslider-value-display-max-width: 80%;
-@agate-arcslider-font-size: inherit;
-@agate-arcslider-font-weight: inherit;
+@agate-arcslider-font-size: 72px;
+@agate-arcslider-font-weight: 300;
 
 // Button
 // ---------------------------------------

--- a/styles/variables-gallium.less
+++ b/styles/variables-gallium.less
@@ -7,11 +7,6 @@
 @agate-arcpicker-font-size: 72px;
 @agate-arcpicker-font-weight: 300;
 
-// ArcSlider
-// -------------------------------------------------
-@agate-arcslider-font-size: 72px;
-@agate-arcslider-font-weight: 300;
-
 // Button
 // ---------------------------------------
 @agate-button-border-radius: 6px;

--- a/styles/variables-silicon.less
+++ b/styles/variables-silicon.less
@@ -18,11 +18,6 @@
 @agate-arcpicker-font-size: 72px;
 @agate-arcpicker-font-weight: 300;
 
-// ArcSlider
-// -------------------------------------------------
-@agate-arcslider-font-size: 72px;
-@agate-arcslider-font-weight: 300;
-
 // Body
 // ----------------------------------
 @agate-body-small-font-size: 21px;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The text-size in TemperatureControl/Arcslider was too small for all skins except Gallium/Silicon

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Since there is no official GUI spec for ArcSlider besided Silicon skins, The same values from Silicon were applied to all skins

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-141479

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian daniel.stoian@lgepartner.com