### PR TITLE
WRN-792: Fix testcases for latest chrome driver 

### DIFF
--- a/tests/ui/specs/Popup/PopupPage.js
+++ b/tests/ui/specs/Popup/PopupPage.js
@@ -98,7 +98,7 @@ class PopupPage extends Page {
 	}
 
 	clickPopupFloatLayer () {
-		$('#floatLayer').click();
+		$('#floatLayer>div').click();
 	}
 
 	waitForOpen (selector, timeout) {

--- a/tests/ui/specs/VirtualList/VirtualGridList/VirtualGridList-specs.js
+++ b/tests/ui/specs/VirtualList/VirtualGridList/VirtualGridList-specs.js
@@ -36,7 +36,7 @@ describe('Focus after calling scrollTo()', function () {
 		Page.showPointerByKeycode();
 		Page.item(20).moveTo();
 		// Click 'Click me' item.
-		browser.positionClick();
+		Page.item(20).click();
 		Page.delay(500);
 		// Verify: list is scrolled to first item.
 		expect(Page.topLeftVisibleItemId()).to.equal('item0');


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When we use latest chrome driver not 2.44, some test cases are failed due to api change.

1.
element not interactable: element has zero size

2.
move target out of bounds
  (Session info: headless chrome=87.0.4280.141)
[chrome 87.0.4280.141 linux #0-15] move target out of bounds

3.
browser.positionClick is not a function
[chrome 87.0.4280.141 linux #0-15] TypeError: browser.positionClick is not a function

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- positionClick() is replaced with click();
- Prevent to move target out of bound
- Interact (eg. click) with "#floatLayer>div"instead of "#floatLayer"because the size is zero. 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRN-792
Jenkins pass : 

### Comments
