### PR TITLE
WRN-6758: Changed Input numeric keyboard for Samsung devices.

### DIFF
--- a/Input/Input.js
+++ b/Input/Input.js
@@ -288,7 +288,16 @@ const InputBase = kind({
 		},
 		className: ({focused, iconBefore, iconAfter, invalid, size, styler, value}) => styler.append({emptyValue: !value, focused, invalid, hasIconBefore: iconBefore, hasIconAfter: iconAfter}, size),
 		dir: ({value, placeholder}) => isRtlText(value || placeholder) ? 'rtl' : 'ltr',
-		invalidTooltip: ({css, invalid, invalidMessage = $L('Please enter a valid value.')}) => {
+		inputMode: ({type}) => {
+			// eslint-disable-next-line
+			const samsung = navigator.userAgent.includes('SM-');
+			return type === 'number' && samsung ? 'numeric' : '';
+		},
+		inputType: ({type}) => {
+			// eslint-disable-next-line
+			const samsung = navigator.userAgent.includes('SM-');
+			return type === 'number' && samsung ? 'text' : type;
+		},invalidTooltip: ({css, invalid, invalidMessage = $L('Please enter a valid value.')}) => {
 			if (invalid && invalidMessage) {
 				return (
 					<Tooltip css={css} relative>
@@ -301,7 +310,7 @@ const InputBase = kind({
 		value: ({value}) => typeof value === 'number' ? value : (value || '')
 	},
 
-	render: ({clearButton, clearIcon, css, dir, disabled, handleClear, iconAfter, iconBefore, invalidTooltip, onChange, placeholder, size, type, value, ...rest}) => {
+	render: ({clearButton, clearIcon, css, dir, disabled, handleClear, iconAfter, iconBefore, inputMode, inputType, invalidTooltip, onChange, placeholder, size, value, ...rest}) => {
 		const inputProps = extractInputProps(rest);
 		delete rest.dismissOnEnter;
 		delete rest.focused;
@@ -309,6 +318,7 @@ const InputBase = kind({
 		delete rest.invalidMessage;
 		delete rest.onBeforeChange;
 		delete rest.rtl;
+		delete rest.type;
 
 		return (
 			<div {...rest} aria-disabled={disabled} disabled={disabled}>
@@ -321,11 +331,12 @@ const InputBase = kind({
 					className={css.input}
 					dir={dir}
 					disabled={disabled}
+					inputMode={inputMode}
 					onChange={onChange}
 					placeholder={placeholder}
 					size={size}
 					tabIndex={-1}
-					type={type}
+					type={inputType}
 					value={value}
 				/>
 				{clearButton ? (

--- a/Input/Input.js
+++ b/Input/Input.js
@@ -297,7 +297,8 @@ const InputBase = kind({
 			// eslint-disable-next-line
 			const samsung = navigator.userAgent.includes('SM-');
 			return type === 'number' && samsung ? 'text' : type;
-		},invalidTooltip: ({css, invalid, invalidMessage = $L('Please enter a valid value.')}) => {
+		},
+		invalidTooltip: ({css, invalid, invalidMessage = $L('Please enter a valid value.')}) => {
 			if (invalid && invalidMessage) {
 				return (
 					<Tooltip css={css} relative>


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [X] Documentation was verified or is not changed
* [X] UI test was passed or is not needed
* [X] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Samsung numeric keyboard has no '-' option. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added inputMode into Input.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRN-6758

### Comments
