### PR TITLE
WRO-11340: Fixed DatePicker padding on Electro skin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,15 @@ The following is a curated list of changes in the Enact agate module, newest cha
 
 ## [unreleased]
 
+### Changed
+
+- `agate/Panels` padding to show correctly all Picker samples for Electro skin
+
 ### Fixed
 
 - `agate/ArcPicker`, `agate/ArcSlider` foreground color for all skins except Carbon
 - `agate/ArcPicker`, `agate/FanSpeedControl` segments color to be visible on Carbon skin
 - `agate/ArcSlider` progress and knob color to be visible on Carbon skin
-- `agate/DatePicker` padding issue on the Electro skin
 - `agate/DatePicker`, `agate/DateTimePicker`, and `agate/TimePicker` to match latest design for Silicon skin
 - `agate/DatePicker`, `agate/RangePicker`, and `agate/TimePicker` text color to be visible on Carbon skin
 - `agate/Dropdown` layout issues for Carbon, Cobalt, Copper, Titanium skins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,7 +162,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 
 ## [2.0.0-alpha.1] - 2021-02-25
 
-- The framework was updated to support React 17.0.1
+-  The framework was updated to support React 17.0.1
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 - `agate/ArcPicker`, `agate/ArcSlider` foreground color for all skins except Carbon
 - `agate/ArcPicker`, `agate/FanSpeedControl` segments color to be visible on Carbon skin
 - `agate/ArcSlider` progress and knob color to be visible on Carbon skin
+- `agate/DatePicker` padding issue on the Electro skin
 - `agate/DatePicker`, `agate/DateTimePicker`, and `agate/TimePicker` to match latest design for Silicon skin
 - `agate/DatePicker`, `agate/RangePicker`, and `agate/TimePicker` text color to be visible on Carbon skin
 - `agate/Dropdown` layout issues for Carbon, Cobalt, Copper, Titanium skins
@@ -157,7 +158,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 
 ## [2.0.0-alpha.1] - 2021-02-25
 
--  The framework was updated to support React 17.0.1
+- The framework was updated to support React 17.0.1
 
 ### Added
 

--- a/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
+++ b/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
@@ -51,7 +51,6 @@ const SkinFrame = Skinnable(kind({
 	}
 }));
 
-
 const PanelsBase = kind({
 	name: 'ThemeEnvironment',
 

--- a/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
+++ b/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
@@ -51,6 +51,7 @@ const SkinFrame = Skinnable(kind({
 	}
 }));
 
+
 const PanelsBase = kind({
 	name: 'ThemeEnvironment',
 

--- a/styles/variables-electro.less
+++ b/styles/variables-electro.less
@@ -84,7 +84,7 @@
 // Panels
 // ---------------------------------------
 @agate-panels-controls-top: (@agate-component-spacing + 21px);
-@agate-panels-panel-padding: @agate-component-spacing;
+@agate-panels-panel-padding: 24px;
 @agate-panels-tab-bar-margin: 0;
 @agate-panels-tab-bg-position: 0;
 @agate-panels-tab-bg-transform: skewX(@electro-skew);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
On Electro skin the padding of the DatePicker component was not set properly and the component was cropped.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I changed the padding to make the component fully visible on Electro skin.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-11340

### Comments
Enact-DCO-1.0-Signed-off-by: Andrei Tirla [andrei.tirla@lgepartner.com](mailto:daniel.stoian@lgepartner.com)