### PR TITLE
PLAT-141485: Fixed checkbox icon size and focus color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The following is a curated list of changes in the Enact agate module, newest cha
 
 - `Noto Sans` font as the default font
 
+### Fixed
+
+- `agate/Checkbox` icon font-size for Carbon, Cobalt, Copper, Electro, and Titanium skins
+
 ## [2.0.0-alpha.3] - 2021-04-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 
 ### Fixed
 
-- `agate/Checkbox` icon font-size for Carbon, Cobalt, Copper, Electro, and Titanium skins
+- `agate/Checkbox` icon font-size and focus color for Carbon, Cobalt, Copper, Electro, and Titanium skins
 
 ## [2.0.0-alpha.3] - 2021-04-26
 

--- a/Checkbox/Checkbox.module.less
+++ b/Checkbox/Checkbox.module.less
@@ -37,6 +37,7 @@
 		.focus({
 			background-color: @agate-checkbox-focus-bg-color;
 			border-radius: @agate-checkbox-border-radius;
+			color: @agate-checkbox-text-color;
 
 			.bg {
 				background-image: @agate-checkbox-focus-bg-image;

--- a/styles/variables-base.less
+++ b/styles/variables-base.less
@@ -169,8 +169,8 @@
 @agate-checkbox-border-radius: inherit;
 @agate-checkbox-border-width: inherit;
 @agate-checkbox-container-position: inherit;
-@agate-checkbox-icon-font-size: inherit;
-@agate-checkbox-size: 46px;
+@agate-checkbox-icon-font-size: 48px;
+@agate-checkbox-size: 45px;
 
 // CheckboxItem
 // ---------------------------------------

--- a/styles/variables-gallium.less
+++ b/styles/variables-gallium.less
@@ -28,7 +28,6 @@
 // ---------------------------------------
 @agate-checkbox-border-width: 0;
 @agate-checkbox-border-radius: 6px;
-@agate-checkbox-icon-font-size: 49px;
 
 // CheckboxItem
 // ---------------------------------------

--- a/styles/variables-silicon.less
+++ b/styles/variables-silicon.less
@@ -75,7 +75,6 @@
 @agate-checkbox-border-radius: 50%;
 @agate-checkbox-border-width: 3px;
 @agate-checkbox-container-position: ((@agate-checkbox-size + (@agate-checkbox-border-width * 2) - 60px) / 2); // Container's total dimensions should be `60px` defined in the GUI spec
-@agate-checkbox-icon-font-size: 49px;
 @agate-checkbox-size: 24px;
 
 // CheckboxItem


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The checkbox icon size was too small for Carbon/Copper/Cobalt/Electro/Titanium skins compared to its parent container
The color was invisible for Cobalt and Copper skins, on focus.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added the same icon font-size as in Gallium and Silicon skins. (For Gallium and Silicon the value is changed from 49px to 48px to respect the enact resolution independence rules - multiple of 3)
Changed  @agate-checkbox-size from 46px to 45px to be a multiple of 3 and respect the enact resolution independence rules
Added color for focus state, the same as for normal state, in order to override spottable styles.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-141485

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian daniel.stoian@lgepartner.com