### PR TITLE
WRO-9305: Enact Browser background color is white when silicon night skin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 - `agate/MediaPlayer` layout issues for Cobalt, Carbon, Copper, Electro, Titanium skins
 - `agate/Picker` and `agate/RangePicker` to match latest design for Silicon skin
 - `agate/Scroller` to update scrollButtons state on initial render
-- `agate/ThemeDecorator` to properly display the background color and background image
+- `agate/ThemeDecorator` to properly apply the background color and background image
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 - `agate/MediaPlayer` layout issues for Cobalt, Carbon, Copper, Electro, Titanium skins
 - `agate/Picker` and `agate/RangePicker` to match latest design for Silicon skin
 - `agate/Scroller` to update scrollButtons state on initial render
-- `agate/ThemeDecorator` fixed a problem with background color and image
+- `agate/ThemeDecorator` so `bg` class works only at the apps' root node not at a child node of the app's root node
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 - `agate/MediaPlayer` layout issues for Cobalt, Carbon, Copper, Electro, Titanium skins
 - `agate/Picker` and `agate/RangePicker` to match latest design for Silicon skin
 - `agate/Scroller` to update scrollButtons state on initial render
+- `agate/ThemeDecorator` fixed a problem with background color 
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 - `agate/MediaPlayer` layout issues for Cobalt, Carbon, Copper, Electro, Titanium skins
 - `agate/Picker` and `agate/RangePicker` to match latest design for Silicon skin
 - `agate/Scroller` to update scrollButtons state on initial render
-- `agate/ThemeDecorator` fixed a problem with background color 
+- `agate/ThemeDecorator` fixed a problem with background color and image
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 - `agate/MediaPlayer` layout issues for Cobalt, Carbon, Copper, Electro, Titanium skins
 - `agate/Picker` and `agate/RangePicker` to match latest design for Silicon skin
 - `agate/Scroller` to update scrollButtons state on initial render
-- `agate/ThemeDecorator` so `bg` class works only at the apps' root node not at a child node of the app's root node
+- `agate/ThemeDecorator` to properly display the background color and background image
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 - `agate/MediaPlayer` layout issues for Cobalt, Carbon, Copper, Electro, Titanium skins
 - `agate/Picker` and `agate/RangePicker` to match latest design for Silicon skin
 - `agate/Scroller` to update scrollButtons state on initial render
-- `agate/ThemeDecorator` to properly apply the background color and background image
+- `agate/ThemeDecorator` to apply the background color and background image properly
 
 ### Removed
 

--- a/ThemeDecorator/ThemeDecorator.module.less
+++ b/ThemeDecorator/ThemeDecorator.module.less
@@ -72,17 +72,20 @@
 		font-variant-ligatures: @agate-base-font-ligatures;
 		color: @agate-text-color;
 
-		&.bg {
-			background-color: @agate-bg-color;
-			background-image: @agate-bg-image;
-
-			&::before {
-				content: "";
-				display: block;
-				background-image: @agate-bg-image2;
-				position: absolute;
-				.position(0);
-			}
+		&.bg ::before {
+			content: "";
+			display: block;
+			background-image: @agate-bg-image2;
+			position: absolute;
+			.position(0);
 		}
 	});
 }
+
+.applySkins({
+	&.bg,
+	> .bg {
+		background-color: @agate-bg-color;
+		background-image: @agate-bg-image;
+	}
+});

--- a/ThemeDecorator/ThemeDecorator.module.less
+++ b/ThemeDecorator/ThemeDecorator.module.less
@@ -72,7 +72,7 @@
 		font-variant-ligatures: @agate-base-font-ligatures;
 		color: @agate-text-color;
 
-		&.bg ::before {
+		&.bg::before {
 			content: "";
 			display: block;
 			background-image: @agate-bg-image2;


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Alexandru Morariu alexandru.morariu@lgepartner.com

### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [X] Documentation was verified or is not changed
* [X] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Changed where the background-color and backgroung-image are applied in ThemeDecorator.module.less to mirror the Sandstone changes and apply them properly.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Because of the applied page background color and image the screenshot tests failed and there are differences in the page background of storybook. However there are no layout shifts and no change in the color of the components themselves.
This effect is present in sandstone also with neutral and light skins.

### Links
[//]: # (Related issues, references)
WRO-9305

### Comments
