### PR TITLE
PLAT-141636: Fixed SliderButton text color to be more visible on Carbon skin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The following is a curated list of changes in the Enact agate module, newest cha
 
 - `Noto Sans` font as the default font
 
+### Fixed
+
+- `agate/SliderButton` button text color to be more visible on Carbon skin
+
 ## [2.0.0-alpha.3] - 2021-04-26
 
 ### Added

--- a/styles/colors-carbon.less
+++ b/styles/colors-carbon.less
@@ -211,7 +211,7 @@
 
 // SliderButton
 // ---------------------------------------
-@agate-sliderbutton-color:          @agate-accent;
+@agate-sliderbutton-color:          @agate-foreground;
 @agate-sliderbutton-bg-color:       @agate-slider-track-bg-color;
 @agate-sliderbutton-bg-image:       @agate-slider-track-bg-image;
 @agate-sliderbutton-focus-color:    @agate-slider-focus-color;


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
On Carbon skin, the text color for the buttons in SliderButton component was hardly visible, so I changed it to a more visible one.

### Links
[//]: # (Related issues, references)
PLAT-141636

### Comments