### PR TITLE
WRO-13490: Modify jsdocs comments for @link tag

### DIFF
--- a/Arc/Arc.js
+++ b/Arc/Arc.js
@@ -26,7 +26,7 @@ import {arcPath} from './utils';
  * An arc component.
  *
  * This component is most often not used directly but may be composed within another component as it
- * is within [Arc]{@link agate/Arc.Arc}.
+ * is within {@link agate/Arc.Arc|Arc}.
  *
  * @class ArcBase
  * @memberof agate/Arc
@@ -151,7 +151,7 @@ const ArcBase = kind({
 });
 
 /**
- * Applies Agate specific behaviors to [ArcBase]{@link agate/Arc.ArcBase} components.
+ * Applies Agate specific behaviors to {@link agate/Arc.ArcBase|ArcBase} components.
  *
  * @hoc
  * @memberof agate/Arc

--- a/ArcPicker/ArcPicker.js
+++ b/ArcPicker/ArcPicker.js
@@ -30,7 +30,7 @@ import css from './ArcPicker.module.less';
 /**
  * An Agate component for displaying an arc picker.
  * This component is most often not used directly but may be composed within another component as it
- * is within [ArcPicker]{@link agate/ArcPicker.ArcPicker}.
+ * is within {@link agate/ArcPicker.ArcPicker|ArcPicker}.
  *
  * @class ArcPickerBase
  * @memberof agate/ArcPicker
@@ -261,7 +261,7 @@ const ArcPickerBase = kind({
 });
 
 /**
- * Applies Agate specific behaviors to [ArcPickerBase]{@link agate/ArcPicker.ArcPickerBase} components.
+ * Applies Agate specific behaviors to {@link agate/ArcPicker.ArcPickerBase|ArcPickerBase} components.
  *
  * @hoc
  * @memberof agate/ArcPicker

--- a/ArcSlider/ArcSlider.js
+++ b/ArcSlider/ArcSlider.js
@@ -34,7 +34,7 @@ import css from './ArcSlider.module.less';
  * An arc slider component.
  *
  * This component is most often not used directly but may be composed within another component as it
- * is within [ArcSlider]{@link agate/ArcSlider.ArcSlider}.
+ * is within {@link agate/ArcSlider.ArcSlider|ArcSlider}.
  *
  * @class ArcSliderBase
  * @memberof agate/ArcSlider
@@ -283,7 +283,7 @@ const ArcSliderBase = kind({
 });
 
 /**
- * Applies Agate specific behaviors to [ArcSliderBase]{@link agate/ArcSlider.ArcSliderBase} components.
+ * Applies Agate specific behaviors to {@link agate/ArcSlider.ArcSliderBase|ArcSliderBase} components.
  *
  * @hoc
  * @memberof agate/ArcSlider

--- a/BodyText/BodyText.js
+++ b/BodyText/BodyText.js
@@ -28,7 +28,7 @@ const MarqueeBodyText = MarqueeDecorator(UiBodyText);
  * A simple text block component.
  *
  * This component is most often not used directly but may be composed within another component as it
- * is within [BodyText]{@link agate/BodyText.BodyText}.
+ * is within {@link agate/BodyText.BodyText|BodyText}.
  *
  * @class BodyTextBase
  * @memberof agate/BodyText
@@ -44,7 +44,7 @@ const BodyTextBase = kind({
 		 * Centers the contents.
 		 *
 		 * Applies the `centered` CSS class which can be customized by
-		 * [theming]{@link /docs/developer-guide/theming/}.
+		 * {@link /docs/developer-guide/theming/|theming}.
 		 *
 		 * @type {Boolean}
 		 * @default false
@@ -127,7 +127,7 @@ const BodyTextBase = kind({
 });
 
 /**
- * Applies Agate specific behaviors to [BodyTextBase]{@link agate/BodyText.BodyTextBase}.
+ * Applies Agate specific behaviors to {@link agate/BodyText.BodyTextBase|BodyTextBase}.
  *
  * @hoc
  * @memberof agate/BodyText

--- a/Button/Button.js
+++ b/Button/Button.js
@@ -34,7 +34,7 @@ import componentCss from './Button.module.less';
  * A button component.
  *
  * This component is most often not used directly but may be composed within another component as it
- * is within [Button]{@link agate/Button.Button}.
+ * is within {@link agate/Button.Button|Button}.
  *
  * @class ButtonBase
  * @memberof agate/Button
@@ -325,7 +325,7 @@ const IconButtonDecorator = hoc((config, Wrapped) => {
 });
 
 /**
- * Applies Agate specific behaviors to [ButtonBase]{@link agate/Button.ButtonBase} components.
+ * Applies Agate specific behaviors to {@link agate/Button.ButtonBase|ButtonBase} components.
  *
  * @hoc
  * @memberof agate/Button

--- a/Checkbox/Checkbox.js
+++ b/Checkbox/Checkbox.js
@@ -26,7 +26,7 @@ import componentCss from './Checkbox.module.less';
  * A checkbox component, ready to use in Agate applications.
  *
  * `Checkbox` may be used independently to represent a toggleable state but is more commonly used as
- * part of [CheckboxItem]{@link agate/CheckboxItem}.
+ * part of {@link agate/CheckboxItem|CheckboxItem}.
  *
  * Usage:
  * ```
@@ -48,7 +48,7 @@ const CheckboxBase = kind({
 		 *
 		 * May be specified as either:
 		 *
-		 * * A string that represents an icon from the [iconList]{@link agate/Icon.Icon.iconList},
+		 * * A string that represents an icon from the {@link agate/Icon.Icon.iconList|iconList},
 		 * * An HTML entity string, Unicode reference or hex value (in the form '0x...'),
 		 * * A URL specifying path to an icon image, or
 		 * * An object representing a resolution independent resource (See {@link ui/resolution})
@@ -102,7 +102,7 @@ const CheckboxBase = kind({
 		 *
 		 * May be specified as either:
 		 *
-		 * * A string that represents an icon from the [iconList]{@link agate/Icon.Icon.iconList},
+		 * * A string that represents an icon from the {@link agate/Icon.Icon.iconList|iconList},
 		 * * An HTML entity string, Unicode reference or hex value (in the form '0x...'),
 		 * * A URL specifying path to an icon image, or
 		 * * An object representing a resolution independent resource (See {@link ui/resolution})
@@ -185,7 +185,7 @@ const CheckboxDecorator = compose(
 /**
  * An Agate-styled checkbox component.
  *
- * `Checkbox` will manage its `selected` state via [Toggleable]{@link ui/Toggleable} unless set
+ * `Checkbox` will manage its `selected` state via {@link ui/Toggleable|Toggleable} unless set
  * directly.
  *
  * @class Checkbox

--- a/CheckboxItem/CheckboxItem.js
+++ b/CheckboxItem/CheckboxItem.js
@@ -34,7 +34,7 @@ Checkbox.displayName = 'Checkbox';
  * An item with a checkbox component, ready to use in Agate applications.
  *
  * `CheckboxItem` may be used to allow the user to select a single option or used as part of a
- * [Group]{@link ui/Group} when multiple [selections]{@link ui/Group.Group.select} are possible.
+ * {@link ui/Group|Group} when multiple {@link ui/Group.Group.select|selections} are possible.
  *
  * Usage:
  * ```
@@ -75,7 +75,7 @@ const CheckboxItemBase = kind({
 		 *
 		 * May be specified as either:
 		 *
-		 * * A string that represents an icon from the [iconList]{@link ui/Icon.Icon.iconList},
+		 * * A string that represents an icon from the {@link ui/Icon.Icon.iconList|iconList},
 		 * * An HTML entity string, Unicode reference or hex value (in the form '0x...'),
 		 * * A URL specifying path to an icon image, or
 		 * * An object representing a resolution independent resource (See {@link ui/resolution})
@@ -104,7 +104,7 @@ const CheckboxItemBase = kind({
 		 *
 		 * May be specified as either:
 		 *
-		 * * A string that represents an icon from the [iconList]{@link agate/Icon.Icon.iconList},
+		 * * A string that represents an icon from the {@link agate/Icon.Icon.iconList|iconList},
 		 * * An HTML entity string, Unicode reference or hex value (in the form '0x...'),
 		 * * A URL specifying path to an icon image, or
 		 * * An object representing a resolution independent resource (See {@link ui/resolution})
@@ -166,7 +166,7 @@ const CheckboxItemBase = kind({
 });
 
 /**
- * Applies Agate specific behaviors to [CheckboxItem]{@link agate/CheckboxItem.CheckboxItem} components.
+ * Applies Agate specific behaviors to {@link agate/CheckboxItem.CheckboxItem|CheckboxItem} components.
  *
  * @hoc
  * @memberof agate/CheckboxItem
@@ -182,7 +182,7 @@ const CheckboxItemDecorator = compose(
 /**
  * An Agate-styled item with a checkbox component.
  *
- * `CheckboxItem` will manage its `selected` state via [Toggleable]{@link ui/Toggleable} unless set
+ * `CheckboxItem` will manage its `selected` state via {@link ui/Toggleable|Toggleable} unless set
  * directly.
  *
  * @class CheckboxItem

--- a/ColorPicker/ColorPicker.js
+++ b/ColorPicker/ColorPicker.js
@@ -44,7 +44,7 @@ const convertToHSL = (value) => convert[value.charAt(0) === '#' ? 'hex' : 'keywo
  * The color picker base component which sets-up the component's structure.
  *
  * This component is most often not used directly but may be composed within another component as it
- * is within [ColorPicker]{@link agate/ColorPicker.ColorPicker}.
+ * is within {@link agate/ColorPicker.ColorPicker|ColorPicker}.
  *
  * @class ColorPickerBase
  * @memberof agate/ColorPicker
@@ -114,7 +114,7 @@ const ColorPickerBase = kind({
 		onChange: PropTypes.func,
 
 		/**
-		 * Callback method passed to the [SwatchButton]{@link agate/ColorPicker.SwatchButton} component with a payload containing the `value` that was just selected.
+		 * Callback method passed to the {@link agate/ColorPicker.SwatchButton|SwatchButton} component with a payload containing the `value` that was just selected.
 		 *
 		 * @type {Function}
 		 * @public
@@ -146,7 +146,7 @@ const ColorPickerBase = kind({
 		onSaturationChange: PropTypes.func,
 
 		/**
-		 * Callback method passed to the [Button]{@link agate/Button.Button} component as `onTap`. This is used to toggle the visibility of the H/S/L sliders.
+		 * Callback method passed to the {@link agate/Button.Button|Button} component as `onTap`. This is used to toggle the visibility of the H/S/L sliders.
 		 *
 		 * @type {Function}
 		 * @public
@@ -357,7 +357,7 @@ const ColorPickerExtended = hoc((config, Wrapped) => {
 });
 
 /**
- * Applies Agate specific behaviors to [ColorPickerBase]{@link agate/ColorPicker.ColorPickerBase}.
+ * Applies Agate specific behaviors to {@link agate/ColorPicker.ColorPickerBase|ColorPickerBase}.
  *
  * @hoc
  * @memberof agate/ColorPicker

--- a/ColorPicker/SwatchButton.js
+++ b/ColorPicker/SwatchButton.js
@@ -21,7 +21,7 @@ import componentCss from './SwatchButton.module.less';
  * A swatch component which sets-up the component's structure.
  *
  * This component is most often not used directly but may be composed within another component as it
- * is within [SwatchButton]{@link agate/ColorPicker.SwatchButton}.
+ * is within {@link agate/ColorPicker.SwatchButton|SwatchButton}.
  *
  * @class SwatchButtonBase
  * @memberof agate/ColorPicker
@@ -105,7 +105,7 @@ const SwatchButtonBase = kind({
 });
 
 /**
- * Applies Agate specific behaviors to [SwatchButtonBase]{@link agate/ColorPicker.SwatchButtonBase}.
+ * Applies Agate specific behaviors to {@link agate/ColorPicker.SwatchButtonBase|SwatchButtonBase}.
  *
  * @hoc
  * @memberof agate/ColorPicker

--- a/ContextualPopupDecorator/ContextualPopup.js
+++ b/ContextualPopupDecorator/ContextualPopup.js
@@ -54,8 +54,8 @@ const ContextualPopupRoot = Skinnable('div');
 
 /**
  * A popup component used by
- * [ContextualPopupDecorator]{@link agate/ContextualPopupDecorator.ContextualPopupDecorator} to
- * wrap its [popupComponent]{@link agate/ContextualPopupDecorator.ContextualPopupDecorator.popupComponent}.
+ * {@link agate/ContextualPopupDecorator.ContextualPopupDecorator|ContextualPopupDecorator} to
+ * wrap its {@link agate/ContextualPopupDecorator.ContextualPopupDecorator.popupComponent|popupComponent}.
  *
  * `ContextualPopup` is usually not used directly but is made available for unique application use
  * cases.

--- a/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -78,7 +78,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 		static propTypes = /** @lends agate/ContextualPopupDecorator.ContextualPopupDecorator.prototype */ {
 			/**
 			 * The component rendered within the
-			 * [ContextualPopup]{@link agate/ContextualPopupDecorator.ContextualPopup}.
+			 * {@link agate/ContextualPopupDecorator.ContextualPopup|ContextualPopup}.
 			 *
 			 * @type {Component}
 			 * @required
@@ -156,7 +156,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 
 			/**
 			 * CSS class name to pass to the
-			 * [ContextualPopup]{@link agate/ContextualPopupDecorator.ContextualPopup}.
+			 * {@link agate/ContextualPopupDecorator.ContextualPopup|ContextualPopup}.
 			 *
 			 * This is commonly used to set width and height of the popup.
 			 *
@@ -195,8 +195,8 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			rtl: PropTypes.bool,
 
 			/**
-			 * Registers the ContextualPopupDecorator component with an [ApiDecorator]
-			 * {@link core/internal/ApiDecorator.ApiDecorator}.
+			 * Registers the ContextualPopupDecorator component with an
+			 * {@link core/internal/ApiDecorator.ApiDecorator|ApiDecorator}.
 			 *
 			 * @type {Function}
 			 * @private
@@ -216,7 +216,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			 * The current skin for this component.
 			 *
 			 * When `noSkin` is set on the config object, `skin` will only be applied to the
-			 * [ContextualPopup]{@link agate/ContextualPopupDecorator.ContextualPopup} and not
+			 * {@link agate/ContextualPopupDecorator.ContextualPopup|ContextualPopup} and not
 			 * to the popup's activator component.
 			 *
 			 * @see {@link agate/Skinnable.Skinnable.skin}
@@ -723,7 +723,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 
 /**
  * Adds support for positioning a
- * [ContextualPopup]{@link agate/ContextualPopupDecorator.ContextualPopup} relative to the
+ * {@link agate/ContextualPopupDecorator.ContextualPopup|ContextualPopup} relative to the
  * wrapped component.
  *
  * `ContextualPopupDecorator` may be used to show additional settings or actions rendered within a

--- a/DatePicker/DatePicker.js
+++ b/DatePicker/DatePicker.js
@@ -103,7 +103,7 @@ const dateTimeConfig = {
 };
 
 /**
- * Applies Agate specific behaviors to [DatePickerBase]{@link agate/DatePicker.DatePickerBase} components.
+ * Applies Agate specific behaviors to {@link agate/DatePicker.DatePickerBase|DatePickerBase} components.
  *
  * @hoc
  * @memberof agate/DatePicker
@@ -120,7 +120,7 @@ const DatePickerDecorator = compose(
  *
  * `DatePicker` may be used to select the year, month, and day. It uses a standard `Date` object for
  * its `value` which can be shared as the `value` for a
- * [TimePicker]{@link agate/TimePicker.TimePicker} to select both a date and time.
+ * {@link agate/TimePicker.TimePicker|TimePicker} to select both a date and time.
  *
  * By default, `DatePicker` maintains the state of its `value` property. Supply the
  * `defaultValue` property to control its initial value. If you wish to directly control updates

--- a/DatePicker/DatePickerBase.js
+++ b/DatePicker/DatePickerBase.js
@@ -11,7 +11,7 @@ import css from './DatePicker.module.less';
  * A date selection component.
  *
  * This component is most often not used directly but may be composed within another component as it
- * is within [DatePicker]{@link agate/DatePicker.DatePicker}.
+ * is within {@link agate/DatePicker.DatePicker|DatePicker}.
  *
  * @class DatePickerBase
  * @memberof agate/DatePicker

--- a/DateTimePicker/DateTimePicker.js
+++ b/DateTimePicker/DateTimePicker.js
@@ -162,7 +162,7 @@ const DateTimePickerBase = kind({
 });
 
 /**
- * Applies Agate specific behaviors to [DateTimePickerBase]{@link agate/DateTimePicker.DateTimePickerBase} components.
+ * Applies Agate specific behaviors to {@link agate/DateTimePicker.DateTimePickerBase|DateTimePickerBase} components.
  *
  * @hoc
  * @memberof agate/DateTimePicker

--- a/Drawer/Drawer.js
+++ b/Drawer/Drawer.js
@@ -185,7 +185,7 @@ const DrawerBase = kind({
 });
 
 /**
- * Applies Agate specific behaviors to [DrawerBase]{@link agate/Drawer.DrawerBase}.
+ * Applies Agate specific behaviors to {@link agate/Drawer.DrawerBase|DrawerBase}.
  *
  * @hoc
  * @memberof agate/Drawer

--- a/Dropdown/Dropdown.js
+++ b/Dropdown/Dropdown.js
@@ -374,7 +374,7 @@ const DropdownBase = kind({
 
 /**
  * Applies Agate specific behaviors and functionality to
- * [DropdownBase]{@link agate/Dropdown.DropdownBase}.
+ * {@link agate/Dropdown.DropdownBase|DropdownBase}.
  *
  * @hoc
  * @memberof agate/Dropdown

--- a/FanSpeedControl/FanSpeedControl.js
+++ b/FanSpeedControl/FanSpeedControl.js
@@ -25,7 +25,7 @@ import css from './FanSpeedControl.module.less';
 /**
  * An Agate component for displaying fan speed.
  * This component is most often not used directly but may be composed within another component as it
- * is within [FanSpeedControl]{@link agate/FanSpeedControl.FanSpeedControl}.
+ * is within {@link agate/FanSpeedControl.FanSpeedControl|FanSpeedControl}.
  *
  * @class FanSpeedControlBase
  * @memberof agate/FanSpeedControl
@@ -145,7 +145,7 @@ const FanSpeedControlBase = kind({
 });
 
 /**
- * Applies Agate specific behaviors to [FanSpeedControlBase]{@link agate/FanSpeedControl.FanSpeedControlBase} components.
+ * Applies Agate specific behaviors to {@link agate/FanSpeedControl.FanSpeedControlBase|FanSpeedControlBase} components.
  *
  * @hoc
  * @memberof agate/FanSpeedControl
@@ -160,7 +160,7 @@ const FanSpeedControlDecorator = compose(
 
 /**
  * FanSpeedControl with Agate styling and
- * [`FanSpeedControlDecorator`]{@link agate/FanSpeedControl.FanSpeedControlDecorator} applied.
+ * {@link agate/FanSpeedControl.FanSpeedControlDecorator|FanSpeedControlDecorator} applied.
  *
  * Usage:
  * ```

--- a/Header/Header.js
+++ b/Header/Header.js
@@ -41,7 +41,7 @@ const HeaderBase = kind({
 		/**
 		 * Title of the header.
 		 *
-		 * This is a [`slot`]{@link ui/Slottable.Slottable}, so it can be used as a tag-name inside
+		 * This is a {@link ui/Slottable.Slottable|slot}, so it can be used as a tag-name inside
 		 * this component.
 		 *
 		 * Example:
@@ -102,7 +102,7 @@ const HeaderBase = kind({
 		/**
 		 * Text displayed below the title.
 		 *
-		 * This is a [`slot`]{@link ui/Slottable.Slottable}, so it can be used as a tag-name inside
+		 * This is a {@link ui/Slottable.Slottable|slot}, so it can be used as a tag-name inside
 		 * this component.
 		 *
 		 * @type {String}
@@ -112,7 +112,7 @@ const HeaderBase = kind({
 		/**
 		 * Text displayed above the title.
 		 *
-		 * This is a [`slot`]{@link ui/Slottable.Slottable}, so it can be used as a tag-name inside
+		 * This is a {@link ui/Slottable.Slottable|slot}, so it can be used as a tag-name inside
 		 * this component.
 		 *
 		 * @type {String}
@@ -164,7 +164,7 @@ const HeaderBase = kind({
 });
 
 /**
- * Applies Agate specific behaviors to [Header]{@link agate/Header.Header} components.
+ * Applies Agate specific behaviors to {@link agate/Header.Header|Header} components.
  *
  * @hoc
  * @memberof agate/Header

--- a/Heading/Heading.js
+++ b/Heading/Heading.js
@@ -32,7 +32,7 @@ import componentCss from './Heading.module.less';
  * A labeled Heading component.
  *
  * This component is most often not used directly but may be composed within another component as it
- * is within [Heading]{@link agate/Heading.Heading}.
+ * is within {@link agate/Heading.Heading|Heading}.
  *
  * @class HeadingBase
  * @memberof agate/Heading
@@ -153,7 +153,7 @@ const HeadingBase = kind({
 });
 
 /**
- * Applies Agate specific behaviors to [HeadingBase]{@link agate/Heading.HeadingBase}.
+ * Applies Agate specific behaviors to {@link agate/Heading.HeadingBase|HeadingBase}.
  *
  * @hoc
  * @memberof agate/Heading

--- a/Icon/Icon.js
+++ b/Icon/Icon.js
@@ -42,7 +42,7 @@ const IconBase = kind({
 		 *
 		 * May be specified as either:
 		 *
-		 * * A string that represents an icon from the [iconList]{@link ui/Icon.Icon.iconList},
+		 * * A string that represents an icon from the {@link ui/Icon.Icon.iconList|iconList},
 		 * * An HTML entity string, Unicode reference or hex value (in the form '0x...'),
 		 * * A URL specifying path to an icon image, or
 		 * * An object representing a resolution independent resource (See {@link ui/resolution}).
@@ -132,7 +132,7 @@ const IconBase = kind({
 // Let's find a way to import this list directly, and bonus feature, render our icons in the docs
 // next to their names.
 /**
- * An object whose keys can be used as the child of an [Icon]{@link agate/Icon.Icon} component.
+ * An object whose keys can be used as the child of an {@link agate/Icon.Icon|Icon} component.
  *
  * List of Icons:
  * ```
@@ -290,7 +290,7 @@ const IconBase = kind({
  */
 
 /**
- * Agate-specific behaviors to apply to [IconBase]{@link agate/Icon.IconBase}.
+ * Agate-specific behaviors to apply to {@link agate/Icon.IconBase|IconBase}.
  *
  * @hoc
  * @memberof agate/Icon

--- a/Image/Image.js
+++ b/Image/Image.js
@@ -137,7 +137,7 @@ const ResponsiveImageDecorator = hoc((config, Wrapped) => {
 });
 
 /**
- * agate-specific behaviors to apply to [Image]{@link agate/Image.ImageBase}.
+ * agate-specific behaviors to apply to {@link agate/Image.ImageBase|Image}.
  *
  * @hoc
  * @memberof agate/Image

--- a/ImageItem/ImageItem.js
+++ b/ImageItem/ImageItem.js
@@ -157,7 +157,7 @@ const ImageItemBase = kind({
 });
 
 /**
- * Applies Agate specific behaviors to [ImageItemBase]{@link agate/ImageItem.ImageItemBase}
+ * Applies Agate specific behaviors to {@link agate/ImageItem.ImageItemBase|ImageItemBase}
  *
  * @hoc
  * @memberof agate/ImageItem

--- a/IncrementSlider/IncrementSlider.js
+++ b/IncrementSlider/IncrementSlider.js
@@ -128,9 +128,9 @@ const IncrementSliderBase = kind({
 		decrementAriaLabel: PropTypes.string,
 
 		/**
-		 * Assign a custom icon for the decrementer. All strings supported by [Icon]{@link agate/Icon.Icon} are
+		 * Assign a custom icon for the decrementer. All strings supported by {@link agate/Icon.Icon|Icon} are
 		 * supported. Without a custom icon, the default is used, and is automatically changed when
-		 * [vertical]{@link agate/IncrementSlider.IncrementSlider#vertical} is changed.
+		 * {@link agate/IncrementSlider.IncrementSlider#vertical|vertical} is changed.
 		 *
 		 * @type {String}
 		 * @default 'minus'
@@ -171,9 +171,9 @@ const IncrementSliderBase = kind({
 		incrementAriaLabel: PropTypes.string,
 
 		/**
-		 * Assign a custom icon for the incrementer. All strings supported by [Icon]{@link agate/Icon.Icon} are
+		 * Assign a custom icon for the incrementer. All strings supported by {@link agate/Icon.Icon|Icon} are
 		 * supported. Without a custom icon, the default is used, and is automatically changed when
-		 * [vertical]{@link agate/IncrementSlider.IncrementSlider#vertical} is changed.
+		 * {@link agate/IncrementSlider.IncrementSlider#vertical|vertical} is changed.
 		 *
 		 * @type {String}
 		 * @default 'plus'
@@ -378,7 +378,7 @@ const IncrementSliderBase = kind({
 		 * Enables the built-in tooltip
 		 *
 		 * To customize the tooltip, pass either a custom tooltip component or an instance of
-		 * [IncrementSliderTooltip]{@link agate/IncrementSlider.IncrementSliderTooltip} with additional props configured.
+		 * {@link agate/IncrementSlider.IncrementSliderTooltip|IncrementSliderTooltip} with additional props configured.
 		 *
 		 * ```
 		 * <IncrementSlider
@@ -389,7 +389,7 @@ const IncrementSliderBase = kind({
 		 * ```
 		 *
 		 * The tooltip may also be passed as a child via the `"tooltip"` slot. See
-		 * [Slottable]{@link ui/Slottable} for more information on how slots can be used.
+		 * {@link ui/Slottable|Slottable} for more information on how slots can be used.
 		 *
 		 * ```
 		 * <IncrementSlider>
@@ -592,7 +592,7 @@ const IncrementSliderBase = kind({
 });
 
 /**
- * Applies Agate specific behaviors to [IncrementSliderBase]{@link agate/IncrementSlider.IncrementSliderBase}
+ * Applies Agate specific behaviors to {@link agate/IncrementSlider.IncrementSliderBase|IncrementSliderBase}
  *
  * @hoc
  * @memberof agate/IncrementSlider
@@ -629,9 +629,9 @@ const IncrementSliderDecorator = compose(
 const IncrementSlider = IncrementSliderDecorator(IncrementSliderBase);
 
 /**
- * A [Tooltip]{@link agate/TooltipDecorator.Tooltip} specifically adapted for use with
- * [ProgressBar]{@link agate/ProgressBar.ProgressBar} or
- * [IncrementSlider]{@link agate/IncrementSlider.IncrementSlider}.
+ * A {@link agate/TooltipDecorator.Tooltip|Tooltip} specifically adapted for use with
+ * {@link agate/ProgressBar.ProgressBar|ProgressBar} or
+ * {@link agate/IncrementSlider.IncrementSlider|IncrementSlider}.
  *
  * @see {@link agate/ProgressBar.ProgressBarTooltip}
  * @class IncrementSliderTooltip

--- a/IncrementSlider/IncrementSlider.js
+++ b/IncrementSlider/IncrementSlider.js
@@ -52,7 +52,7 @@ const forwardWithType = (type, props) => forward(type, {type}, props);
 
 /**
  * A stateless Slider with IconButtons to increment and decrement the value. In most circumstances,
- * you will want to use the stateful version: {@link agate/IncrementSlider.IncrementSlider}.
+ * you will want to use the stateful version: {@link agate/IncrementSlider.IncrementSlider|IncrementSlider}.
  *
  * @class IncrementSliderBase
  * @memberof agate/IncrementSlider

--- a/IncrementSlider/IncrementSliderButton.js
+++ b/IncrementSlider/IncrementSliderButton.js
@@ -7,8 +7,8 @@ import {onlyUpdateForProps} from '../internal/util';
 import componentCss from './IncrementSliderButton.module.less';
 
 /**
- * A [Button]{@link agate/Button.Button} customized for
- * [IncrementSlider]{@link agate/IncrementSlider.IncrementSlider}. It is optimized to only
+ * A {@link agate/Button.Button|Button} customized for
+ * {@link agate/IncrementSlider.IncrementSlider|IncrementSlider}. It is optimized to only
  * update when `disabled` is changed to minimize unnecessary render cycles.
  *
  * @class IncrementSliderButton

--- a/Input/Input.js
+++ b/Input/Input.js
@@ -120,8 +120,8 @@ const InputBase = kind({
 		iconBefore: PropTypes.string,
 
 		/**
-		 * Indicates [value]{@link agate/Input.InputBase.value} is invalid and shows
-		 * [invalidMessage]{@link agate/Input.InputBase.invalidMessage}, if set.
+		 * Indicates {@link agate/Input.InputBase.value|value} is invalid and shows
+		 * {@link agate/Input.InputBase.invalidMessage|invalidMessage}, if set.
 		 *
 		 * @type {Boolean}
 		 * @default false
@@ -131,7 +131,7 @@ const InputBase = kind({
 
 		/**
 		 * The tooltip text to be displayed when the input is
-		 * [invalid]{@link agate/Input.InputBase.invalid}.
+		 * {@link agate/Input.InputBase.invalid|invalid}.
 		 *
 		 * If this value is *falsy*, the tooltip will not be shown.
 		 *
@@ -197,7 +197,7 @@ const InputBase = kind({
 		onKeyDown: PropTypes.func,
 
 		/**
-		 * Text to display when [value]{@link agate/Input.InputBase.value} is not set.
+		 * Text to display when {@link agate/Input.InputBase.value|value} is not set.
 		 *
 		 * @type {String}
 		 * @default ''
@@ -228,7 +228,7 @@ const InputBase = kind({
 		 * Accepted values correspond to the standard HTML5 input types.
 		 *
 		 * @type {String}
-		 * @see [MDN input types doc]{@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types}
+		 * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types|MDN input types doc}
 		 * @default 'text'
 		 * @public
 		 */
@@ -348,7 +348,7 @@ const InputBase = kind({
 });
 
 /**
- * Applies Agate specific behaviors to [InputBase]{@link agate/Input.InputBase} components.
+ * Applies Agate specific behaviors to {@link agate/Input.InputBase|InputBase} components.
  *
  * @class InputDecorator
  * @hoc

--- a/Input/InputSpotlightDecorator.js
+++ b/Input/InputSpotlightDecorator.js
@@ -28,7 +28,7 @@ const handleKeyDown = handle(
 );
 
 /**
- * Default config for [InputSpotlightDecorator]{@link agate/Input.InputSpotlightDecorator}.
+ * Default config for {@link agate/Input.InputSpotlightDecorator|InputSpotlightDecorator}.
  *
  * @memberof agate/Input/InputSpotlightDecorator.InputSpotlightDecorator
  * @hocconfig

--- a/Item/Item.js
+++ b/Item/Item.js
@@ -332,7 +332,7 @@ const ItemBase = kind({
 });
 
 /**
- * Agate specific behaviors to apply to [Item]{@link agate/Item.ItemBase}.
+ * Agate specific behaviors to apply to {@link agate/Item.ItemBase|Item}.
  *
  * @class ItemDecorator
  * @hoc

--- a/Keypad/Keypad.js
+++ b/Keypad/Keypad.js
@@ -365,7 +365,7 @@ const KeypadBehaviorDecorator = hoc((config, Wrapped) => {
 });
 
 /**
- * Applies Agate specific behaviors to [KeypadBase]{@link agate/Keypad.KeypadBase}
+ * Applies Agate specific behaviors to {@link agate/Keypad.KeypadBase|KeypadBase}
  *
  * @hoc
  * @memberof agate/Keypad

--- a/LabeledIcon/LabeledIcon.js
+++ b/LabeledIcon/LabeledIcon.js
@@ -76,7 +76,7 @@ const LabeledIconBase = kind({
 });
 
 /**
- * Adds Agate specific behaviors to [LabeledIconBase]{@link agate/LabeledIcon.LabeledIconBase}.
+ * Adds Agate specific behaviors to {@link agate/LabeledIcon.LabeledIconBase|LabeledIconBase}.
  *
  * @hoc
  * @memberof agate/LabeledIcon

--- a/LabeledIconButton/LabeledIconButton.js
+++ b/LabeledIconButton/LabeledIconButton.js
@@ -140,7 +140,7 @@ const LabeledIconButtonBase = kind({
 		 *
 		 * Setting `selected` may be useful when the component represents a toggleable option. The
 		 * visual effect may be customized using the
-		 * [css]{@link agate/LabeledIconButton.LabeledIconButtonBase.css} prop.
+		 * {@link agate/LabeledIconButton.LabeledIconButtonBase.css|css} prop.
 		 */
 		selected: PropTypes.bool,
 
@@ -212,7 +212,7 @@ const LabeledIconButtonBase = kind({
 });
 
 /**
- * Adds Agate specific behaviors to [LabeledIconButtonBase]{@link agate/LabeledIconButton.LabeledIconButtonBase}.
+ * Adds Agate specific behaviors to {@link agate/LabeledIconButton.LabeledIconButtonBase|LabeledIconButtonBase}.
  *
  * @memberof agate/LabeledIconButton
  * @hoc

--- a/MediaPlayer/MediaControls.js
+++ b/MediaPlayer/MediaControls.js
@@ -117,9 +117,9 @@ const MediaControls = kind({
 
 		/**
 		 * A string which is sent to the `pause` icon of the player controls. This can be
-		 * anything that is accepted by [Icon]{@link agate/Icon.Icon}. This will be temporarily replaced by
-		 * the [playIcon]{@link agate/MediaPlayer.MediaControls.playIcon} when the
-		 * [paused]{@link agate/MediaPlayer.MediaControls.paused} boolean is `false`.
+		 * anything that is accepted by {@link agate/Icon.Icon|Icon}. This will be temporarily replaced by
+		 * the {@link agate/MediaPlayer.MediaControls.playIcon|playIcon} when the
+		 * {@link agate/MediaPlayer.MediaControls.paused|paused} boolean is `false`.
 		 *
 		 * @type {String}
 		 * @default 'pause'
@@ -130,8 +130,8 @@ const MediaControls = kind({
 		/**
 		 * A string which is sent to the `play` icon of the player controls. This can be
 		 * anything that is accepted by {@link agate/Icon.Icon}. This will be temporarily replaced by
-		 * the [pauseIcon]{@link agate/MediaPlayer.MediaControls.pauseIcon} when the
-		 * [paused]{@link agate/MediaPlayer.MediaControls.paused} boolean is `true`.
+		 * the {@link agate/MediaPlayer.MediaControls.pauseIcon|pauseIcon} when the
+		 * {@link agate/MediaPlayer.MediaControls.paused|paused} boolean is `true`.
 		 *
 		 * @type {String}
 		 * @default 'play'

--- a/MediaPlayer/MediaPlayer.js
+++ b/MediaPlayer/MediaPlayer.js
@@ -350,7 +350,7 @@ const MediaPlayerBase = kind({
 });
 
 /**
- * Media player behaviors to apply to [MediaPlayerBase]{@link agate/MediaPlayer.MediaPlayerBase}.
+ * Media player behaviors to apply to {@link agate/MediaPlayer.MediaPlayerBase|MediaPlayerBase}.
  *
  * @class MediaPlayerBehaviorDecorator
  * @hoc

--- a/MediaPlayer/MediaPlayer.js
+++ b/MediaPlayer/MediaPlayer.js
@@ -54,7 +54,7 @@ const getDurFmt = (locale) => {
 };
 
 /**
- * A player for media {@link agate/MediaPlayer.MediaPlayer}.
+ * A player for media {@link agate/MediaPlayer.MediaPlayer|MediaPlayer}.
  *
  * @class MediaPlayerBase
  * @memberof agate/MediaPlayer

--- a/MediaPlayer/MediaSlider.js
+++ b/MediaPlayer/MediaSlider.js
@@ -7,7 +7,7 @@ import css from './MediaSlider.module.less';
 
 /**
  * A customized slider suitable for use within media player components such as
- * [MediaPlayer]{@link agate/MediaPlayer.MediaPlayer}.
+ * {@link agate/MediaPlayer.MediaPlayer|MediaPlayer}.
  *
  * @class MediaSlider
  * @memberof agate/MediaPlayer

--- a/Panels/Breadcrumb.js
+++ b/Panels/Breadcrumb.js
@@ -25,7 +25,7 @@ export const breadcrumbWidth = 105;
 /**
  * Vertical, transparent bar used to navigate to a prior Panel.
  *
- * [`BreadcrumbPanels`]{@link agate/Panels.BreadcrumbPanels} has one breadcrumb.
+ * {@link agate/Panels.BreadcrumbPanels|BreadcrumbPanels} has one breadcrumb.
  *
  * @class Breadcrumb
  * @memberof agate/Panels

--- a/Panels/Panel.js
+++ b/Panels/Panel.js
@@ -12,8 +12,8 @@ import componentCss from './Panel.module.less';
 let panelId = 0;
 
 /**
- * A Panel is the standard view container used inside a [Panels]{@link agate/Panels.Panels} view
- * manager instance. [Panels]{@link agate/Panels.Panels} will typically contain several
+ * A Panel is the standard view container used inside a {@link agate/Panels.Panels|Panels} view
+ * manager instance. {@link agate/Panels.Panels|Panels} will typically contain several
  * instances of these and transition between them.
  *
  * @class Panel
@@ -27,7 +27,7 @@ const PanelBase = kind({
 
 	propTypes: /** @lends agate/Panels.Panel.prototype */ {
 		/**
-		 * By default, the panel will be labeled by its [Header]{@link agate/Header.Header}.
+		 * By default, the panel will be labeled by its {@link agate/Header.Header|Header}.
 		 * When `aria-label` is set, it will be used instead to provide an accessibility label for
 		 * the panel.
 		 *
@@ -70,8 +70,8 @@ const PanelBase = kind({
 		/**
 		 * Header for the panel.
 		 *
-		 * This is usually passed by the [Slottable]{@link ui/Slottable.Slottable} API by using a
-		 * [Header]{@link agate/Header.Header} component as a child of the Panel.
+		 * This is usually passed by the {@link ui/Slottable.Slottable|Slottable} API by using a
+		 * {@link agate/Header.Header|Header} component as a child of the Panel.
 		 *
 		 * @type {Node}
 		 * @public
@@ -81,9 +81,9 @@ const PanelBase = kind({
 		/**
 		 * Hides the body components.
 		 *
-		 * When a Panel is used within [`Panels`]{@link agate/Panels.Panels},
-		 * [`BreadcrumbPanels`]{@link agate/Panels.BreadcrumbPanels}, or
-		 * [`TabbedPanels`]{@link agate/Panels.TabbedPanels},
+		 * When a Panel is used within {@link agate/Panels.Panels|Panels},
+		 * {@link agate/Panels.BreadcrumbPanels|BreadcrumbPanels}, or
+		 * {@link agate/Panels.TabbedPanels|TabbedPanels},
 		 * this property will be set automatically to `true` on render and `false` after animating
 		 * into view.
 		 *

--- a/Panels/Panels.js
+++ b/Panels/Panels.js
@@ -17,7 +17,7 @@ import componentCss from './Panels.module.less';
 const getControlsId = (id) => id && `${id}-controls`;
 
 /**
- * Basic Panels component without breadcrumbs or default [arranger]{@link ui/ViewManager.Arranger}
+ * Basic Panels component without breadcrumbs or default {@link ui/ViewManager.Arranger|arranger}
  *
  * @class PanelsBase
  * @memberof agate/Panels
@@ -112,7 +112,7 @@ const PanelsBase = kind({
 		 *
 		 * When defined, `Panels` will manage the presentation state of `Panel` instances in order
 		 * to restore it when returning to the `Panel`. See
-		 * [noSharedState]{@link agate/Panels.Panels.noSharedState} for more details on shared
+		 * {@link agate/Panels.Panels.noSharedState|noSharedState} for more details on shared
 		 * state.
 		 *
 		 * @type {String}
@@ -299,7 +299,7 @@ const PanelsBase = kind({
 });
 
 /**
- * Applies Agate specific behaviors to [Panels]{@link agate/Panels.Panels} components.
+ * Applies Agate specific behaviors to {@link agate/Panels.Panels|Panels} components.
  *
  * @hoc
  * @memberof agate/Panels

--- a/Picker/Picker.js
+++ b/Picker/Picker.js
@@ -24,7 +24,7 @@ import PickerCore, {ChangeAdapter, PickerItem} from '../internal/Picker';
 /**
  * The base `Picker` component.
  *
- * This version is not [`spottable`]{@link spotlight/Spottable.Spottable}.
+ * This version is not {@link spotlight/Spottable.Spottable|spottable}.
  *
  * @class PickerBase
  * @memberof agate/Picker
@@ -163,7 +163,7 @@ const PickerBase = kind({
 });
 
 /**
- * Applies Agate specific behaviors to [PickerBase]{@link agate/Picker.PickerBase} components.
+ * Applies Agate specific behaviors to {@link agate/Picker.PickerBase|PickerBase} components.
  *
  * @hoc
  * @memberof agate/Picker

--- a/Popup/Popup.js
+++ b/Popup/Popup.js
@@ -222,7 +222,7 @@ const PopupBase = kind({
 		 *
 		 * It can be either `'none'`, `'self-first'`, or `'self-only'`.
 		 *
-		 * Note: The ready-to-use [Popup]{@link agate/Popup.Popup} component only supports
+		 * Note: The ready-to-use {@link agate/Popup.Popup|Popup} component only supports
 		 * `'self-first'` and `'self-only'`.
 		 *
 		 * @type {('none'|'self-first'|'self-only')}
@@ -329,7 +329,7 @@ const PopupBase = kind({
 });
 
 /**
- * Applies Agate specific behaviors to [PopupBase]{@link agate/Popup.PopupBase}.
+ * Applies Agate specific behaviors to {@link agate/Popup.PopupBase|PopupBase}.
  *
  * @hoc
  * @memberof agate/Popup
@@ -345,7 +345,7 @@ const PopupDecorator = compose(
 
 /**
  * A stateful component that renders a popup in a
- * [FloatingLayer]{@link ui/FloatingLayer.FloatingLayer}.
+ * {@link ui/FloatingLayer.FloatingLayer|FloatingLayer}.
  *
  * @class Popup
  * @memberof agate/Popup

--- a/Popup/PopupState.js
+++ b/Popup/PopupState.js
@@ -36,7 +36,7 @@ const forwardShow = forward('onShow');
 
 /**
  * A hoc component that renders a popup in a
- * [FloatingLayer]{@link ui/FloatingLayer.FloatingLayer}.
+ * {@link ui/FloatingLayer.FloatingLayer|FloatingLayer}.
  *
  * @hoc PopupState
  * @memberof agate/Popup
@@ -119,7 +119,7 @@ const PopupState = hoc((config, Wrapped) => {
 			 * Called after show transition has completed, and immediately with no transition.
 			 *
 			 * Note: The function does not run if Popup is initially opened and
-			 * [noAnimation]{@link agate/Popup.PopupBase#noAnimation} is `true`.
+			 * {@link agate/Popup.PopupBase#noAnimation|noAnimation} is `true`.
 			 *
 			 * @type {Function}
 			 * @public

--- a/PopupMenu/PopupMenu.js
+++ b/PopupMenu/PopupMenu.js
@@ -202,7 +202,7 @@ const PopupMenuBase = kind({
 });
 
 /**
- * Applies Agate specific behaviors to [PopupMenuBase]{@link agate/PopupMenu.PopupMenuBase}.
+ * Applies Agate specific behaviors to {@link agate/PopupMenu.PopupMenuBase|PopupMenuBase}.
  *
  * @hoc
  * @memberof agate/PopupMenu

--- a/ProgressBar/ProgressBar.js
+++ b/ProgressBar/ProgressBar.js
@@ -101,7 +101,7 @@ const ProgressBarBase = kind({
 		 * Enables the built-in tooltip.
 		 *
 		 * To customize the tooltip, pass either a custom tooltip component or an instance of
-		 * [ProgressBarTooltip]{@link agate/ProgressBar.ProgressBarTooltip} with additional
+		 * {@link agate/ProgressBar.ProgressBarTooltip|ProgressBarTooltip} with additional
 		 * props configured.
 		 *
 		 * The provided component will receive the following props from `ProgressBar`:
@@ -122,7 +122,7 @@ const ProgressBarBase = kind({
 		 * ```
 		 *
 		 * The tooltip may also be passed as a child via the `"tooltip"` slot. See
-		 * [Slottable]{@link ui/Slottable} for more information on how slots can be used.
+		 * {@link ui/Slottable|Slottable} for more information on how slots can be used.
 		 *
 		 * Usage:
 		 * ```
@@ -179,7 +179,7 @@ const ProgressBarBase = kind({
 });
 
 /**
- * Agate-specific behaviors to apply to [ProgressBar]{@link agate/ProgressBar.ProgressBarBase}.
+ * Agate-specific behaviors to apply to {@link agate/ProgressBar.ProgressBarBase|ProgressBar}.
  *
  * @hoc
  * @memberof agate/ProgressBar

--- a/ProgressBar/ProgressBarTooltip.js
+++ b/ProgressBar/ProgressBarTooltip.js
@@ -103,9 +103,9 @@ const getSide = (orientation, position) => {
 };
 
 /**
- * A [Tooltip]{@link agate/TooltipDecorator.Tooltip} specifically adapted for use with
- * [ProgressBar]{@link agate/ProgressBar.ProgressBar},
- * [Slider]{@link agate/Slider.Slider} or [IncrementSlider]{@link agate/IncrementSlider.IncrementSlider}.
+ * A {@link agate/TooltipDecorator.Tooltip|Tooltip} specifically adapted for use with
+ * {@link agate/ProgressBar.ProgressBar|ProgressBar},
+ * {@link agate/Slider.Slider|Slider} or {@link agate/IncrementSlider.IncrementSlider|IncrementSlider}.
  *
  * @class ProgressBarTooltip
  * @memberof agate/ProgressBar

--- a/RadioItem/RadioItem.js
+++ b/RadioItem/RadioItem.js
@@ -122,7 +122,7 @@ const RadioItemBase = kind({
 });
 
 /**
- * Applies Agate specific behaviors to [RadioItem]{@link agate/RadioItem.RadioItem} components.
+ * Applies Agate specific behaviors to {@link agate/RadioItem.RadioItem|RadioItem} components.
  *
  * @hoc
  * @memberof agate/RadioItem

--- a/RangePicker/RangePicker.js
+++ b/RangePicker/RangePicker.js
@@ -36,7 +36,7 @@ const RangePickerBase = kind({
 		 * The maximum value selectable by the picker (inclusive).
 		 *
 		 * The range between `min` and `max` should be evenly divisible by
-		 * [step]{@link agate/RangePicker.RangePickerBase.step}.
+		 * {@link agate/RangePicker.RangePickerBase.step|step}.
 		 *
 		 * @type {Number}
 		 * @required
@@ -48,7 +48,7 @@ const RangePickerBase = kind({
 		 * The minimum value selectable by the picker (inclusive).
 		 *
 		 * The range between `min` and `max` should be evenly divisible by
-		 * [step]{@link agate/RangePicker.RangePickerBase.step}.
+		 * {@link agate/RangePicker.RangePickerBase.step|step}.
 		 *
 		 * @type {Number}
 		 * @required
@@ -188,7 +188,7 @@ const RangePickerBase = kind({
 });
 
 /**
- * Applies Agate specific behaviors to [RangePickerBase]{@link agate/RangePicker.RangePickerBase} components.
+ * Applies Agate specific behaviors to {@link agate/RangePicker.RangePickerBase|RangePickerBase} components.
  *
  * @hoc
  * @memberof agate/RangePicker

--- a/Scroller/Scroller.js
+++ b/Scroller/Scroller.js
@@ -179,7 +179,7 @@ Scroller.propTypes = /** @lends agate/Scroller.Scroller.prototype */ {
 	/**
 	 * Unique identifier for the component.
 	 *
-	 * When defined and when the `Scroller` is within a [Panel]{@link agate/Panels.Panel}, the
+	 * When defined and when the `Scroller` is within a {@link agate/Panels.Panel|Panel}, the
 	 * `Scroller` will store its scroll position and restore that position when returning to the
 	 * `Panel`.
 	 *

--- a/Skinnable/Skinnable.js
+++ b/Skinnable/Skinnable.js
@@ -1,5 +1,5 @@
 /**
- * Exports the {@link agate/Skinnable.Skinnable} Higher-order Component (HOC).
+ * Exports the {@link agate/Skinnable.Skinnable|Skinnable} Higher-order Component (HOC).
  *
  * @module agate/Skinnable
  * @exports Skinnable

--- a/Skinnable/Skinnable.js
+++ b/Skinnable/Skinnable.js
@@ -24,7 +24,7 @@ const defaultConfig = {
 };
 
 /**
- * This Higher-order Component is based on [ui/Skinnable]{@link ui/Skinnable.Skinnable} and comes
+ * This Higher-order Component is based on {@link ui/Skinnable.Skinnable|ui/Skinnable} and comes
  * pre-configured for Agate's supported skins: 'carbon', 'cobalt', 'copper', 'electro', 'gallium',
  * 'silicon', and 'titanium'. It is used to apply the relevant skinning classes to each component
  * and has been used to pre-select specific skins for some components.

--- a/Slider/Slider.js
+++ b/Slider/Slider.js
@@ -205,7 +205,7 @@ const SliderBase = kind({
 		 * Enables the built-in tooltip
 		 *
 		 * To customize the tooltip, pass either a custom tooltip component or an instance of
-		 * [SliderTooltip]{@link agate/Slider.SliderTooltip} with additional props configured.
+		 * {@link agate/Slider.SliderTooltip|SliderTooltip} with additional props configured.
 		 *
 		 * ```
 		 * <Slider
@@ -216,7 +216,7 @@ const SliderBase = kind({
 		 * ```
 		 *
 		 * The tooltip may also be passed as a child via the `"tooltip"` slot. See
-		 * [Slottable]{@link ui/Slottable} for more information on how slots can be used.
+		 * {@link ui/Slottable|Slottable} for more information on how slots can be used.
 		 *
 		 * ```
 		 * <Slider>
@@ -323,7 +323,7 @@ const SliderBase = kind({
 });
 
 /**
- * Agate-specific slider behaviors to apply to [SliderBase]{@link agate/Slider.SliderBase}.
+ * Agate-specific slider behaviors to apply to {@link agate/Slider.SliderBase|SliderBase}.
  *
  * @hoc
  * @memberof agate/Slider
@@ -343,8 +343,8 @@ const SliderDecorator = compose(
 );
 
 /**
- * Slider input with Agate styling, [`Spottable`]{@link spotlight/Spottable.Spottable},
- * [Touchable]{@link ui/Touchable} and [`SliderDecorator`]{@link agate/Slider.SliderDecorator}
+ * Slider input with Agate styling, {@link spotlight/Spottable.Spottable|Spottable},
+ * {@link ui/Touchable|Touchable} and {@link agate/Slider.SliderDecorator|SliderDecorator}
  * applied.
  *
  * By default, `Slider` maintains the state of its `value` property. Supply the `defaultValue`
@@ -373,9 +373,9 @@ const Slider = SliderDecorator(SliderBase);
  */
 
 /**
- * A [Tooltip]{@link agate/TooltipDecorator.Tooltip} specifically adapted for use with
- * [ProgressBar]{@link agate/ProgressBar.ProgressBar} or
- * [Slider]{@link agate/Slider.Slider}.
+ * A {@link agate/TooltipDecorator.Tooltip|Tooltip} specifically adapted for use with
+ * {@link agate/ProgressBar.ProgressBar|ProgressBar} or
+ * {@link agate/Slider.Slider|Slider}.
  *
  * @see {@link agate/ProgressBar.ProgressBarTooltip}
  * @class SliderTooltip

--- a/SliderButton/SliderButton.js
+++ b/SliderButton/SliderButton.js
@@ -193,7 +193,7 @@ const SliderButtonBase = kind({
 });
 
 /**
- * Agate specific behaviors to apply to [SliderButton]{@link agate/SliderButton.SliderButtonBase}.
+ * Agate specific behaviors to apply to {@link agate/SliderButton.SliderButtonBase|SliderButton}.
  *
  * @hoc
  * @memberof agate/SliderButton

--- a/Spinner/Spinner.js
+++ b/Spinner/Spinner.js
@@ -208,7 +208,7 @@ const SpinnerBase = kind({
 });
 
 /**
- * Agate-specific Spinner behaviors to apply to [Spinner]{@link agate/Spinner.SpinnerBase}.
+ * Agate-specific Spinner behaviors to apply to {@link agate/Spinner.SpinnerBase|Spinner}.
  *
  * @hoc
  * @memberof agate/Spinner

--- a/Switch/Switch.js
+++ b/Switch/Switch.js
@@ -39,7 +39,7 @@ const SwitchBase = kind({
 		 *
 		 * May be specified as either:
 		 *
-		 * * A string that represents an icon from the [iconList]{@link agate/Icon.Icon.iconList},
+		 * * A string that represents an icon from the {@link agate/Icon.Icon.iconList|iconList},
 		 * * An HTML entity string, Unicode reference or hex value (in the form '0x...'),
 		 * * A URL specifying path to an icon image, or
 		 * * An object representing a resolution independent resource (See {@link ui/resolution})
@@ -158,7 +158,7 @@ const SwitchDecorator = compose(
 /**
  * An Agate-styled component that looks like a toggle switch.
  *
- * `Switch` will manage its `selected` state via [Toggleable]{@link ui/Toggleable} unless set
+ * `Switch` will manage its `selected` state via {@link ui/Toggleable|Toggleable} unless set
  * directly.
  *
  * @class Switch

--- a/SwitchItem/SwitchItem.js
+++ b/SwitchItem/SwitchItem.js
@@ -155,7 +155,7 @@ const SwitchItemBase = kind({
 });
 
 /**
- * Applies Agate specific behaviors to [SwitchItemBase]{@link agate/SwitchItem.SwitchItemBase} components.
+ * Applies Agate specific behaviors to {@link agate/SwitchItem.SwitchItemBase|SwitchItemBase} components.
  *
  * @hoc
  * @memberof agate/SwitchItem
@@ -174,7 +174,7 @@ const SwitchItemDecorator = compose(
 /**
  * An Agate-styled item with a switch component.
  *
- * `SwitchItem` will manage its `selected` state via [Toggleable]{@link ui/Toggleable} unless set
+ * `SwitchItem` will manage its `selected` state via {@link ui/Toggleable|Toggleable} unless set
  * directly.
  *
  * @class SwitchItem

--- a/TabGroup/TabGroup.js
+++ b/TabGroup/TabGroup.js
@@ -298,7 +298,7 @@ const TabGroupBase = kind({
 TabGroupBase.defaultSlot = 'tabs';
 
 /**
- * Applies Agate specific behaviors to [TabGroup]{@link agate/TabGroup.TabGroupBase} components.
+ * Applies Agate specific behaviors to {@link agate/TabGroup.TabGroupBase|TabGroup} components.
  *
  * @hoc
  * @memberof agate/TabGroup

--- a/TemperatureControl/TemperatureControl.js
+++ b/TemperatureControl/TemperatureControl.js
@@ -134,7 +134,7 @@ const TemperatureControlBase =  kind({
 });
 
 /**
- * Applies Agate specific behaviors to [TemperatureControlBase]{@link agate/TemperatureControl.TemperatureControlBase}.
+ * Applies Agate specific behaviors to {@link agate/TemperatureControl.TemperatureControlBase|TemperatureControlBase}.
  *
  * @hoc
  * @memberof agate/TemperatureControl
@@ -150,7 +150,7 @@ const TemperatureControlDecorator = compose(
 
 /**
  * TemperatureControl with Agate styling
- * and [`TemperatureControlDecorator`]{@link agate/TemperatureControl.TemperatureControlDecorator}
+ * and {@link agate/TemperatureControl.TemperatureControlDecorator|TemperatureControlDecorator}
  * applied.
  *
  * Usage:

--- a/ThemeDecorator/ThemeDecorator.js
+++ b/ThemeDecorator/ThemeDecorator.js
@@ -240,7 +240,7 @@ const CustomizableSkinStyle = kind({
 });
 
 /**
- * {@link agate/ThemeDecorator.ThemeDecorator} is a Higher-order Component that applies
+ * {@link agate/ThemeDecorator.ThemeDecorator|ThemeDecorator} is a Higher-order Component that applies
  * Agate theming to an application. It also applies
  * {@link ui/FloatingLayer.FloatingLayerDecorator|floating layer},
  * {@link ui/resolution.ResolutionDecorator|resolution independence},

--- a/ThemeDecorator/ThemeDecorator.js
+++ b/ThemeDecorator/ThemeDecorator.js
@@ -242,13 +242,13 @@ const CustomizableSkinStyle = kind({
 /**
  * {@link agate/ThemeDecorator.ThemeDecorator} is a Higher-order Component that applies
  * Agate theming to an application. It also applies
- * [floating layer]{@link ui/FloatingLayer.FloatingLayerDecorator},
- * [resolution independence]{@link ui/resolution.ResolutionDecorator},
- * [skin support]{@link ui/Skinnable}, [spotlight]{@link spotlight.SpotlightRootDecorator}, and
- * [internationalization support]{@link i18n/I18nDecorator.I18nDecorator}. It is meant to be applied to
+ * {@link ui/FloatingLayer.FloatingLayerDecorator|floating layer},
+ * {@link ui/resolution.ResolutionDecorator|resolution independence},
+ * {@link ui/Skinnable|skin support}, {@link spotlight.SpotlightRootDecorator|spotlight}, and
+ * {@link i18n/I18nDecorator.I18nDecorator|internationalization support}. It is meant to be applied to
  * the root element of an app.
  *
- * [Skins]{@link ui/Skinnable} provide a way to change the coloration of your app. The currently
+ * {@link ui/Skinnable|Skins} provide a way to change the coloration of your app. The currently
  * supported skins for Agate are "agate" (the default, dark skin) and "agate-light".
  * Use the `skin` property to assign a skin. Ex: `<DecoratedApp skin="light" />`
  *

--- a/TimePicker/TimePicker.js
+++ b/TimePicker/TimePicker.js
@@ -189,7 +189,7 @@ const dateTimeConfig = {
 };
 
 /**
- * Applies Agate specific behaviors to [TimePickerBase]{@link agate/TimePicker.TimePickerBase} components.
+ * Applies Agate specific behaviors to {@link agate/TimePicker.TimePickerBase|TimePickerBase} components.
  *
  * @hoc
  * @memberof agate/TimePicker
@@ -204,8 +204,8 @@ const TimePickerDecorator = compose(
 /**
  * A component that allows displaying or selecting time.
  *
- * Set the [value]{@link agate/TimePicker.TimePicker#value} property to a standard JavaScript
- * [Date] {@link /docs/developer-guide/glossary/#date} object to initialize the picker.
+ * Set the {@link agate/TimePicker.TimePicker#value|value} property to a standard JavaScript
+ *  {@link /docs/developer-guide/glossary/#date|Date} object to initialize the picker.
  *
  * By default, `TimePicker` maintains the state of its `value` property. Supply the
  * `defaultValue` property to control its initial value. If you wish to directly control updates

--- a/TimePicker/TimePickerBase.js
+++ b/TimePicker/TimePickerBase.js
@@ -69,9 +69,9 @@ class HourPicker extends Component {
 }
 
 /**
- * {@link agate/TimePicker.TimePickerBase} is the stateless functional time picker
+ * {@link agate/TimePicker.TimePickerBase|TimePickerBase} is the stateless functional time picker
  * component. Should not be used directly but may be composed within another component as it is
- * within {@link agate/TimePicker.TimePicker}.
+ * within {@link agate/TimePicker.TimePicker|TimePicker}.
  *
  * @class TimePickerBase
  * @memberof agate/TimePicker

--- a/ToggleButton/ToggleButton.js
+++ b/ToggleButton/ToggleButton.js
@@ -22,7 +22,7 @@ import Skinnable from '../Skinnable';
 import css from './ToggleButton.module.less';
 
 /**
- * A stateless [Button]{@link agate/Button.Button} that can be toggled by changing its
+ * A stateless {@link agate/Button.Button|Button} that can be toggled by changing its
  * `selected` property.
  *
  * @class ToggleButtonBase
@@ -168,7 +168,7 @@ const ToggleButtonBase = kind({
 });
 
 /**
- * Applies Agate specific behaviors to [ToggleButtonBase]{@link agate/ToggleButton.ToggleButtonBase} components.
+ * Applies Agate specific behaviors to {@link agate/ToggleButton.ToggleButtonBase|ToggleButtonBase} components.
  *
  * @hoc
  * @memberof agate/ToggleButton

--- a/TooltipDecorator/Tooltip.js
+++ b/TooltipDecorator/Tooltip.js
@@ -83,7 +83,7 @@ const TooltipBase = kind({
 		/**
 		 * Allows the tooltip to marquee.
 		 *
-		 * Specifying a [`width`]{@link agate/TooltipDecorator.TooltipBase#width} restricts
+		 * Specifying a {@link agate/TooltipDecorator.TooltipBase#width|width} restricts
 		 * the marquee to that size.
 		 *
 		 * @type {Boolean}

--- a/TooltipDecorator/TooltipDecorator.js
+++ b/TooltipDecorator/TooltipDecorator.js
@@ -24,7 +24,7 @@ import {adjustDirection, adjustAnchor, calcOverflow, getLabelOffset, getPosition
 let currentTooltip; // needed to know whether or not we should stop a showing job when unmounting
 
 /**
- * Default config for [TooltipDecorator]{@link agate/TooltipDecorator.TooltipDecorator}
+ * Default config for {@link agate/TooltipDecorator.TooltipDecorator|TooltipDecorator}
  *
  * @memberof agate/TooltipDecorator.TooltipDecorator
  * @hocconfig
@@ -35,7 +35,7 @@ const defaultConfig = {
 	 * flipping to an alternate orientation or adjusting its offset to remain on screen.
 	 * The default of 24 is derived from a standard 12px screen-keepout size plus the standard
 	 * Spotlight-outset (12px) margin/padding value which keeps elements and text aligned inside a
-	 * [Panel]{@link agate/Panels.Panel}. Note: This value will be scaled according to the
+	 * {@link agate/Panels.Panel|Panel}. Note: This value will be scaled according to the
 	 * resolution.
 	 *
 	 * @type {Number}
@@ -59,7 +59,7 @@ const defaultConfig = {
 };
 
 /**
- * A higher-order component which positions [Tooltip]{@link agate/TooltipDecorator.Tooltip} in
+ * A higher-order component which positions {@link agate/TooltipDecorator.Tooltip|Tooltip} in
  * relation to the wrapped component.
  *
  * The tooltip is automatically displayed when the decorated component is focused after a set
@@ -111,7 +111,7 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			/**
 			 * Allows the tooltip to marquee.
 			 *
-			 * Specifying a [`tooltipWidth`]{@link agate/TooltipDecorator.TooltipDecorator#tooltipWidth}
+			 * Specifying a {@link agate/TooltipDecorator.TooltipDecorator#tooltipWidth|tooltipWidth}
 			 * restricts the marquee to that size.
 			 *
 			 * @type {Boolean}

--- a/VirtualList/VirtualList.js
+++ b/VirtualList/VirtualList.js
@@ -195,7 +195,7 @@ VirtualList.propTypes = /** @lends agate/VirtualList.VirtualList.prototype */ {
 	/**
 	 * Unique identifier for the component.
 	 *
-	 * When defined and when the `VirtualList` is within a [Panel]{@link agate/Panels.Panel},
+	 * When defined and when the `VirtualList` is within a {@link agate/Panels.Panel|Panel},
 	 * the `VirtualList` will store its scroll position and restore that position when returning to
 	 * the `Panel`.
 	 *
@@ -632,7 +632,7 @@ VirtualGridList.propTypes = /** @lends agate/VirtualList.VirtualGridList.prototy
 	/**
 	 * Unique identifier for the component.
 	 *
-	 * When defined and when the `VirtualGridList` is within a [Panel]{@link agate/Panels.Panel},
+	 * When defined and when the `VirtualGridList` is within a {@link agate/Panels.Panel|Panel},
 	 * the `VirtualGridList` will store its scroll position and restore that position when returning to
 	 * the `Panel`.
 	 *

--- a/WindDirectionControl/WindDirectionControl.js
+++ b/WindDirectionControl/WindDirectionControl.js
@@ -101,7 +101,7 @@ const WindDirectionControlBase = kind({
 });
 
 /**
- * Applies Agate specific behaviors to [WindDirectionControlBase]{@link agate/WindDirectionControl.WindDirectionControlBase}.
+ * Applies Agate specific behaviors to {@link agate/WindDirectionControl.WindDirectionControlBase|WindDirectionControlBase}.
  *
  * @hoc
  * @memberof agate/WindDirectionControl
@@ -116,7 +116,7 @@ const WindDirectionControlDecorator = compose(
 
 /**
  * WindDirectionControl with Agate styling and
- * [WindDirectionControlDecorator]{@link agate/WindDirectionControl.WindDirectionControlDecorator} applied.
+ * {@link agate/WindDirectionControl.WindDirectionControlDecorator|WindDirectionControlDecorator} applied.
  *
  * Usage:
  * ```

--- a/internal/Picker/Picker.js
+++ b/internal/Picker/Picker.js
@@ -78,7 +78,7 @@ const PickerBase = kind({
 		 * The maximum value selectable by the picker (inclusive).
 		 *
 		 * The range between `min` and `max` should be evenly divisible by
-		 * [step]{@link agate/internal/Picker.Picker.step}.
+		 * {@link agate/internal/Picker.Picker.step|step}.
 		 *
 		 * @type {Number}
 		 * @required
@@ -90,7 +90,7 @@ const PickerBase = kind({
 		 * The minimum value selectable by the picker (inclusive).
 		 *
 		 * The range between `min` and `max` should be evenly divisible by
-		 * [step]{@link agate/internal/Picker.Picker.step}.
+		 * {@link agate/internal/Picker.Picker.step|step}.
 		 *
 		 * @type {Number}
 		 * @required
@@ -597,7 +597,7 @@ const ChangeAdapter = hoc((config, Wrapped) => {
 });
 
 /**
- * Applies Agate specific behaviors to [Picker]{@link agate/Picker.Picker}.
+ * Applies Agate specific behaviors to {@link agate/Picker.Picker|Picker}.
  *
  * @hoc
  * @memberof agate/internal/Picker

--- a/internal/ToggleIcon/ToggleIcon.js
+++ b/internal/ToggleIcon/ToggleIcon.js
@@ -57,7 +57,7 @@ const ToggleIconDecorator = compose(
 );
 
 /**
- * A customizable Agate starting point [Icon]{@link agate/Icon.Icon} that responds to the
+ * A customizable Agate starting point {@link agate/Icon.Icon|Icon} that responds to the
  * `selected` prop.
  *
  * @class ToggleIcon

--- a/useScroll/ScrollButton.js
+++ b/useScroll/ScrollButton.js
@@ -8,8 +8,8 @@ import Button from '../Button';
 import css from './Scrollbar.module.less';
 
 /**
- * A [Button]{@link agate/Button.Button} used within
- * a [Scrollbar]{@link agate/useScroll.Scrollbar}.
+ * A {@link agate/Button.Button|Button} used within
+ * a {@link agate/useScroll.Scrollbar|Scrollbar}.
  *
  * @class ScrollButton
  * @memberof agate/useScroll

--- a/useScroll/ScrollButtons.js
+++ b/useScroll/ScrollButtons.js
@@ -29,7 +29,7 @@ const
 	};
 
 /**
- * A custom hook that returns Agate-themed scroll buttons behavior. It is used in [Scrollbar]{@link agate/useScroll.Scrollbar}.
+ * A custom hook that returns Agate-themed scroll buttons behavior. It is used in {@link agate/useScroll.Scrollbar|Scrollbar}.
  *
  * @function useScrollButtons
  * @memberof agate/useScroll

--- a/useScroll/ScrollbarTrack.js
+++ b/useScroll/ScrollbarTrack.js
@@ -24,7 +24,7 @@ ScrollbarTrack.displayName = 'ScrollbarTrack';
 
 ScrollbarTrack.propTypes = /** @lends agate/useScroll.ScrollbarTrack.prototype */ {
 	/**
-	 * Called when [ScrollbarTrack]{@link agate/useScroll.ScrollbarTrack} is updated.
+	 * Called when {@link agate/useScroll.ScrollbarTrack|ScrollbarTrack} is updated.
 	 *
 	 * @type {Function}
 	 * @private

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -38,8 +38,8 @@ const
 
 /**
  * The name of a custom attribute which indicates the index of an item in
- * [VirtualList]{@link agate/VirtualList.VirtualList} or
- * [VirtualGridList]{@link agate/VirtualList.VirtualGridList}.
+ * {@link agate/VirtualList.VirtualList|VirtualList} or
+ * {@link agate/VirtualList.VirtualGridList|VirtualGridList}.
  *
  * @constant dataIndexAttribute
  * @memberof agate/useScroll


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Adrian Cocoara adrian.cocoara@lgepartner.com

### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [X] Documentation was verified or is not changed
* [X] UI test was passed or is not needed
* [X] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
documentation module from docs-utils has updated to version 14.0.0. In order for the links to be rendered correctly, they have been changed as:
[BodyText]{https://github.com/link agate/BodyText.BodyText}
=> {https://github.com/link agate/BodyText.BodyText|BodyText}

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-13490

### Comments
