### PR TITLE
WRO-11656: Change the image used in the sample to svg

### DIFF
--- a/samples/qa-a11y/src/views/ImageItem.js
+++ b/samples/qa-a11y/src/views/ImageItem.js
@@ -4,13 +4,19 @@ import Section from '../components/Section';
 
 import appCss from '../App/App.module.less';
 
+const svgGenerator = (width, height, bgColor, textColor, customText) => (
+	`data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' width='${width}' height='${height}'%3E` +
+	`%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E` +
+	`%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+);
+
 const ImageItemView = () => (
 	<>
 		<Section title="Default">
 			<ImageItem
 				alt="With Children"
 				orientation="horizontal"
-				src="http://via.placeholder.com/200x200/7ed31d/ffffff"
+				src={svgGenerator(200, 200, '7ed31d', 'ffffff', '200 X 200')}
 			>
 				Text 0
 			</ImageItem>
@@ -20,7 +26,7 @@ const ImageItemView = () => (
 				disabled
 				orientation="horizontal"
 				selected
-				src="http://via.placeholder.com/200x200/7ed31d/ffffff"
+				src={svgGenerator(200, 200, '7ed31d', 'ffffff', '200 X 200')}
 			>
 				Text 1
 			</ImageItem>
@@ -31,7 +37,7 @@ const ImageItemView = () => (
 				alt="Aria-labelled with Children"
 				aria-label="This is a Label 0."
 				orientation="horizontal"
-				src="http://via.placeholder.com/200x200/7ed31d/ffffff"
+				src={svgGenerator(200, 200, '7ed31d', 'ffffff', '200 X 200')}
 			>
 				Text 0
 			</ImageItem>
@@ -41,7 +47,7 @@ const ImageItemView = () => (
 				aria-label="This is a Label 1."
 				disabled
 				orientation="horizontal"
-				src="http://via.placeholder.com/200x200/7ed31d/ffffff"
+				src={svgGenerator(200, 200, '7ed31d', 'ffffff', '200 X 200')}
 			>
 				Text 1
 			</ImageItem>

--- a/samples/qa-a11y/src/views/VirtualGridList.js
+++ b/samples/qa-a11y/src/views/VirtualGridList.js
@@ -8,6 +8,13 @@ import ri from '@enact/ui/resolution';
 import {useState} from 'react';
 
 const items = [];
+
+const svgGenerator = (width, height, bgColor, textColor, customText) => (
+	`data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' width='${width}' height='${height}'%3E` +
+	`%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E` +
+	`%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+);
+
 // eslint-disable-next-line enact/prop-types
 const renderItem = ({index, ...rest}) => {
 	const {caption, label, src} = items[index];
@@ -30,9 +37,9 @@ for (let i = 0; i < 100; i++) {
 		color = Math.floor((Math.random() * (0x1000000 - 0x101010)) + 0x101010).toString(16),
 		label = `SubItem ${count}`,
 		src = {
-			'hd': `http://via.placeholder.com/200x200/${color}/ffffff/png?text=Image+${i}`,
-			'fhd': `http://via.placeholder.com/300x300/${color}/ffffff/png?text=Image+${i}`,
-			'uhd': `http://via.placeholder.com/600x600/${color}/ffffff/png?text=Image+${i}`
+			'hd': svgGenerator(200, 200, color, 'ffffff', `Image ${i}`),
+			'fhd': svgGenerator(300, 300, color, 'ffffff', `Image ${i}`),
+			'uhd': svgGenerator(600, 600, color, 'ffffff', `Image ${i}`)
 		};
 
 	items.push({caption, label, src});

--- a/samples/sampler/stories/default/Image.js
+++ b/samples/sampler/stories/default/Image.js
@@ -4,13 +4,9 @@ import {mergeComponentMetadata} from '@enact/storybook-utils';
 import ri from '@enact/ui/resolution';
 import Image, {ImageBase, ImageDecorator} from '@enact/agate/Image';
 
-import css from './Image.module.less';
+import {svgGenerator} from '../helper/svg';
 
-const svgGenerator = (width, height, bgColor, textColor, customText) => (
-	`data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' width='${width}' height='${height}'%3E` +
-	`%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E` +
-	`%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
-);
+import css from './Image.module.less';
 
 const src = {
 	hd: svgGenerator(200, 200, '7ed31d', 'ffffff', '200 X 200'),

--- a/samples/sampler/stories/default/ImageItem.js
+++ b/samples/sampler/stories/default/ImageItem.js
@@ -4,11 +4,7 @@ import {boolean, text, select} from '@enact/storybook-utils/addons/controls';
 import ri from '@enact/ui/resolution';
 import ImageItem, {ImageItemBase} from '@enact/agate/ImageItem';
 
-const svgGenerator = (width, height, bgColor, textColor, customText) => (
-    `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' width='${width}' height='${height}'%3E` +
-	`%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E` +
-	`%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
-);
+import {svgGenerator} from '../helper/svg';
 
 const src = {
 	hd: svgGenerator(200, 200, '7ed31d', 'ffffff', 'image0'),

--- a/samples/sampler/stories/default/VirtualGridList.js
+++ b/samples/sampler/stories/default/VirtualGridList.js
@@ -6,6 +6,8 @@ import {VirtualListBasic as UiVirtualListBasic} from '@enact/ui/VirtualList';
 import ImageItem from '@enact/agate/ImageItem';
 import VirtualList, {VirtualGridList} from '@enact/agate/VirtualList';
 
+import {svgGenerator} from '../helper/svg';
+
 const VirtualGridListConfig = mergeComponentMetadata('VirtualGridList', UiVirtualListBasic, VirtualGridList, VirtualList);
 
 const
@@ -50,7 +52,7 @@ const updateDataSize = (dataSize) => {
 			count = (headingZeros + i).slice(-itemNumberDigits),
 			text = `Item ${count}${shouldAddLongContent({index: i, modIndex: 2})}`,
 			color = Math.floor((Math.random() * (0x1000000 - 0x101010)) + 0x101010).toString(16),
-			src = `http://via.placeholder.com/300x300/${color}/ffffff/png?text=Image+${i}`;
+			src = svgGenerator(300, 300, color, 'ffffff', `Image ${i}`);
 
 		items.push({text, src});
 	}

--- a/samples/sampler/stories/helper/svg.js
+++ b/samples/sampler/stories/helper/svg.js
@@ -1,0 +1,8 @@
+// SVG image For Samples
+//
+
+export const svgGenerator = (width, height, bgColor, textColor, customText) => (
+	`data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${width} ${height}' width='${width}' height='${height}'%3E` +
+	`%3Crect width='${width}' height='${height}' fill='%23${bgColor}'%3E%3C/rect%3E` +
+	`%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
+);

--- a/samples/sampler/stories/qa/ImageItem.js
+++ b/samples/sampler/stories/qa/ImageItem.js
@@ -1,6 +1,8 @@
 import ri from '@enact/ui/resolution';
 import ImageItem from '@enact/agate/ImageItem';
 
+import {svgGenerator} from '../helper/svg';
+
 ImageItem.displayName = 'ImageItem';
 
 export default {
@@ -11,7 +13,7 @@ export default {
 export const withoutChildren = () => (
 	<div style={{width: ri.scaleToRem(400), height: ri.scaleToRem(300)}}>
 		<ImageItem
-			src="http://via.placeholder.com/300x400/9037ab/ffffff/png?text=Image0"
+			src={svgGenerator(300, 400, '9037ab', 'ffffff', 'Image0')}
 		/>
 	</div>
 );

--- a/tests/screenshot/apps/components/Image.js
+++ b/tests/screenshot/apps/components/Image.js
@@ -1,9 +1,11 @@
 import Image from '../../../../Image';
 
+import hd from '../../images/200x200.png';
+
 const ImageTests = [
 	<Image />,
-	<Image src="http://via.placeholder.com/200x200" />,
-	<Image sizing="fit" src="http://via.placeholder.com/200x200" />
+	<Image src={hd} />,
+	<Image sizing="fit" src={hd} />
 ];
 
 export default ImageTests;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There is a problem that image download often fails on the placeholder website used in samples

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Instead of downloading the image from the site, change it to create and use the image as svg

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-11656

### Comments
Enact-DCO-1.0-Signed-off-by: SJ RO (sj.ro@lge.com)