### PR TITLE
PLAT-141486: ThumbnailItem - image not visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 - `agate/Slider` to apply focus styling while dragging by touch
 - `agate/SliderButton` button text color to be more visible on Carbon skin
 - `agate/ThumbnailItem` to match latest design for Silicon skin
+- `agate/ThumbnailItem` to display thumbnail image properly in all skins
 
 ## [2.0.0-alpha.3] - 2021-04-26
 
@@ -41,7 +42,6 @@ The following is a curated list of changes in the Enact agate module, newest cha
 
 - `agate/Checkbox`, `agate/FanSpeedControl`, `agate/ImageItem`, `agate/Item`, and `agate/WindDirectionControl` to match latest design for Silicon skin
 - `agate/Dropdown` misalignment of `Button` and `ContextualPopup` on the edge of screen
-- `agate/ThumbnailItem` height and image size
 
 ## [2.0.0-alpha.2] - 2021-04-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 
 - `agate/Checkbox`, `agate/FanSpeedControl`, `agate/ImageItem`, `agate/Item`, and `agate/WindDirectionControl` to match latest design for Silicon skin
 - `agate/Dropdown` misalignment of `Button` and `ContextualPopup` on the edge of screen
+- `agate/ThumbnailItem` height and image size
 
 ## [2.0.0-alpha.2] - 2021-04-02
 

--- a/styles/variables-base.less
+++ b/styles/variables-base.less
@@ -776,11 +776,11 @@
 // ThumbnailItem
 // ---------------------------------------
 @agate-thumbnailitem-line-height: inherit;
-@agate-thumbnailitem-height: inherit;
+@agate-thumbnailitem-height: 120px;
 @agate-thumbnailitem-content-font-size: inherit;
 @agate-thumbnailitem-label-font-size: inherit;
-@agate-thumbnailitem-thumbnail-height: inherit;
-@agate-thumbnailitem-thumbnail-width: inherit;
+@agate-thumbnailitem-thumbnail-height: 60px;
+@agate-thumbnailitem-thumbnail-width: 60px;
 @agate-thumbnailitem-round-border-radius: inherit;
 @agate-roundthumbnailitem-border-width: inherit;
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The ThumbnailItem and its thumbnail image would not display correctly for skins other than Silicon and Gallium.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Made ThumbnailItem and its thumbnail image display correctly.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-141486

### Comments

Enact-DCO-1.0-Signed-off-by: Paul Beldean paul.beldean@lgepartner.com