### PR TITLE
WRO-13688: Increment Slider - fix ref console error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The following is a curated list of changes in the Enact agate module, newest changes on the top.
 
+## Unreleased
+
+### Added
+
+- `agate/IncrementSlider` `sliderRef` prop to pass reference to the slider node
+- `agate/Slider` `sliderRef` prop to pass reference to the slider node
+
 ## [2.0.1] - 2022-09-29
 
 ### Changed

--- a/IncrementSlider/IncrementSlider.js
+++ b/IncrementSlider/IncrementSlider.js
@@ -120,12 +120,12 @@ const IncrementSliderBase = kind({
 		css: PropTypes.object,
 
 		/**
-		* Sets the hint string read when focusing the decrement button.
-		*
-		* @type {String}
-		* @default 'press button to decrease the value'
-		* @public
-		*/
+		 * Sets the hint string read when focusing the decrement button.
+		 *
+		 * @type {String}
+		 * @default 'press button to decrease the value'
+		 * @public
+		 */
 		decrementAriaLabel: PropTypes.string,
 
 		/**
@@ -163,12 +163,12 @@ const IncrementSliderBase = kind({
 		id: PropTypes.string,
 
 		/**
-		* Sets the hint string read when focusing the increment button.
-		*
-		* @default 'press button to increase the value'
-		* @type {String}
-		* @public
-		*/
+		 * Sets the hint string read when focusing the increment button.
+		 *
+		 * @default 'press button to increase the value'
+		 * @type {String}
+		 * @public
+		 */
 		incrementAriaLabel: PropTypes.string,
 
 		/**
@@ -500,43 +500,43 @@ const IncrementSliderBase = kind({
 	},
 
 	render: ({
-		activateOnFocus,
-		active,
-		'aria-hidden': ariaHidden,
-		backgroundProgress,
-		css,
-		decrementAriaLabel,
-		decrementDisabled,
-		decrementIcon,
-		disabled,
-		focused,
-		id,
-		incrementAriaLabel,
-		incrementDisabled,
-		incrementIcon,
-		knobStep,
-		max,
-		min,
-		noFill,
-		onActivate,
-		onChange,
-		onDecrement,
-		onDecrementSpotlightDisappear,
-		onDragEnd,
-		onDragStart,
-		onIncrement,
-		onIncrementSpotlightDisappear,
-		onSpotlightDisappear,
-		orientation,
-		progressAnchor,
-		size,
-	    sliderRef,
-		spotlightDisabled,
-		step,
-		tooltip,
-		value,
-		...rest
-	}) => {
+		 activateOnFocus,
+		 active,
+		 'aria-hidden': ariaHidden,
+		 backgroundProgress,
+		 css,
+		 decrementAriaLabel,
+		 decrementDisabled,
+		 decrementIcon,
+		 disabled,
+		 focused,
+		 id,
+		 incrementAriaLabel,
+		 incrementDisabled,
+		 incrementIcon,
+		 knobStep,
+		 max,
+		 min,
+		 noFill,
+		 onActivate,
+		 onChange,
+		 onDecrement,
+		 onDecrementSpotlightDisappear,
+		 onDragEnd,
+		 onDragStart,
+		 onIncrement,
+		 onIncrementSpotlightDisappear,
+		 onSpotlightDisappear,
+		 orientation,
+		 progressAnchor,
+		 size,
+		 sliderRef,
+		 spotlightDisabled,
+		 step,
+		 tooltip,
+		 value,
+		 ...rest
+	 }) => {
 		const ariaProps = extractAriaProps(rest);
 		delete rest.onSpotlightDirection;
 		delete rest.onSpotlightDown;

--- a/IncrementSlider/IncrementSlider.js
+++ b/IncrementSlider/IncrementSlider.js
@@ -606,6 +606,7 @@ const IncrementSliderDecorator = compose(
 	Changeable,
 	IdProvider({generateProp: null, prefix: 's_'}),
 	SliderBehaviorDecorator({emitSpotlightEvents: 'onSpotlightDirection'}),
+	Spottable,
 	Skinnable,
 	Slottable({slots: ['knob', 'tooltip']})
 );

--- a/IncrementSlider/IncrementSlider.js
+++ b/IncrementSlider/IncrementSlider.js
@@ -20,6 +20,7 @@
  */
 
 import {forward} from '@enact/core/handle';
+import EnactPropTypes from '@enact/core/internal/prop-types';
 import {is} from '@enact/core/keymap';
 import kind from '@enact/core/kind';
 import {extractAriaProps} from '@enact/core/util';
@@ -356,6 +357,14 @@ const IncrementSliderBase = kind({
 		size: PropTypes.oneOf(['small', 'large']),
 
 		/**
+		 * Called with the reference to the Slider node.
+		 *
+		 * @type {Object|Function}
+		 * @public
+		 */
+		sliderRef: EnactPropTypes.ref,
+
+		/**
 		 * Disables spotlight navigation into the component.
 		 *
 		 * @type {Boolean}
@@ -372,7 +381,6 @@ const IncrementSliderBase = kind({
 		 * @public
 		 */
 		step: PropTypes.number,
-
 
 		/**
 		 * Enables the built-in tooltip
@@ -522,6 +530,7 @@ const IncrementSliderBase = kind({
 		orientation,
 		progressAnchor,
 		size,
+	    sliderRef,
 		spotlightDisabled,
 		step,
 		tooltip,
@@ -568,6 +577,7 @@ const IncrementSliderBase = kind({
 					onDragStart={onDragStart}
 					onSpotlightDisappear={onSpotlightDisappear}
 					orientation={orientation}
+					sliderRef={sliderRef}
 					spotlightDisabled={spotlightDisabled}
 					progressAnchor={progressAnchor}
 					step={step}
@@ -606,7 +616,6 @@ const IncrementSliderDecorator = compose(
 	Changeable,
 	IdProvider({generateProp: null, prefix: 's_'}),
 	SliderBehaviorDecorator({emitSpotlightEvents: 'onSpotlightDirection'}),
-	Spottable,
 	Skinnable,
 	Slottable({slots: ['knob', 'tooltip']})
 );

--- a/IncrementSlider/IncrementSlider.js
+++ b/IncrementSlider/IncrementSlider.js
@@ -120,12 +120,12 @@ const IncrementSliderBase = kind({
 		css: PropTypes.object,
 
 		/**
-		 * Sets the hint string read when focusing the decrement button.
-		 *
-		 * @type {String}
-		 * @default 'press button to decrease the value'
-		 * @public
-		 */
+		* Sets the hint string read when focusing the decrement button.
+		*
+		* @type {String}
+		* @default 'press button to decrease the value'
+		* @public
+		*/
 		decrementAriaLabel: PropTypes.string,
 
 		/**
@@ -163,12 +163,12 @@ const IncrementSliderBase = kind({
 		id: PropTypes.string,
 
 		/**
-		 * Sets the hint string read when focusing the increment button.
-		 *
-		 * @default 'press button to increase the value'
-		 * @type {String}
-		 * @public
-		 */
+		* Sets the hint string read when focusing the increment button.
+		*
+		* @default 'press button to increase the value'
+		* @type {String}
+		* @public
+		*/
 		incrementAriaLabel: PropTypes.string,
 
 		/**
@@ -500,43 +500,43 @@ const IncrementSliderBase = kind({
 	},
 
 	render: ({
-		 activateOnFocus,
-		 active,
-		 'aria-hidden': ariaHidden,
-		 backgroundProgress,
-		 css,
-		 decrementAriaLabel,
-		 decrementDisabled,
-		 decrementIcon,
-		 disabled,
-		 focused,
-		 id,
-		 incrementAriaLabel,
-		 incrementDisabled,
-		 incrementIcon,
-		 knobStep,
-		 max,
-		 min,
-		 noFill,
-		 onActivate,
-		 onChange,
-		 onDecrement,
-		 onDecrementSpotlightDisappear,
-		 onDragEnd,
-		 onDragStart,
-		 onIncrement,
-		 onIncrementSpotlightDisappear,
-		 onSpotlightDisappear,
-		 orientation,
-		 progressAnchor,
-		 size,
-		 sliderRef,
-		 spotlightDisabled,
-		 step,
-		 tooltip,
-		 value,
-		 ...rest
-	 }) => {
+		activateOnFocus,
+		active,
+		'aria-hidden': ariaHidden,
+		backgroundProgress,
+		css,
+		decrementAriaLabel,
+		decrementDisabled,
+		decrementIcon,
+		disabled,
+		focused,
+		id,
+		incrementAriaLabel,
+		incrementDisabled,
+		incrementIcon,
+		knobStep,
+		max,
+		min,
+		noFill,
+		onActivate,
+		onChange,
+		onDecrement,
+		onDecrementSpotlightDisappear,
+		onDragEnd,
+		onDragStart,
+		onIncrement,
+		onIncrementSpotlightDisappear,
+		onSpotlightDisappear,
+		orientation,
+		progressAnchor,
+		size,
+		sliderRef,
+		spotlightDisabled,
+		step,
+		tooltip,
+		value,
+		...rest
+	}) => {
 		const ariaProps = extractAriaProps(rest);
 		delete rest.onSpotlightDirection;
 		delete rest.onSpotlightDown;

--- a/Slider/Slider.js
+++ b/Slider/Slider.js
@@ -97,7 +97,6 @@ const SliderBase = kind({
 		 */
 		css: PropTypes.object,
 
-
 		/**
 		 * Disables component and does not generate events.
 		 *

--- a/Slider/Slider.js
+++ b/Slider/Slider.js
@@ -19,6 +19,7 @@
 // TODO: Add 'activated' styling for slider (If 5-way is needed)
 
 import {forKey, forProp, forward, forwardWithPrevent, handle} from '@enact/core/handle';
+import EnactPropTypes from '@enact/core/internal/prop-types';
 import kind from '@enact/core/kind';
 import Spottable from '@enact/spotlight/Spottable';
 import Changeable from '@enact/ui/Changeable';
@@ -192,6 +193,14 @@ const SliderBase = kind({
 		progressAnchor: PropTypes.number,
 
 		/**
+		 * Called with the reference to the uiSlider node.
+		 *
+		 * @type {Object|Function}
+		 * @public
+		 */
+		sliderRef: EnactPropTypes.ref,
+
+		/**
 		 * The amount to increment or decrement the value.
 		 *
 		 * @type {Number}
@@ -294,7 +303,7 @@ const SliderBase = kind({
 		tooltip: ({tooltip}) => tooltip === true ? ProgressBarTooltip : tooltip
 	},
 
-	render: ({css, disabled, focused, tooltip, ...rest}) => {
+	render: ({css, disabled, focused, sliderRef, tooltip, ...rest}) => {
 		delete rest.activateOnFocus;
 		delete rest.active;
 		delete rest.knobStep;
@@ -309,6 +318,7 @@ const SliderBase = kind({
 				progressBarComponent={
 					<ProgressBar css={css} />
 				}
+				ref={sliderRef}
 				tooltipComponent={
 					<ComponentOverride
 						component={tooltip}

--- a/Slider/Slider.js
+++ b/Slider/Slider.js
@@ -193,7 +193,7 @@ const SliderBase = kind({
 		progressAnchor: PropTypes.number,
 
 		/**
-		 * Called with the reference to the uiSlider node.
+		 * Called with the reference to the Slider node.
 		 *
 		 * @type {Object|Function}
 		 * @public

--- a/Slider/SliderBehaviorDecorator.js
+++ b/Slider/SliderBehaviorDecorator.js
@@ -189,7 +189,7 @@ const SliderBehaviorDecorator = hoc(defaultConfig, (config, Wrapped) => {
 					onDragStart={this.handleDragStart}
 					onDragEnd={this.handleDragEnd}
 					onFocus={this.handleFocus}
-					ref={this.sliderRef}
+					sliderRef={this.sliderRef}
 				/>
 			);
 		}


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
IncrementSlider sample throws the following warning: "Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?"

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Passed sliderRef from SliderBehaviorDecorator to IncrementSlider to Slider.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-13688

### Comments
