### PR TITLE
WRN-3773: Fix 5-way navigation of list items when item's internal content is updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 - `agate/ContextualPopupDecorator` layout for Carbon, Cobalt, Copper, Electro, Titanium skins
 - `agate/TabGroup` button padding for Cobalt and Copper skins
 - `agate/VirtualList` 5-way navigation between scroll buttons when `focusableScrollbar`
+- `agate/VirtualList` 5-way navigation between items properly when item's content is updated
 
 ## [2.0.0-beta.2] - 2021-06-24
 

--- a/VirtualList/useThemeVirtualList.js
+++ b/VirtualList/useThemeVirtualList.js
@@ -28,8 +28,12 @@ const useSpottable = (props, instances) => {
 	const {scrollMode} = props;
 	const {itemRefs, scrollContainerRef, scrollContentHandle} = instances;
 	const getItemNode = (index) => {
-		const itemNode = itemRefs.current[index % scrollContentHandle.current.state.numOfItems];
-		return (itemNode && parseInt(itemNode.dataset.index) === index) ? itemNode : null;
+		const itemContainerRef = itemRefs.current[index % scrollContentHandle.current.state.numOfItems];
+		if (itemContainerRef) {
+			const itemNode = itemContainerRef.children[0];
+			return (parseInt(itemNode.dataset.index) === index) ? itemNode : itemContainerRef.querySelector(`[data-index="${index}"]`);
+		}
+		return null;
 	};
 
 	// Mutable value


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
5-way navigation to an *updated (re-rendered)* item fails when item's content is updated without updating a list.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The issue occurs due to an invalid DOM node info which is used to target 5-way navigation.
`enact/ui`'s logic is updated in enactjs/enact/pull/2937 to provide safe item container nodes rather than item nodes which could be invalidated by item-internal rendering, and this PR updates `VirtualList` to use the item container nodes.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-3773
enactjs/enact/pull/2937

### Comments
