### PR TITLE
WRO-10826: Fixed foreground color for ArcSlider and ArcPicker

### DIFF
--- a/ArcPicker/ArcPicker.js
+++ b/ArcPicker/ArcPicker.js
@@ -121,7 +121,15 @@ const ArcPickerBase = kind({
 		 */
 		selectionType: PropTypes.oneOf(['cumulative', 'single']),
 
-		/*
+		/**
+		 * The current skin for this component.
+		 *
+		 * @type {String}
+		 * @private
+		 */
+		skin: PropTypes.string,
+
+		/**
 		 * State of possible skin variants.
 		 *
 		 * Used to set backgroundColor and foregroundColor.
@@ -185,9 +193,18 @@ const ArcPickerBase = kind({
 	computed: {
 		arcSegments: (props, context) => {
 			const {accent: accentColor} = context || {};
-			const {children, endAngle, isFocused, onClick, radius, selectionType, skinVariants, startAngle, strokeWidth, value} = props;
+			const {children, endAngle, isFocused, onClick, radius, selectionType, skin, skinVariants, startAngle, strokeWidth, value} = props;
 			const backgroundColor = props.backgroundColor || (skinVariants && skinVariants.night ? '#444444' : '#888888');
-			const foregroundColor = props.foregroundColor || (skinVariants && skinVariants.night ? '#ffffff' : '#343434');
+			let foregroundColor;
+			if (props.foregroundColor) {
+				foregroundColor = props.foregroundColor;
+			} else if (skinVariants && skinVariants.night ) {
+				foregroundColor = '#ffffff';
+			} else if ( skin === 'carbon') {
+				foregroundColor = '#343434';
+			} else {
+				foregroundColor = '#000000';
+			}
 
 			if (!Array.isArray(children)) return [];
 			return (
@@ -255,7 +272,7 @@ const ArcPickerDecorator = compose(
 	Changeable,
 	ArcPickerBehaviorDecorator,
 	Spottable,
-	Skinnable({variantsProp: 'skinVariants'})
+	Skinnable({prop: 'skin', variantsProp: 'skinVariants'})
 );
 
 /**

--- a/ArcPicker/ArcPicker.js
+++ b/ArcPicker/ArcPicker.js
@@ -198,9 +198,9 @@ const ArcPickerBase = kind({
 			let foregroundColor;
 			if (props.foregroundColor) {
 				foregroundColor = props.foregroundColor;
-			} else if (skinVariants && skinVariants.night ) {
+			} else if (skinVariants && skinVariants.night) {
 				foregroundColor = '#ffffff';
-			} else if ( skin === 'carbon') {
+			} else if (skin === 'carbon') {
 				foregroundColor = '#343434';
 			} else {
 				foregroundColor = '#000000';

--- a/ArcPicker/ArcPicker.js
+++ b/ArcPicker/ArcPicker.js
@@ -196,6 +196,7 @@ const ArcPickerBase = kind({
 			const {children, endAngle, isFocused, onClick, radius, selectionType, skin, skinVariants, startAngle, strokeWidth, value} = props;
 			const backgroundColor = props.backgroundColor || (skinVariants && skinVariants.night ? '#444444' : '#888888');
 			let foregroundColor;
+
 			if (props.foregroundColor) {
 				foregroundColor = props.foregroundColor;
 			} else if (skinVariants && skinVariants.night) {

--- a/ArcSlider/ArcSlider.js
+++ b/ArcSlider/ArcSlider.js
@@ -238,6 +238,7 @@ const ArcSliderBase = kind({
 		}
 	},
 
+
 	render: ({'aria-valuetext': ariaValuetext, backgroundColor, componentRef, circleRadius, disabled, endAngle, foregroundColor, max, min, radius, size, slotCenter, startAngle, strokeWidth, value, ...rest}) => {
 		const valueAngle = valueToAngle(clamp(min, max, value), min, Math.max(min, max), startAngle, endAngle);
 		const knobPosition = angleToPosition(valueAngle, radius - (strokeWidth / 2), size);

--- a/ArcSlider/ArcSlider.js
+++ b/ArcSlider/ArcSlider.js
@@ -135,6 +135,14 @@ const ArcSliderBase = kind({
 		radius: PropTypes.number,
 
 		/**
+		 * The current skin for this component.
+		 *
+		 * @type {String}
+		 * @private
+		 */
+		skin: PropTypes.string,
+
+		/**
 		 * State of possible skin variants.
 		 *
 		 * Used to set backgroundColor and foregroundColor.
@@ -217,7 +225,17 @@ const ArcSliderBase = kind({
 		},
 		circleRadius: ({isFocused}) => isFocused ? 20 : 15,
 		backgroundColor: ({backgroundColor, skinVariants}) => backgroundColor || (skinVariants && skinVariants.night ? '#444444' : '#888888'),
-		foregroundColor: ({foregroundColor, skinVariants}) => foregroundColor || (skinVariants && skinVariants.night ? '#ffffff' : '#343434')
+		foregroundColor: ({foregroundColor, skin,  skinVariants}) => {
+			if (foregroundColor) {
+				return foregroundColor;
+			} else if (skinVariants && skinVariants.night ) {
+				return '#ffffff';
+			} else if ( skin === 'carbon') {
+				return '#343434';
+			} else {
+				return '#000000';
+			}
+		}
 	},
 
 	render: ({'aria-valuetext': ariaValuetext, backgroundColor, componentRef, circleRadius, disabled, endAngle, foregroundColor, max, min, radius, size, slotCenter, startAngle, strokeWidth, value, ...rest}) => {
@@ -279,7 +297,7 @@ const ArcSliderDecorator = compose(
 	ArcSliderBehaviorDecorator,
 	Touchable,
 	Spottable,
-	Skinnable({variantsProp: 'skinVariants'})
+	Skinnable({prop: 'skin', variantsProp: 'skinVariants'})
 );
 
 /**

--- a/ArcSlider/ArcSlider.js
+++ b/ArcSlider/ArcSlider.js
@@ -238,7 +238,6 @@ const ArcSliderBase = kind({
 		}
 	},
 
-
 	render: ({'aria-valuetext': ariaValuetext, backgroundColor, componentRef, circleRadius, disabled, endAngle, foregroundColor, max, min, radius, size, slotCenter, startAngle, strokeWidth, value, ...rest}) => {
 		const valueAngle = valueToAngle(clamp(min, max, value), min, Math.max(min, max), startAngle, endAngle);
 		const knobPosition = angleToPosition(valueAngle, radius - (strokeWidth / 2), size);

--- a/ArcSlider/ArcSlider.js
+++ b/ArcSlider/ArcSlider.js
@@ -228,9 +228,9 @@ const ArcSliderBase = kind({
 		foregroundColor: ({foregroundColor, skin,  skinVariants}) => {
 			if (foregroundColor) {
 				return foregroundColor;
-			} else if (skinVariants && skinVariants.night ) {
+			} else if (skinVariants && skinVariants.night) {
 				return '#ffffff';
-			} else if ( skin === 'carbon') {
+			} else if (skin === 'carbon') {
 				return '#343434';
 			} else {
 				return '#000000';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 
 ### Fixed
 
+- `agate/ArcPicker`, `agate/ArcSlider` foreground color for all skins except Carbon
 - `agate/ArcPicker`, `agate/FanSpeedControl` segments color to be visible on Carbon skin
 - `agate/ArcSlider` progress and knob color to be visible on Carbon skin
 - `agate/DatePicker`, `agate/DateTimePicker`, and `agate/TimePicker` to match latest design for Silicon skin


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
ui-tests job on jenkins was failing because the foreground color of the component did not match the expectation
Cause of this bug is a previous PR #667 where the color was changed for all skins, not just Carbon skin

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added extra conditions for applying the new foreground color only for carbon skin and maintaining the old black color for the other skins

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-10826

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian [daniel.stoian@lgepartner.com](mailto:daniel.stoian@lgepartner.com)
