### PR TITLE
PLAT-142521: Fix not applying empty string to FanSpeedControl sampler

### DIFF
--- a/samples/sampler/stories/default/FanSpeedControl.js
+++ b/samples/sampler/stories/default/FanSpeedControl.js
@@ -1,12 +1,13 @@
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {action} from '@enact/storybook-utils/addons/actions';
-import {boolean, number, select} from '@enact/storybook-utils/addons/knobs';
-import FanSpeedControl from '@enact/agate/FanSpeedControl';
+import {boolean, number} from '@enact/storybook-utils/addons/knobs';
+import {FanSpeedControl, FanSpeedControlBase} from '@enact/agate/FanSpeedControl';
+import {select} from '@storybook/addon-knobs';
 
 import {iconList} from './util/icons';
 
 FanSpeedControl.displayName = 'FanSpeedControl';
-const Config = mergeComponentMetadata('FanSpeedControl', FanSpeedControl);
+const Config = mergeComponentMetadata('FanSpeedControl', FanSpeedControl, FanSpeedControlBase);
 
 export default {
 	title: 'Agate/FanSpeedControl',
@@ -16,7 +17,7 @@ export default {
 export const _FanSpeedControl = () => (
 	<FanSpeedControl
 		disabled={boolean('disabled', Config)}
-		icon={select('icon', ['', ...iconList], Config, 'fan')}
+		icon={select('icon', ['', ...iconList], Config.defaultProps['icon'], 'FanSpeedControl')}
 		max={number('max', Config, {max: 40, min: 1, range: true, step: 1}, 10)}
 		min={number('min', Config, {max: 40, min: 1, range: true, step: 1}, 1)}
 		onChange={action('onChange')}


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The empty string didn't apply to the icon prop in FanSpeedControl sampler.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Since our storybook-utils `select` nullifies the null string, so the empty string couldn't be applied.
Replaced that with the one from @storybook/addon-knobs.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Maybe we need to add some options for not nullifying the value.

### Links
[//]: # (Related issues, references)
PLAT-142521

### Comments
