### PR TITLE
PLAT-144923: Popup button must be centered in Silicon skin

### DIFF
--- a/samples/sampler/stories/default/Popup.js
+++ b/samples/sampler/stories/default/Popup.js
@@ -55,7 +55,6 @@ export const _Popup = () => {
 	);
 };
 
-
 _Popup.storyName = 'Popup';
 _Popup.parameters = {
 	info: {

--- a/samples/sampler/stories/default/Popup.js
+++ b/samples/sampler/stories/default/Popup.js
@@ -55,6 +55,7 @@ export const _Popup = () => {
 	);
 };
 
+
 _Popup.storyName = 'Popup';
 _Popup.parameters = {
 	info: {

--- a/samples/sampler/stories/default/Popup.js
+++ b/samples/sampler/stories/default/Popup.js
@@ -10,6 +10,9 @@ const Config = mergeComponentMetadata('Popup', PopupBase);
 const prop = {
 	buttons: {
 		'no buttons': null,
+		'1 button': <buttons>
+			<Button>OK</Button>
+		</buttons>,
 		'2 buttons': <buttons>
 			<Button>OK</Button>
 			<Button>Cancel</Button>
@@ -23,7 +26,7 @@ export default {
 };
 
 export const _Popup = () => {
-	const buttonsSelection = select('buttons', ['no buttons', '2 buttons'], Config, 'no');
+	const buttonsSelection = select('buttons', ['no buttons', '1 button', '2 buttons'], Config, 'no');
 	const buttons = prop.buttons[buttonsSelection];
 
 	return (


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
On Silicon skin, the button/buttons in Popup must be centered at all times. I added an extra story for Popup with 1 button to check this. 

### Links
[//]: # (Related issues, references)
PLAT-144923

### Comments