### PR TITLE
PLAT-122723: Fix VirtualList 5-way navigation between scroll buttons when `focusableScrollbars`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact agate module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `agate/VirtualList` 5-way navigation between scroll buttons when `focusableScrollbar`
+
 ## [2.0.0-beta.2] - 2021-06-24
 
 ### Added

--- a/useScroll/ScrollButtons.js
+++ b/useScroll/ScrollButtons.js
@@ -3,7 +3,7 @@ import {getTargetByDirectionFromElement} from '@enact/spotlight/src/target';
 import {is} from '@enact/core/keymap';
 import Spotlight, {getDirection} from '@enact/spotlight';
 import utilEvent from '@enact/ui/useScroll/utilEvent';
-import {createRef, useState, useEffect} from 'react';
+import {useRef, useState, useEffect} from 'react';
 import ReactDOM from 'react-dom';
 
 const
@@ -40,18 +40,21 @@ const useScrollButtons = (props) => {
 	const [prevButtonDisabled, setPrevButtonDisabled] = useState(true);
 	const [nextButtonDisabled, setNextButtonDisabled] = useState(true);
 
-	const nextButtonRef = createRef();
-	const prevButtonRef = createRef();
+	const nextButtonRef = useRef();
+	const prevButtonRef = useRef();
 
 	useEffect(() => {
-		utilEvent('keydown').addEventListener(nextButtonRef, onKeyDownNext);
-		utilEvent('keydown').addEventListener(prevButtonRef, onKeyDownPrev);
+		const nextRef = nextButtonRef.current;
+		const prevRef = prevButtonRef.current;
+
+		utilEvent('keydown').addEventListener(nextRef, onKeyDownNext);
+		utilEvent('keydown').addEventListener(prevRef, onKeyDownPrev);
 
 		return () => {
-			utilEvent('keydown').removeEventListener(nextButtonRef, onKeyDownNext);
-			utilEvent('keydown').removeEventListener(prevButtonRef, onKeyDownPrev);
+			utilEvent('keydown').removeEventListener(nextRef, onKeyDownNext);
+			utilEvent('keydown').removeEventListener(prevRef, onKeyDownPrev);
 		};
-	}, []);	// eslint-disable-line react-hooks/exhaustive-deps
+	});
 
 	const updateButtons = (bounds) => {
 		const


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
5-way `down` from `up` scrollbar button goes to a list item.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
`createRef` returns a new ref on every render so it should be `useRef`.
Removed [] dependency since it needs to be updated when props changed.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
PLAT-122723

### Comments
