### PR TITLE
WRO-10538: Temperature control: Layout issue for locale es-ES and unit selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 - `agate/Picker` and `agate/RangePicker` to match latest design for Silicon skin
 - `agate/Scroller` to update scrollButtons state on initial render
 - `agate/Scroller` should not scroll when focus moves from a scroll button to another
+- `agate/TemperatureControl` to have text inline for Spanish locale
 - `agate/ThemeDecorator` to apply the background color and background image properly
 
 ### Removed
@@ -40,7 +41,6 @@ The following is a curated list of changes in the Enact agate module, newest cha
 - `agate/PopupMenu` title to marquee for long text
 - `agate/RadioItem` icons to not be bigger than icon container
 - `agate/TabGroup` button padding for Cobalt and Copper skins
-- `agate/TemperatureControl` to have text inline for Spanish locale
 - `agate/VirtualList` 5-way navigation between scroll buttons when `focusableScrollbar`
 
 ## [2.0.0-beta.2] - 2021-06-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 - `agate/PopupMenu` title to marquee for long text
 - `agate/RadioItem` icons to not be bigger than icon container
 - `agate/TabGroup` button padding for Cobalt and Copper skins
+- `agate/TemperatureControl` to have text inline for Spanish locale
 - `agate/VirtualList` 5-way navigation between scroll buttons when `focusableScrollbar`
 
 ## [2.0.0-beta.2] - 2021-06-24

--- a/TemperatureControl/TemperatureControl.js
+++ b/TemperatureControl/TemperatureControl.js
@@ -123,7 +123,7 @@ const TemperatureControlBase =  kind({
 					min={min}
 					onChange={onChange}
 					slotCenter={
-						<span className={css.textContainer}>{currentTemperatureString}</span>
+						<span>{currentTemperatureString}</span>
 					}
 					startAngle={50}
 					value={value}

--- a/TemperatureControl/TemperatureControl.js
+++ b/TemperatureControl/TemperatureControl.js
@@ -123,7 +123,7 @@ const TemperatureControlBase =  kind({
 					min={min}
 					onChange={onChange}
 					slotCenter={
-						<span>{currentTemperatureString}</span>
+						<span className={css.textContainer}>{currentTemperatureString}</span>
 					}
 					startAngle={50}
 					value={value}

--- a/TemperatureControl/TemperatureControl.module.less
+++ b/TemperatureControl/TemperatureControl.module.less
@@ -13,4 +13,8 @@
 		height: 100%;
 		width: 100%;
 	}
+
+	.textContainer {
+		white-space: nowrap;
+	}
 }

--- a/TemperatureControl/TemperatureControl.module.less
+++ b/TemperatureControl/TemperatureControl.module.less
@@ -5,6 +5,7 @@
 
 .temperatureControl {
 	position: relative;
+	white-space: nowrap;
 
 	.slider {
 		display: flex;
@@ -12,9 +13,5 @@
 		justify-content: center;
 		height: 100%;
 		width: 100%;
-	}
-
-	.textContainer {
-		white-space: nowrap;
 	}
 }

--- a/samples/sampler/stories/default/TemperatureControl.js
+++ b/samples/sampler/stories/default/TemperatureControl.js
@@ -21,14 +21,14 @@ export const _TemperatureControl = (args) => (
 		max={args['max']}
 		min={args['min']}
 		onChange={action('onChange')}
-		unit={args['unit']}
+		unit={args['defaultUnitOfMeasurement']}
 	/>
 );
 
 boolean('disabled', _TemperatureControl, Config);
 number('max', _TemperatureControl, Config);
 number('min', _TemperatureControl, Config);
-select('unit', _TemperatureControl, prop.unit, Config);
+select('defaultUnitOfMeasurement', _TemperatureControl, prop.unit, Config, 'Celsius');
 
 _TemperatureControl.storyName = 'TemperatureControl';
 _TemperatureControl.parameters = {


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Alexandru Morariu alexandru.morariu@lgepartner.com

### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [X] Documentation was verified or is not changed
* [X] UI test was passed or is not needed
* [X] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Added a css class for the span of the TemperatureControl. The 'unit' prop still has uses to show a programmer how the interval he choses is represented in all the locales so I renamed  it to 'defaultUnitOfMeasurement' to better reflect it's role .

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-10538

### Comments
