### PR TITLE
PLAT-141482: Fixed ArcPicker visibility issue for Titanium skin.

### DIFF
--- a/ArcPicker/ArcPicker.js
+++ b/ArcPicker/ArcPicker.js
@@ -121,6 +121,14 @@ const ArcPickerBase = kind({
 		 */
 		selectionType: PropTypes.oneOf(['cumulative', 'single']),
 
+		/**
+		 * The current skin for this component.
+		 *
+		 * @type {String}
+		 * @public
+		 */
+		skin: PropTypes.string,
+
 		/*
 		 * State of possible skin variants.
 		 *
@@ -185,8 +193,8 @@ const ArcPickerBase = kind({
 	computed: {
 		arcSegments: (props, context) => {
 			const {accent: accentColor} = context || {};
-			const {children, endAngle, isFocused, onClick, radius, selectionType, skinVariants, startAngle, strokeWidth, value} = props;
-			const backgroundColor = props.backgroundColor || (skinVariants && skinVariants.night ? '#444444' : '#888888');
+			const {children, endAngle, isFocused, onClick, radius, selectionType, skin, skinVariants, startAngle, strokeWidth, value} = props;
+			const backgroundColor = props.backgroundColor || (skinVariants && skinVariants.night ?  '#444444' : skin === 'titanium'? '#fff' : '#888888');
 			const foregroundColor = props.foregroundColor || (skinVariants && skinVariants.night ? '#ffffff' : '#000000');
 
 			if (!Array.isArray(children)) return [];
@@ -255,7 +263,10 @@ const ArcPickerDecorator = compose(
 	Changeable,
 	ArcPickerBehaviorDecorator,
 	Spottable,
-	Skinnable({variantsProp: 'skinVariants'})
+	Skinnable({
+		prop: 'skin',
+		variantsProp: 'skinVariants'
+	})
 );
 
 /**

--- a/ArcPicker/ArcPicker.js
+++ b/ArcPicker/ArcPicker.js
@@ -195,7 +195,7 @@ const ArcPickerBase = kind({
 			const {accent: accentColor} = context || {};
 			const {children, endAngle, isFocused, onClick, radius, selectionType, skin, skinVariants, startAngle, strokeWidth, value} = props;
 
-			const backgroundColorNight = skin === 'titanium' ? '#fff' : '#888888';
+			const backgroundColorNight = skin === 'titanium' ? '#ffffff' : '#888888';
 			const backgroundColor = props.backgroundColor || (skinVariants && skinVariants.night ?  '#444444' : backgroundColorNight);
 			const foregroundColor = props.foregroundColor || (skinVariants && skinVariants.night ? '#ffffff' : '#000000');
 

--- a/ArcPicker/ArcPicker.js
+++ b/ArcPicker/ArcPicker.js
@@ -194,7 +194,9 @@ const ArcPickerBase = kind({
 		arcSegments: (props, context) => {
 			const {accent: accentColor} = context || {};
 			const {children, endAngle, isFocused, onClick, radius, selectionType, skin, skinVariants, startAngle, strokeWidth, value} = props;
-			const backgroundColor = props.backgroundColor || (skinVariants && skinVariants.night ?  '#444444' : skin === 'titanium'? '#fff' : '#888888');
+
+			const backgroundColorNight = skin === 'titanium' ? '#fff' : '#888888';
+			const backgroundColor = props.backgroundColor || (skinVariants && skinVariants.night ?  '#444444' : backgroundColorNight);
 			const foregroundColor = props.foregroundColor || (skinVariants && skinVariants.night ? '#ffffff' : '#000000');
 
 			if (!Array.isArray(children)) return [];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 
 ### Fixed
 
+- `agate/ArcPicker` default background color for Titanium skin
 - `agate/ArcSlider` text size be the same on all skins
 - `agate/ArcSlider` style to match latest design for Silicon skin
 - `agate/RadioItem` icon border-color to be visible when item is focused in Carbon skin


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
On Titanium skin is hard to separate the selected and unselected segments while hovering over it.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Changed the color from Grey to White only on Titanium Skin.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-141482

### Comments
Enact-DCO-1.0-Signed-off-by: Alexandru Morariu alexandru.morariu@lgepartner.com