### PR TITLE
WRN-2730: Fix the title of story is the same as the story name in QA sampler

### DIFF
--- a/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
+++ b/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
@@ -234,13 +234,15 @@ const StorybookDecorator = (story, config) => {
 		}
 	}
 
+	const componentName = config.kind.replace(/^([^/]+)\//, '');
+
 	// NOTE: 'config' object is not extensible
 	const hasInfoText = config.parameters && config.parameters.info && config.parameters.info.text;
 	const hasProps = config.parameters && config.parameters.props;
 
 	return (
 		<Theme
-			title={`${config.kind}`.replace(/\//g, ' ').trim()}
+			title={componentName === config.name ? `${config.kind}`.replace(/\//g, ' ').trim() : `${componentName} ${config.name}`}
 			description={hasInfoText ? config.parameters.info.text : null}
 			locale={globals.locale}
 			{...skinKnobs}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Before migrating storybook 6.x, the title of each sample was the same as its story name.
There seems to be a bug when migrating the storybook.


### Resolution
Make the title of each sample the same as the story name.


### Additional Considerations


### Links
WRN-2730


### Comments
