### PR TITLE
WRO-12023: Allow double tap behavior on Input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 - `agate/DatePicker`, `agate/DateTimePicker`, and `agate/TimePicker` to match latest design for Silicon skin
 - `agate/DatePicker`, `agate/RangePicker`, and `agate/TimePicker` text color to be visible on Carbon skin
 - `agate/Dropdown` layout issues for Carbon, Cobalt, Copper, Titanium skins
+- `agate/Input` to be selectable via double tap
 - `agate/MediaPlayer` layout issues for Cobalt, Carbon, Copper, Electro, Titanium skins
 - `agate/Picker` and `agate/RangePicker` to match latest design for Silicon skin
 - `agate/Scroller` to update scrollButtons state on initial render

--- a/Input/InputSpotlightDecorator.js
+++ b/Input/InputSpotlightDecorator.js
@@ -239,7 +239,9 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			// the <input> has focus and Spotlight is paused.
 			if (!disabled && !spotlightDisabled) {
 				this.focusInput(ev.currentTarget);
-				ev.preventDefault();
+				if (ev.target.tagName !== 'INPUT') {
+					ev.preventDefault();
+				}
 			}
 
 			forwardMouseDown(ev, this.props);


### PR DESCRIPTION

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Cannot select text via double tap

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
It was side effect from https://github.com/enactjs/agate/pull/354
We should allow default browser behavior when user touch / mouse-down `input` tag.
So I add condition to `preventDefault`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-12023
PLAT-94190

### Comments
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com)
