### PR TITLE
PLAT-141621: Fixed Popup body background-color for other skins than Silicon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ The following is a curated list of changes in the Enact agate module, newest cha
 
 - `agate/Popup` to have the same background-color for body and buttons section for all skins except Silicon
 
-
 ## [2.0.0-alpha.3] - 2021-04-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The following is a curated list of changes in the Enact agate module, newest cha
 
 - `Noto Sans` font as the default font
 
+### Fixed
+
+- `agate/Popup` to have the same background-color for body and buttons section for all skins except Silicon
+
+
 ## [2.0.0-alpha.3] - 2021-04-26
 
 ### Added

--- a/styles/colors-base.less
+++ b/styles/colors-base.less
@@ -323,7 +323,7 @@
 @agate-popup-body-border-color: inherit;
 @agate-popup-body-bg-color: inherit;
 @agate-popup-body-bg-image: inherit;
-@agate-popup-buttons-bg-color: inherit;
+@agate-popup-buttons-bg-color: transparent;
 @agate-popup-text-color: @agate-text-color;
 
 // PopupMenu


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Set buttons section background-color to transparent for all skins, except Silicon. The bug was introduced when Silicon updated its design requirements and had a different background-color for the buttons section.

### Links
[//]: # (Related issues, references)
PLAT-141621

### Comments