### PR TITLE
PLAT-143413: [Screenshot test] Set default input-type class for focus

### DIFF
--- a/tests/screenshot/apps/Agate-View.js
+++ b/tests/screenshot/apps/Agate-View.js
@@ -1,7 +1,7 @@
 import classnames from 'classnames/bind';
 import spotlight from '@enact/spotlight';
 import {urlParamsToObject} from '@enact/ui-test-utils/utils';
-import {cloneElement, Component as ReactComponent} from 'react';
+import {cloneElement, Component as ReactComponent, useEffect} from 'react';
 
 import ThemeDecorator from '../../../ThemeDecorator';
 
@@ -143,6 +143,11 @@ const ExportedAgateApp = (props) => {
 	}
 
 	const WrappedAgateApp = ThemeDecorator({noAutoFocus}, App);
+
+	useEffect(() => {
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		document.querySelector('#root > div').classList.add('spotlight-input-key');
+	}, []);
 
 	return (
 		<WrappedAgateApp {...props} skin={skin} skinVariants={skinVariants} locale={locale} />


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There is screenshot test fail about focus



### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)

Set default input-type class for focus.
Fix wrong TC on FormCheckboxItem (regression from #856)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
PLAT-143413

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)