### PR TITLE
WRO-11351: DateTimePicker - showAllskins= true: Active bar background-color is not correct

### DIFF
--- a/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
+++ b/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
@@ -44,7 +44,6 @@ const SkinFrame = Skinnable(kind({
 	},
 
 	render: (props) => {
-		console.log(props)
 		delete props.hideChildren;
 		delete props.spotlightId;
 

--- a/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
+++ b/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.js
@@ -44,6 +44,7 @@ const SkinFrame = Skinnable(kind({
 	},
 
 	render: (props) => {
+		console.log(props)
 		delete props.hideChildren;
 		delete props.spotlightId;
 
@@ -183,29 +184,36 @@ const StorybookDecorator = (story, config) => {
 	}
 
 	return (
-		<Theme
-			title={componentName === config.name ? `${config.kind}`.replace(/\//g, ' ').trim() : `${componentName} ${config.name}`}
-			description={hasInfoText ? config.parameters.info.text : null}
-			locale={localeFromURL || globals.locale}
-			skin={showAllSkins ? skins['Gallium'] : skinFromURL || globals.skin}
-			skinVariants={JSON.parse(globals['night mode']) ? 'night' : null}
-			accent={accentFromURL || (accent || defaultColors['gallium'].accent)}
-			highlight={highlightFromURL || (highlight || defaultColors['gallium'].highlight)}
-			{...(hasProps ? config.parameters.props : null)}
-		>
-			{showAllSkins ?
-				<Scroller>
-					{Object.keys(skins).map((skin) => (
-						<SkinFrame skin={skins[skin]} key={skin}>
-							<Cell size="20%" component={Heading}>{skin}</Cell>
-							<Cell>{sample}</Cell>
-						</SkinFrame>
-					))}
-				</Scroller> : sample}
-		</Theme>
+		!showAllSkins ?
+			<Theme
+				title={componentName === config.name ? `${config.kind}`.replace(/\//g, ' ').trim() : `${componentName} ${config.name}`}
+				description={hasInfoText ? config.parameters.info.text : null}
+				locale={localeFromURL || globals.locale}
+				skin={showAllSkins ? skins['Gallium'] : skinFromURL || globals.skin}
+				skinVariants={JSON.parse(globals['night mode']) ? 'night' : null}
+				accent={accentFromURL || (accent || defaultColors['gallium'].accent)}
+				highlight={highlightFromURL || (highlight || defaultColors['gallium'].highlight)}
+				{...(hasProps ? config.parameters.props : null)}
+			>
+				{sample}
+			</Theme> :
+			<>
+				{Object.keys(skins).map((skin) => (
+					<SkinFrame
+						key={skin}
+						locale={localeFromURL || globals.locale}
+						skin={skins[skin]}
+						skinVariants={JSON.parse(globals['night mode']) ? 'night' : null}
+						accent={defaultColors[skins[skin]].accent}
+						highlight={defaultColors[skins[skin]].highlight}
+					>
+						<Cell size="20%" component={Heading}>{skin}</Cell>
+						<Cell>{sample}</Cell>
+					</SkinFrame>
+				))}
+			</>
 	);
 };
-
 
 export default StorybookDecorator;
 export {StorybookDecorator as Theme};

--- a/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.module.less
+++ b/samples/sampler/src/ThemeEnvironment/ThemeEnvironment.module.less
@@ -11,6 +11,7 @@
 		// These background rules, and the &::before below are cloned from ThemeDecorator to mimic the style an app gets.
 		background-color: @agate-bg-color;
 		background-image: @agate-bg-image;
+		font-family: @agate-base-font-family;
 
 		&::before {
 			content: "";


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When showAllSkins is true each skin sample has the same accent and highlight colors as the one set in config.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Changed the default arc/segment color from black to dark grey (since Carbon has black background color on panels). 
Changed focused text color to white for pickers. 
Also added padding to the Panel component as the ArcPicker and ArcSlider samplers were too close to the left toolbar.   

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Mapped the skins object and rendered a SkinFrame for each skin, which takes its corresponding accent and highlight colors. Also added Agate font to SkinFrame. 

### Links
[//]: # (Related issues, references)
WRO-11351

### Comments
