### PR TITLE
WRO-14150: Fixed focused background color for Picker when content fits the width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact agate module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `agate/Picker` and `agate/RangePicker` width and height of the focused background
+
 ## [2.0.1] - 2022-09-29
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 
 ### Fixed
 
-- `agate/Picker` and `agate/RangePicker` width and height of the focused background
+- `agate/Picker` and `agate/RangePicker` width of the focus background
 
 ## [2.0.1] - 2022-09-29
 

--- a/internal/DateComponentPicker/DateComponentPicker.module.less
+++ b/internal/DateComponentPicker/DateComponentPicker.module.less
@@ -11,6 +11,8 @@
 	position: relative;
 
 	.applySkins({
+		.padding-start-end(@agate-datecomponentpicker-padding);
+
 		.active {
 			&::before {
 				background-color: transparent;

--- a/internal/Picker/Picker.module.less
+++ b/internal/Picker/Picker.module.less
@@ -18,7 +18,6 @@
 	.focusBackground {
 		display: none;
 		position: absolute;
-		width: calc(100% - 90px);
 		z-index: 1;
 	}
 
@@ -37,6 +36,7 @@
 			height: ~"calc(100% - 2 *" (.extract(@agate-picker-padding, top)[]) ~")";
 			background-color: @agate-picker-focus-bg-color;
 			background-image: @agate-picker-focus-bg-image;
+			width: ~"calc(90% - " .extract(@agate-picker-padding, left)[] ~"- " .extract(@agate-picker-padding, right)[] ~ ")";
 		}
 
 		.disabled({
@@ -143,7 +143,7 @@
 
 			.focusBackground {
 				background-image: @agate-picker-horizontal-focus-bg-image;
-				height: calc(100% - 60px);
+				height: ~"calc(75% - 2*" .extract(@agate-picker-padding, top)[] ~ ")";
 				width: calc(100% - 2 * @agate-picker-padding);
 			}
 

--- a/internal/Picker/Picker.module.less
+++ b/internal/Picker/Picker.module.less
@@ -122,7 +122,7 @@
 				background-image: @agate-picker-active-bg-image;
 				position: absolute;
 				height: @agate-picker-active-height;
-				width: ~"calc(100% - 2 *" (.extract(@agate-picker-padding, left)[])~ ")";
+				width: ~"calc(100% - " (.extract(@agate-picker-padding, left)[]) ~"- " (.extract(@agate-picker-padding, right)[]) ~ ")";
 				left: 50%;
 				transform: translateX(-50%);
 			}

--- a/internal/Picker/Picker.module.less
+++ b/internal/Picker/Picker.module.less
@@ -122,7 +122,7 @@
 				background-image: @agate-picker-active-bg-image;
 				position: absolute;
 				height: @agate-picker-active-height;
-				width: ~"calc(100% - " (.extract(@agate-picker-padding, left)[]) ~"- " (.extract(@agate-picker-padding, right)[]) ~ ")";
+				width: ~"calc(100% - 2 *" (.extract(@agate-picker-padding, top)[])~ ")";
 				left: 50%;
 				transform: translateX(-50%);
 			}

--- a/internal/Picker/Picker.module.less
+++ b/internal/Picker/Picker.module.less
@@ -18,7 +18,8 @@
 	.focusBackground {
 		display: none;
 		position: absolute;
-		width: 87%;
+		width: calc(100% - 90px);
+		min-width: 80%;
 		z-index: 1;
 	}
 
@@ -143,7 +144,7 @@
 
 			.focusBackground {
 				background-image: @agate-picker-horizontal-focus-bg-image;
-				height: 75%;
+				height: calc(100% - 60px);
 				width: calc(100% - 2 * @agate-picker-padding);
 			}
 

--- a/internal/Picker/Picker.module.less
+++ b/internal/Picker/Picker.module.less
@@ -18,6 +18,7 @@
 	.focusBackground {
 		display: none;
 		position: absolute;
+		width: 87%;
 		z-index: 1;
 	}
 
@@ -36,7 +37,6 @@
 			height: ~"calc(100% - 2 *" (.extract(@agate-picker-padding, top)[]) ~")";
 			background-color: @agate-picker-focus-bg-color;
 			background-image: @agate-picker-focus-bg-image;
-			width: ~"calc(90% - " .extract(@agate-picker-padding, left)[] ~"- " .extract(@agate-picker-padding, right)[] ~ ")";
 		}
 
 		.disabled({
@@ -122,7 +122,7 @@
 				background-image: @agate-picker-active-bg-image;
 				position: absolute;
 				height: @agate-picker-active-height;
-				width: ~"calc(100% - 2 *" (.extract(@agate-picker-padding, top)[])~ ")";
+				width: ~"calc(100% - 2 *" (.extract(@agate-picker-padding, left)[])~ ")";
 				left: 50%;
 				transform: translateX(-50%);
 			}
@@ -143,7 +143,7 @@
 
 			.focusBackground {
 				background-image: @agate-picker-horizontal-focus-bg-image;
-				height: ~"calc(75% - 2*" .extract(@agate-picker-padding, top)[] ~ ")";
+				height: 75%;
 				width: calc(100% - 2 * @agate-picker-padding);
 			}
 

--- a/styles/variables-base.less
+++ b/styles/variables-base.less
@@ -208,6 +208,10 @@
 @agate-contextual-popup-padding-vertical:    18px;
 @agate-contextual-popup-padding:             @agate-contextual-popup-padding-vertical @agate-contextual-popup-padding-horizontal;
 
+// DateComponentPicker
+// ---------------------------------------
+@agate-datecomponentpicker-padding: @agate-picker-padding;
+
 // DateTimePicker
 // ---------------------------------------
 @agate-datetimepicker-divider-height: inherit;

--- a/styles/variables-silicon.less
+++ b/styles/variables-silicon.less
@@ -92,6 +92,10 @@
 @agate-contextual-popup-padding-horizontal:  24px;
 @agate-contextual-popup-padding-vertical:    15px;
 
+// DateComponentPicker
+// ---------------------------------------
+@agate-datecomponentpicker-padding: 6px 6px 6px 9px;
+
 // DateTimePicker
 // ---------------------------------------
 @agate-datetimepicker-divider-height: 21px;
@@ -394,7 +398,6 @@
 @agate-picker-font-weight: bold;
 @agate-picker-active-font-weight: bold;
 @agate-picker-active-height: 99px;
-@agate-picker-padding: 6px 6px 6px 9px;
 @agate-picker-horizontal-active-width: 201px;
 @agate-picker-horizontal-item-height: 159px;
 @agate-picker-horizontal-item-width: 249px;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Changed the width/height of the container with className focusBackground. Instead of (100% - a fixed value in px), I calculated a percentage based on the absolute values presented in the UX guide. (example 610/700px = 87% ) https://app.zeplin.io/project/5fab9d1c39e44d926043ec54/screen/60222935a453c3bac7a1778d 
I moved the uneven padding for silicon skin from Picker to the DateComponentPicker. The uneven padding was necesary only in the date and time picker components. 
For Picker and RangePicker it generated an unnecesary uneven position of the text and background focus container, especially when the picker width was the same as the text width.

Ss tests showed a change of text position in Date and Time pickers for some locales on Silicon, but the change respects the UX guide.
The other skins are unaffected

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-14150

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian [daniel.stoian@lgepartner.com](mailto:daniel.stoian@lgepartner.com)
