### PR TITLE
WRP-3052: Refactor header for qa-scroller and qa-virtuallist samples

### DIFF
--- a/Header/Header.js
+++ b/Header/Header.js
@@ -2,7 +2,7 @@
  * Agate styled Header.
  *
  * @example
- * <Header title="Profile" titleAbove="Settings" noLine>
+ * <Header hideLine title="Profile" titleAbove="Settings">
  * 	<Button>Close</Button>
  * </Header>
  *

--- a/samples/qa-scroller/src/components/Controls/Controls.js
+++ b/samples/qa-scroller/src/components/Controls/Controls.js
@@ -12,27 +12,18 @@ const Controls = ({handleFocusableScrollbar, handleHeight, handleScrollMode, han
 	const rowWidth = typeof window !== 'undefined' ? `${ri.scaleToRem(window.innerWidth)}` : `${ri.scaleToRem(1920)}`;
 
 	return (
-		<Row style={{width: rowWidth}}>
-			<Cell>
+		<Row style={{width: rowWidth}} wrap>
+			<Cell align="center" shrink>
 				<label>height:</label>
 				<Input onChange={handleHeight} size="small" style={inputWidth} type="number" value={height} />
 			</Cell>
-			<Cell>
+			<Cell align="center" shrink>
 				<label>width:</label>
 				<Input onChange={handleWidth} size="small" style={inputWidth} type="number" value={width} />
 			</Cell>
-			<Cell
-				component={CheckboxItem}
-				onClick={handleFocusableScrollbar}
-			>
-				Focusable Scrollbar
-			</Cell>
-			<Cell>
-				<ScrollModeSwitch defaultSelected={nativeScroll} onToggle={handleScrollMode} />
-			</Cell>
-			<Cell>
-				<LocaleSwitch />
-			</Cell>
+			<CheckboxItem onClick={handleFocusableScrollbar} style={{minWidth: '12em'}}>Focusable Scrollbar</CheckboxItem>
+			<ScrollModeSwitch defaultSelected={nativeScroll} onToggle={handleScrollMode} style={{minWidth: '12em'}} />
+			<LocaleSwitch style={{minWidth: '12em'}} />
 		</Row>
 	);
 };

--- a/samples/qa-scroller/src/views/MainView.js
+++ b/samples/qa-scroller/src/views/MainView.js
@@ -8,7 +8,7 @@ import RadioItem from '@enact/agate/RadioItem';
 import Scroller from '@enact/agate/Scroller';
 import TimePicker from '@enact/agate/TimePicker';
 import Group from '@enact/ui/Group';
-import {Column} from '@enact/ui/Layout';
+import {Layout} from '@enact/ui/Layout';
 import ri from '@enact/ui/resolution';
 import {useCallback, useState} from 'react';
 
@@ -47,20 +47,18 @@ const MainView = () => {
 
 	return (
 		<Panel>
-			<Header hideLine title="">
-				<Column>
-					<h1>Scroller</h1>
-					<Controls
-						handleFocusableScrollbar={handleFocusableScrollbar}
-						handleHeight={handleHeight}
-						handleScrollMode={handleScrollMode}
-						handleWidth={handleWidth}
-						height={height}
-						nativeScroll={nativeScroll}
-						width={width}
-					/>
-				</Column>
-			</Header>
+			<Header hideLine title="Scroller" />
+			<Layout>
+				<Controls
+					handleFocusableScrollbar={handleFocusableScrollbar}
+					handleHeight={handleHeight}
+					handleScrollMode={handleScrollMode}
+					handleWidth={handleWidth}
+					height={height}
+					nativeScroll={nativeScroll}
+					width={width}
+				/>
+			</Layout>
 			<hr />
 			<Scroller
 				focusableScrollbar={focusableScrollbar}

--- a/samples/qa-virtuallist/src/views/MainPanel.js
+++ b/samples/qa-virtuallist/src/views/MainPanel.js
@@ -4,7 +4,7 @@ import Header from '@enact/agate/Header';
 import Input from '@enact/agate/Input';
 import {Panel} from '@enact/agate/Panels';
 import VirtualList from '@enact/agate/VirtualList';
-import {Cell, Column, Row} from '@enact/ui/Layout';
+import {Cell, Layout, Row} from '@enact/ui/Layout';
 import ri from '@enact/ui/resolution';
 import PropTypes from 'prop-types';
 import {useCallback, useEffect, useState} from 'react';
@@ -61,39 +61,29 @@ const MainPanel = ({...rest}) => {
 
 	return (
 		<Panel {...rest}>
-			<Header hideLine title="">
-				<Column>
-					<h1>Virtual List</h1>
-					<Row style={{width: rowWidth}}>
-						<Cell shrink>
-							<label>DataSize:</label>
-							<Input
-								onChange={handleChange}
-								placeholder={`${listItems.length}`}
-								size="small"
-								style={{width: '5em'}}
-								type="number"
-								value={value}
-							/>
-						</Cell>
-						<Cell shrink>
-							<Button onClick={onChangeDataSize} size="small">Set DataSize</Button>
-						</Cell>
-						<Cell>
-							<CheckboxItem onClick={onToggleDisabled} size="small">Disabled Items</CheckboxItem>
-						</Cell>
-						<Cell>
-							<CheckboxItem onClick={onToggleChildProps} size="small">Child Props</CheckboxItem>
-						</Cell>
-						<Cell>
-							<ScrollModeSwitch defaultSelected={nativeScroll} onToggle={onChangeScrollMode} />
-						</Cell>
-						<Cell>
-							<LocaleSwitch />
-						</Cell>
-					</Row>
-				</Column>
-			</Header>
+			<Header hideLine title="Virtual List" />
+			<Layout>
+				<Row style={{width: rowWidth}} wrap>
+					<Cell align="center" shrink>
+						<label>DataSize:</label>
+						<Input
+							onChange={handleChange}
+							placeholder={`${listItems.length}`}
+							size="small"
+							style={{width: '5em'}}
+							type="number"
+							value={value}
+						/>
+					</Cell>
+					<Cell align="center" shrink>
+						<Button onClick={onChangeDataSize} size="small">Set DataSize</Button>
+					</Cell>
+					<CheckboxItem onClick={onToggleDisabled} size="small" style={{height: '2em', minWidth: '8em'}}>Disabled Items</CheckboxItem>
+					<CheckboxItem onClick={onToggleChildProps} size="small" style={{height: '2em', minWidth: '8em'}}>Child Props</CheckboxItem>
+					<ScrollModeSwitch defaultSelected={nativeScroll} onToggle={onChangeScrollMode} style={{height: '2em', minWidth: '8em'}} />
+					<LocaleSwitch style={{height: '2em', minWidth: '8em'}} />
+				</Row>
+			</Layout>
 			<hr />
 			<VirtualList
 				className={css.verticalPadding}


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The header of qa-scroller and qa-virtuallist samples is not adapting to the screen width.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Refactored page header styling to work with different type of screen widths.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-3052

### Comments
