### PR TITLE
WRN-6762: Fixed Input not to lose focus on Android devices when used with Scroller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact agate module, newest cha
 
 ## [unreleased]
 
+### Changed
+
+- `agate/useScroll` handleResizeWindow method to not blur the focused item if its type is input
+
 ### Fixed
 
 - `agate/ContextualPopupDecorator` layout for Carbon, Cobalt, Copper, Electro, Titanium skins

--- a/samples/sampler/stories/default/Scroller.js
+++ b/samples/sampler/stories/default/Scroller.js
@@ -5,7 +5,6 @@ import ri from '@enact/ui/resolution';
 import {ScrollerBasic as UiScrollerBasic} from '@enact/ui/Scroller';
 import BodyText from '@enact/agate/BodyText';
 import Scroller from '@enact/agate/Scroller';
-import Input from "@enact/agate/Input";
 
 const prop = {
 	direction: ['both', 'horizontal', 'vertical'],

--- a/samples/sampler/stories/default/Scroller.js
+++ b/samples/sampler/stories/default/Scroller.js
@@ -5,6 +5,7 @@ import ri from '@enact/ui/resolution';
 import {ScrollerBasic as UiScrollerBasic} from '@enact/ui/Scroller';
 import BodyText from '@enact/agate/BodyText';
 import Scroller from '@enact/agate/Scroller';
+import Input from "@enact/agate/Input";
 
 const prop = {
 	direction: ['both', 'horizontal', 'vertical'],
@@ -32,6 +33,7 @@ export const _Scroller = () => (
 		spotlightDisabled={boolean('spotlightDisabled', ScrollerConfig, false)}
 		verticalScrollbar={select('verticalScrollbar', prop.scrollbarOption, ScrollerConfig)}
 	>
+		<Input type="number" />
 		<div
 			style={{
 				height: ri.scaleToRem(2004),

--- a/samples/sampler/stories/default/Scroller.js
+++ b/samples/sampler/stories/default/Scroller.js
@@ -33,7 +33,6 @@ export const _Scroller = () => (
 		spotlightDisabled={boolean('spotlightDisabled', ScrollerConfig, false)}
 		verticalScrollbar={select('verticalScrollbar', prop.scrollbarOption, ScrollerConfig)}
 	>
-		<Input type="number" />
 		<div
 			style={{
 				height: ri.scaleToRem(2004),

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -198,7 +198,7 @@ const useThemeScroll = (props, instances) => {
 	function handleResizeWindow () {
 		const focusedItem = Spotlight.getCurrent();
 
-		if (focusedItem && !platform.androidChrome && focusedItem.nodeName === 'INPUT') {
+		if (focusedItem && focusedItem.nodeName !== 'INPUT') {
 			focusedItem.blur();
 		}
 	}

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -198,7 +198,7 @@ const useThemeScroll = (props, instances) => {
 	function handleResizeWindow () {
 		const focusedItem = Spotlight.getCurrent();
 
-		if (focusedItem) {
+		if (focusedItem && !platform.androidChrome && focusedItem.nodeName === 'INPUT') {
 			focusedItem.blur();
 		}
 	}


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Adrian Cocoara adrian.cocoara@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fixed scroller on Android devices so the VKB is always displayed and you can modify the input data.

When the VKB is displaying, a page resizing is triggered, Input loses focus and the VKB disappears. Scroller has a handleResizeWindow method defined which tells the Scroller to blur the focused item. I've made a small change to that method, if the focused item is an input, the input should always be focused.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)


### Comments
