### PR TITLE
WRO-3940: Replace `className` config to `css` of ui/MarqueeDecorator

### DIFF
--- a/Button/Button.js
+++ b/Button/Button.js
@@ -337,7 +337,7 @@ const IconButtonDecorator = hoc((config, Wrapped) => {
 const ButtonDecorator = compose(
 	Pure,
 	IconButtonDecorator,
-	MarqueeDecorator({className: componentCss.marquee}),
+	MarqueeDecorator({css: componentCss}),
 	TooltipDecorator({tooltipDestinationProp: 'decoration'}),
 	UiButtonDecorator,
 	Spottable,


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Receiving the "className" config on MarqueeDecorator is not our standard way.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Replace 'className' config to `css` for `ui/MarqueeDecorator`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-3940, WRO-608

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)