### PR TITLE
PLAT-142521: FanSpeedControl - "empty" value is not displayed in the icon list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 
 - `agate/ArcSlider` text size be the same on all skins
 - `agate/ArcSlider` style to match latest design for Silicon skin
-- `agate/FanSpeedControl` to not display an icon when "icon" prop is not passed
+- `agate/FanSpeedControl` to not display an icon when `icon` prop is not passed
 - `agate/RadioItem` icon border-color to be visible when item is focused in Carbon skin
 - `agate/Popup` to have the same background-color for body and buttons section for all skins except Silicon
 - `agate/Popup` to match latest design for Silicon skin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 
 - `agate/ArcSlider` text size be the same on all skins
 - `agate/ArcSlider` style to match latest design for Silicon skin
+- `agate/FanSpeedControl` to not display an icon when "icon" prop is not passed
 - `agate/RadioItem` icon border-color to be visible when item is focused in Carbon skin
 - `agate/Popup` to have the same background-color for body and buttons section for all skins except Silicon
 - `agate/Popup` to match latest design for Silicon skin

--- a/FanSpeedControl/FanSpeedControl.js
+++ b/FanSpeedControl/FanSpeedControl.js
@@ -102,7 +102,6 @@ const FanSpeedControlBase = kind({
 	},
 
 	defaultProps: {
-		icon: 'fan',
 		max: 10,
 		min: 1,
 		value: 1

--- a/FanSpeedControl/tests/FanSpeedControl-specs.js
+++ b/FanSpeedControl/tests/FanSpeedControl-specs.js
@@ -61,7 +61,7 @@ describe('FanSpeedControl Specs', () => {
 		expect(actual).toBe(expected);
 	});
 
-	test('should not display an icon when "icon" props is not passed to component', () => {
+	test('should not display an icon when "icon" prop is not passed to component', () => {
 		const fanSpeedControl = mount(
 			<FanSpeedControl />
 		);

--- a/FanSpeedControl/tests/FanSpeedControl-specs.js
+++ b/FanSpeedControl/tests/FanSpeedControl-specs.js
@@ -50,4 +50,24 @@ describe('FanSpeedControl Specs', () => {
 		const actual = handleChange.mock.calls.length;
 		expect(actual).toBe(expected);
 	});
+
+	test('should display an icon when "icon" prop is passed to component', () => {
+		const fanSpeedControl = mount(
+			<FanSpeedControl icon="fan" />
+		);
+
+		const expected = 983227; // decimal converted charCode of Unicode 'fan' character
+		const actual = fanSpeedControl.find('Icon').text().codePointAt();
+		expect(actual).toBe(expected);
+	});
+
+	test('should not display an icon when "icon" props is not passed to component', () => {
+		const fanSpeedControl = mount(
+			<FanSpeedControl />
+		);
+
+		const expected = undefined; // eslint-disable-line
+		const actual = fanSpeedControl.find('Icon').text().codePointAt();
+		expect(actual).toBe(expected);
+	});
 });

--- a/tests/ui/apps/FanSpeedControl/FanSpeedControl-View.js
+++ b/tests/ui/apps/FanSpeedControl/FanSpeedControl-View.js
@@ -12,18 +12,18 @@ spotlight.setPointerMode(false);
 const app = (props) => <div {...props}>
 	<div>
 		<Section>
-			<Heading>FanSpeedControl Default</Heading>
+			<Heading>FanSpeedControl without icon</Heading>
 			<FanSpeedControl
-				id="fanSpeedControlDefault"
+				id="fanSpeedControlWithoutIcon"
 				max={10}
 				min={1}
 			/>
 		</Section>
 		<Section>
-			<Heading>FanSpeedControl Custom</Heading>
+			<Heading>FanSpeedControl with icon</Heading>
 			<FanSpeedControl
-				id="fanSpeedControlCustom"
-				icon="happyface"
+				id="fanSpeedControlWithIcon"
+				icon="fan"
 				max={10}
 				min={1}
 			/>
@@ -32,6 +32,7 @@ const app = (props) => <div {...props}>
 			<Heading>FanSpeedControl Disabled</Heading>
 			<FanSpeedControl
 				id="fanSpeedControlDisabled"
+				icon="fan"
 				disabled
 				max={10}
 				min={1}

--- a/tests/ui/specs/FanSpeedControl/FanSpeedControl-specs.js
+++ b/tests/ui/specs/FanSpeedControl/FanSpeedControl-specs.js
@@ -8,8 +8,8 @@ describe('FanSpeedControl', function () {
 		Page.open();
 	});
 
-	describe('default', function () {
-		const fanSpeedControl = Page.components.fanSpeedControlDefault;
+	describe('without icon', function () {
+		const fanSpeedControl = Page.components.fanSpeedControlWithoutIcon;
 
 		it('should have the first arc selected by default', function () {
 			Page.spotlightSelect();
@@ -26,8 +26,8 @@ describe('FanSpeedControl', function () {
 			expect(fanSpeedControl.coloredPath(4).getCSSProperty('stroke').value).to.equal(unselectedColor);
 		});
 
-		it('should display `fan` icon', function () {
-			expect(fanSpeedControl.iconValue()).to.equal(983227); // decimal converted charCode of Unicode 'fan' character
+		it('should not display an icon', function () {
+			expect(fanSpeedControl.iconValue()).to.equal(undefined); // eslint-disable-line
 		});
 
 		it('should display value `1` by default', function () {
@@ -41,11 +41,11 @@ describe('FanSpeedControl', function () {
 		});
 	});
 
-	describe('custom', function () {
-		const fanSpeedControl = Page.components.fanSpeedControlCustom;
+	describe('with icon', function () {
+		const fanSpeedControl = Page.components.fanSpeedControlWithIcon;
 
-		it('should display custom icon', function () {
-			expect(fanSpeedControl.iconValue()).to.equal(983060); // decimal converted charCode of Unicode 'happyface' character
+		it('should display an icon', function () {
+			expect(fanSpeedControl.iconValue()).to.equal(983227); // decimal converted charCode of Unicode 'fan' character
 		});
 	});
 

--- a/tests/ui/specs/FanSpeedControl/FanSpeedControlPage.js
+++ b/tests/ui/specs/FanSpeedControl/FanSpeedControlPage.js
@@ -28,11 +28,11 @@ class FanSpeedControlPage extends Page {
 	constructor () {
 		super();
 		this.title = 'FanSpeedControl Test';
-		const fanSpeedControlDefault = new FanSpeedControlInterface('fanSpeedControlDefault');
-		const fanSpeedControlCustom = new FanSpeedControlInterface('fanSpeedControlCustom');
+		const fanSpeedControlWithoutIcon = new FanSpeedControlInterface('fanSpeedControlWithoutIcon');
+		const fanSpeedControlWithIcon = new FanSpeedControlInterface('fanSpeedControlWithIcon');
 		const fanSpeedControlDisabled = new FanSpeedControlInterface('fanSpeedControlDisabled');
 
-		this.components = {fanSpeedControlDefault, fanSpeedControlCustom, fanSpeedControlDisabled};
+		this.components = {fanSpeedControlWithoutIcon, fanSpeedControlWithIcon, fanSpeedControlDisabled};
 	}
 
 	open (urlExtra) {


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Adrian Cocoara adrian.cocoara@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
An icon is always displayed even if there is no `icon` prop passed to component

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Deleted `icon` from `defaultProps`
Updated unit and UI tests

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-142521

### Comments