### PR TITLE
PLAT-141632: Fixed ProgressBar tooltip to not be clipped

### DIFF
--- a/samples/sampler/stories/default/ProgressBar.js
+++ b/samples/sampler/stories/default/ProgressBar.js
@@ -1,6 +1,7 @@
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {boolean, select, number} from '@enact/storybook-utils/addons/knobs';
 import UiProgressBar from '@enact/ui/ProgressBar';
+import ri from '@enact/ui/resolution';
 import ProgressBar, {ProgressBarBase, ProgressBarTooltip} from '@enact/agate/ProgressBar';
 
 ProgressBar.displayName = 'ProgressBar';
@@ -18,6 +19,9 @@ export const _ProgressBar = () => {
 	// added here to force Storybook to put the ProgressBar tab first
 	const disabled = boolean('disabled', ProgressBarConfig);
 
+	// added here to add conditioned styling to vertical ProgressBar so that the tooltip is visible when positioned "left" on LTR or "right" on RTL
+	const orientation = select('orientation', ['horizontal', 'vertical'], ProgressBarConfig);
+
 	// tooltip is first so it appears at the top of the tab. the rest are alphabetical
 	const tooltip = boolean('tooltip', ProgressBarTooltipConfig);
 	const position = select('position', ['', 'above', 'above left', 'above center', 'above right', 'above before', 'above after', 'before', 'left', 'right', 'after', 'below', 'below left', 'below center', 'below right', 'below before', 'below after'], ProgressBarTooltipConfig, '');
@@ -27,10 +31,11 @@ export const _ProgressBar = () => {
 			backgroundProgress={number('backgroundProgress', ProgressBarConfig, {range: true, min: 0, max: 1, step: 0.01}, 0.5)}
 			disabled={disabled}
 			highlighted={boolean('highlighted', ProgressBarConfig)}
-			orientation={select('orientation', ['horizontal', 'vertical'], ProgressBarConfig)}
+			orientation={orientation}
 			progress={number('progress', ProgressBarConfig, {range: true, min: 0, max: 1, step: 0.01}, 0.4)}
 			progressAnchor={number('progressAnchor', ProgressBarConfig, {range: true, min: 0, max: 1, step: 0.01}, 0)}
 			size={select('size', ['small', 'large'], ProgressBarConfig)}
+			style={orientation === 'vertical' ? {marginLeft: ri.scaleToRem(93), marginRight: ri.scaleToRem(72)} : null}
 		>
 			{tooltip ? (
 				<ProgressBarTooltip


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
On all skins, in storybook, when orientation was 'vertical', the tooltip was clipped if positioned "left" on LTR and "right" on RTL. I added a margin left and a margin right to the sample to solve the issue.

### Links
[//]: # (Related issues, references)
PLAT-141632

### Comments