### PR TITLE
WRO-2823: Updated changelog for deprecate `agate/GridListImageItem`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 
 ### Deprecated
 
-- `agate/GridListImageItem` to be removed in 2.0.0, use `agate/ImageItem` instead
+- `agate/GridListImageItem`, to be removed in 2.0.0. Use `agate/ImageItem` instead.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The following is a curated list of changes in the Enact agate module, newest cha
 
 ## [unreleased]
 
+### Deprecated
+
+- `agate/GridListImageItem` to be removed in 2.0.0, use `agate/ImageItem` instead
+
 ### Fixed
 
 - `agate/ContextualPopupDecorator` layout for Carbon, Cobalt, Copper, Electro, Titanium skins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 
 ### Deprecated
 
-- `agate/GridListImageItem`, to be removed in 2.0.0. Use `agate/ImageItem` instead.
+- `agate/GridListImageItem`, to be removed in 2.0.0. Use `agate/ImageItem` instead
 
 ### Fixed
 


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Updated changelog for deprecated `agate/GridListImageItem` to be removed in 2.0.0.


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Deprecate `agate/GridListImageItem` to be removed in 2.0.0.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-2823

### Comments
