### PR TITLE
WRO-14562: Fix node version to 18 in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: focal
 language: node_js
 node_js:
     - lts/*
-    - node
+    # - node
 sudo: false
 before_install:
     - sudo apt-get update


### PR DESCRIPTION
### Checklist

* [ ] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] Documentation was verified or is not changed
* [ ] UI test was passed or is not needed
* [ ] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Node 19 now on published(https://nodejs.org/en/blog/announcements/v19-release-announce/)
After this change, travis fails occurred continually so we need to block the current node temporary.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Update .travis.yml to not use the current node(node 19)

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-14562

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong taeyoung.hong@lge.com