### PR TITLE
WRO-7974: Panels: Fixed Previous panel does not display when 5-way select button in second panel.

### DIFF
--- a/samples/sampler/stories/default/Panels.js
+++ b/samples/sampler/stories/default/Panels.js
@@ -32,10 +32,14 @@ const FirstPanel = kind({
 const SecondPanel = kind({
 	name: 'SecondPanel',
 
-	render: (props) => (
-		<Panel {...props}>
+	propTypes: {
+		onClick: PropTypes.func
+	},
+
+	render: ({onClick, ...rest}) => (
+		<Panel {...rest}>
 			<Header title="Second Panel" />
-			<Button>Click me</Button>
+			<Button onClick={onClick}>Click me</Button>
 		</Panel>
 	)
 });


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fixed Previous panel does not display when 5-way select button in second panel.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-7974

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian [daniel.stoian@lgepartner.com](mailto:daniel.stoian@lgepartner.com)