### PR TITLE
WRO-10539: Fixed Carbon skin: text not showing on some components

### DIFF
--- a/ArcPicker/ArcPicker.js
+++ b/ArcPicker/ArcPicker.js
@@ -187,7 +187,7 @@ const ArcPickerBase = kind({
 			const {accent: accentColor} = context || {};
 			const {children, endAngle, isFocused, onClick, radius, selectionType, skinVariants, startAngle, strokeWidth, value} = props;
 			const backgroundColor = props.backgroundColor || (skinVariants && skinVariants.night ? '#444444' : '#888888');
-			const foregroundColor = props.foregroundColor || (skinVariants && skinVariants.night ? '#ffffff' : '#000000');
+			const foregroundColor = props.foregroundColor || (skinVariants && skinVariants.night ? '#ffffff' : '#343434');
 
 			if (!Array.isArray(children)) return [];
 			return (

--- a/ArcSlider/ArcSlider.js
+++ b/ArcSlider/ArcSlider.js
@@ -134,7 +134,7 @@ const ArcSliderBase = kind({
 		 */
 		radius: PropTypes.number,
 
-		/*
+		/**
 		 * State of possible skin variants.
 		 *
 		 * Used to set backgroundColor and foregroundColor.
@@ -217,7 +217,7 @@ const ArcSliderBase = kind({
 		},
 		circleRadius: ({isFocused}) => isFocused ? 20 : 15,
 		backgroundColor: ({backgroundColor, skinVariants}) => backgroundColor || (skinVariants && skinVariants.night ? '#444444' : '#888888'),
-		foregroundColor: ({foregroundColor, skinVariants}) => foregroundColor || (skinVariants && skinVariants.night ? '#ffffff' : '#000000')
+		foregroundColor: ({foregroundColor, skinVariants}) => foregroundColor || (skinVariants && skinVariants.night ? '#ffffff' : '#343434')
 	},
 
 	render: ({'aria-valuetext': ariaValuetext, backgroundColor, componentRef, circleRadius, disabled, endAngle, foregroundColor, max, min, radius, size, slotCenter, startAngle, strokeWidth, value, ...rest}) => {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ The following is a curated list of changes in the Enact agate module, newest cha
 
 ### Fixed
 
+- `agate/ArcPicker`, `agate/FanSpeedControl` segments color to be visible on Carbon skin
+- `agate/ArcSlider` progress and knob color to be visible on Carbon skin
 - `agate/DatePicker`, `agate/DateTimePicker`, and `agate/TimePicker` to match latest design for Silicon skin
+- `agate/DatePicker`, `agate/RangePicker`, and `agate/TimePicker` text color to be visible on Carbon skin
 - `agate/MediaPlayer` layout issues for Cobalt, Carbon, Copper, Electro, Titanium skins
 - `agate/Picker` and `agate/RangePicker` to match latest design for Silicon skin
 - `agate/Scroller` to update scrollButtons state on initial render

--- a/styles/colors-carbon.less
+++ b/styles/colors-carbon.less
@@ -128,7 +128,7 @@
 @agate-picker-item-bg-color: transparent;
 @agate-picker-item-decrement-bg-image: none;
 @agate-picker-item-increment-bg-image: none;
-@agate-picker-item-focus-color: @agate-spotlight-color;
+@agate-picker-item-focus-color: @agate-white;
 @agate-picker-item-focus-bg-color: @agate-accent;
 @agate-picker-item-focus-bg-image: inherit;
 

--- a/styles/variables-carbon.less
+++ b/styles/variables-carbon.less
@@ -42,6 +42,7 @@
 // ---------------------------------------
 @agate-panel-h-padding: 99px;
 @agate-panels-controls-top: (@agate-component-spacing - 6px);
+@agate-panels-panel-padding: 24px;
 @agate-panels-partial-height: 50%;
 @agate-panels-partial-width: auto;
 @agate-panels-tab-margin: 0;

--- a/styles/variables-carbon.less
+++ b/styles/variables-carbon.less
@@ -22,6 +22,7 @@
 @agate-drawer-border: @agate-popup-border;
 @agate-drawer-padding: @agate-popup-padding;
 
+
 // Header
 // ---------------------------------------
 @agate-header-title-padding-right: 15px;

--- a/styles/variables-carbon.less
+++ b/styles/variables-carbon.less
@@ -22,7 +22,6 @@
 @agate-drawer-border: @agate-popup-border;
 @agate-drawer-padding: @agate-popup-padding;
 
-
 // Header
 // ---------------------------------------
 @agate-header-title-padding-right: 15px;


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
For Carbon skin, there were some issues with some colors for the following components:
- ArcPicker/FanSpeedControl - selected segments not showing
- ArcSlider - Carbon skin - progress and knob not showing
- DatePicker/RangePicker/TimePicker - Carbon skin - text not showing on focus

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Changed the default arc/segment color from black to dark grey (since Carbon has black background color on panels). 
Changed focused text color to white for pickers. 
Also added padding to the Panel component as the ArcPicker and ArcSlider samplers were too close to the left toolbar.   

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-10539

### Comments
