### PR TITLE
PLAT-141638: Fixed RadioItem icon border-color for focused state in Carbon skin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The following is a curated list of changes in the Enact agate module, newest cha
 
 - `Noto Sans` font as the default font
 
+### Fixed
+
+- `agate/RadioItem` icon border-color to be visible when item is focused in Carbon skin
+
 ## [2.0.0-alpha.3] - 2021-04-26
 
 ### Added

--- a/styles/colors-carbon.less
+++ b/styles/colors-carbon.less
@@ -155,7 +155,7 @@
 // RadioItem
 // ---------------------------------------
 @agate-radioitem-focus-color: @agate-item-color;
-@agate-radioitem-icon-border-color: @agate-highlight;
+@agate-radioitem-icon-border-color: @agate-accent;
 @agate-radioitem-icon-bg-color: transparent;
 @agate-radioitem-icon-focus-bg-color: @agate-radioitem-icon-bg-color;
 @agate-radioitem-icon-selected-bg-color: @agate-radioitem-icon-bg-color;


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
On Carbon skin, when RadioItem was focused, the border-color of the icon was invisible. I changed the value to @agate-accent to have the same color as text and circle that shows selected state.

### Links
[//]: # (Related issues, references)
PLAT-141638

### Comments