### PR TITLE
WRO-9302: [Scroller]Should not scroll when focus moves paging control to paging control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 - `agate/MediaPlayer` layout issues for Cobalt, Carbon, Copper, Electro, Titanium skins
 - `agate/Picker` and `agate/RangePicker` to match latest design for Silicon skin
 - `agate/Scroller` to update scrollButtons state on initial render
+- `agate/Scroller` shoould not scroll when focus moves from a scroll button to another
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 - `agate/MediaPlayer` layout issues for Cobalt, Carbon, Copper, Electro, Titanium skins
 - `agate/Picker` and `agate/RangePicker` to match latest design for Silicon skin
 - `agate/Scroller` to update scrollButtons state on initial render
-- `agate/Scroller` shoould not scroll when focus moves from a scroll button to another
+- `agate/Scroller` should not scroll when focus moves from a scroll button to another
 
 ### Removed
 

--- a/Scroller/useSpotlight.js
+++ b/Scroller/useSpotlight.js
@@ -9,7 +9,7 @@ const useSpotlightConfig = (props, instances) => {
 		function handleLeaveContainer ({direction, target}) {
 			// ensure we only scroll to boundary from the contents and not a scroll button which
 			// lie outside of scrollContentRef but within the spotlight container
-			if (scrollContentRef.current.contains(target) && scrollContentRef.current) {
+			if (scrollContentRef.current && scrollContentRef.current.contains(target)) {
 				const
 					{scrollBounds: {maxLeft, maxTop}, scrollPos: {left, top}} = scrollContentHandle.current,
 					isVerticalDirection = (direction === 'up' || direction === 'down'),

--- a/Scroller/useSpotlight.js
+++ b/Scroller/useSpotlight.js
@@ -2,15 +2,14 @@ import Spotlight from '@enact/spotlight';
 import {useEffect} from 'react';
 
 const useSpotlightConfig = (props, instances) => {
-	const {scrollContentHandle} = instances;
-
+	const {scrollContentHandle, scrollContentRef} = instances;
 	// Hooks
 
 	useEffect(() => {
 		function handleLeaveContainer ({direction, target}) {
 			// ensure we only scroll to boundary from the contents and not a scroll button which
 			// lie outside of scrollContentRef but within the spotlight container
-			if (props.scrollContainerContainsDangerously(target)) {
+			if (scrollContentRef.current.contains(target) && scrollContentRef.current) {
 				const
 					{scrollBounds: {maxLeft, maxTop}, scrollPos: {left, top}} = scrollContentHandle.current,
 					isVerticalDirection = (direction === 'up' || direction === 'down'),
@@ -32,7 +31,7 @@ const useSpotlightConfig = (props, instances) => {
 		}
 
 		configureSpotlight();
-	}, [props, scrollContentHandle]);
+	}, [props, scrollContentHandle, scrollContentRef]);
 };
 
 export {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
This PR solves a bug on the Scroller component. When focusableScrollbar=true, focusing the bottom button of the vertical scroller and then moving the focus to the right, beside changing the focus to the right button of the horizontal scroller, triggered also a scroll towards the button of the horizontal scroller.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-9302

### Comments
Enact-DCO-1.0-Signed-off-by: Clapou Vladut [vladut.clapou@lgepartner.com](mailto:vladut.clapou@lgepartner.com)