### PR TITLE
WRO-4551:Update the node version of travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
+dist: focal
 language: node_js
 node_js:
-    - "14"
+    - lts/*
+    - node
 sudo: false
 cache: npm
+before_install:
+    - sudo apt-get update
+    - sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 install:
     - npm config set prefer-offline true
     - npm install -g enactjs/cli#develop
@@ -10,6 +15,7 @@ install:
     - git clone --branch=develop --depth 1 https://github.com/enactjs/enact ../enact
     - pushd ../enact
     - npm install
+    - npm run lerna exec -- --ignore enact-sampler --concurrency 1 -- npm --no-package-lock install
     - npm run lerna exec -- --ignore enact-sampler --concurrency 1 -- npm --no-package-lock link
     - npm run lerna link
     - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ before_install:
     - sudo apt-get update
     - sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 install:
-    - npm cache clean --force
     - npm config set prefer-offline true
     - npm install -g enactjs/cli#develop
     - npm install -g codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_install:
     - sudo apt-get update
     - sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 install:
+    - npm cache clean --force
     - npm config set prefer-offline true
     - npm install -g enactjs/cli#develop
     - npm install -g codecov

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "deep-freeze": "0.0.1",
     "eases": "^1.0.8",
     "immer": "^9.0.12",
+    "invariant": "^2.2.4",
     "prop-types": "^15.8.1",
     "ramda": "^0.28.0",
     "react": "^18.0.0",


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Requires travis test on multiple node versions including lts

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Update .travis.yml so that it can be tested on multiple node versions (lts(16), node(18))
- ubuntu 20 is required for node 18 ( https://docs.travis-ci.com/user/reference/focal/)
- 'npm link' behavior is different between npm6(node14) and npm8(node16,node18) so 'npm install' is done before 'npm link'


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-4551

### Comments
Enact-DCO-1.0-Signed-off-by: SJ RO (sj.ro@lge.com)