### PR TITLE
WRP-3065: Increase code coverage for TooltipDecorator

### DIFF
--- a/TooltipDecorator/tests/TooltipDecorator-specs.js
+++ b/TooltipDecorator/tests/TooltipDecorator-specs.js
@@ -17,18 +17,27 @@ describe('TooltipDecorator Specs', () => {
 			render(<TooltipLabel centered marquee>Label</TooltipLabel>);
 
 			const expected = 'center';
-			const tooltip = screen.getByText('Label');
+			const actual = screen.getByText('Label');
 
-			expect(tooltip).toHaveStyle({'text-align': expected});
+			expect(actual).toHaveStyle({'text-align': expected});
 		});
 
 		test('should not apply alignment when `centered` but not `marquee`', () => {
 			render(<TooltipLabel centered>Label</TooltipLabel>);
 
 			const unexpected = 'center';
-			const tooltip = screen.getByText('Label');
+			const actual = screen.getByText('Label');
 
-			expect(tooltip).not.toHaveStyle({'text-align': unexpected});
+			expect(actual).not.toHaveStyle({'text-align': unexpected});
+		});
+
+		test('should not apply `text-align: center` style when `centered=false`', () => {
+			render(<TooltipLabel centered={false}>Label</TooltipLabel>);
+
+			const expected = 'center';
+			const actual = screen.getByText('Label');
+
+			expect(actual).not.toHaveStyle({'text-align': expected});
 		});
 	});
 
@@ -79,32 +88,6 @@ describe('TooltipDecorator Specs', () => {
 			const actual = screen.queryByText(tooltipText);
 
 			expect(actual).toBeNull();
-		});
-
-		test('should apply `text-align: center` style when `centered=true` and `marquee=true`', () => {
-			render(
-				<TooltipLabel centered marquee>
-					Label
-				</TooltipLabel>
-			);
-
-			const expected = 'center';
-			const actual = screen.getByText('Label');
-
-			expect(actual).toHaveStyle({'text-align': expected});
-		});
-
-		test('should not apply `text-align: center` style when `centered=false`', () => {
-			render(
-				<TooltipLabel centered={false}>
-					Label
-				</TooltipLabel>
-			);
-
-			const expected = 'center';
-			const actual = screen.getByText('Label');
-
-			expect(actual).not.toHaveStyle({'text-align': expected});
 		});
 
 		test('should have `above` class when `direction=above`', () => {

--- a/TooltipDecorator/tests/TooltipDecorator-specs.js
+++ b/TooltipDecorator/tests/TooltipDecorator-specs.js
@@ -1,23 +1,27 @@
 import {FloatingLayerBase, FloatingLayerDecorator} from '@enact/ui/FloatingLayer';
 import '@testing-library/jest-dom';
-import {render, screen} from '@testing-library/react';
+import {act, fireEvent, render, screen, waitFor} from '@testing-library/react';
+
+import Button from '../../Button';
 
 import Tooltip from '../Tooltip';
+import TooltipDecorator from '../TooltipDecorator';
 import TooltipLabel from '../TooltipLabel';
 
-const Root = FloatingLayerDecorator('div');
+const FloatingLayerController = FloatingLayerDecorator('div');
+const TooltipButton = TooltipDecorator(Button);
 
 describe('TooltipDecorator Specs', () => {
 	test('should render component into FloatingLayer if open', () => {
 		const tooltipText = 'This is a tooltip';
 		render(
-			<Root>
+			<FloatingLayerController>
 				<FloatingLayerBase data-testid="floatingLayer" open>
 					<Tooltip>
 						{tooltipText}
 					</Tooltip>
 				</FloatingLayerBase>
-			</Root>
+			</FloatingLayerController>
 		);
 
 		const expected = tooltipText;
@@ -29,13 +33,13 @@ describe('TooltipDecorator Specs', () => {
 	test('should not render component into FloatingLayer if not open', () => {
 		const tooltipText = 'This is a tooltip';
 		render(
-			<Root>
+			<FloatingLayerController>
 				<FloatingLayerBase data-testid="floatingLayer">
 					<Tooltip>
 						{tooltipText}
 					</Tooltip>
 				</FloatingLayerBase>
-			</Root>
+			</FloatingLayerController>
 		);
 
 		const actual = screen.queryByText(tooltipText);
@@ -43,7 +47,7 @@ describe('TooltipDecorator Specs', () => {
 		expect(actual).toBeNull();
 	});
 
-	test('should apply `text-align: center` style when `centered=true` and marquee=true', () => {
+	test('should apply \'text-align: center\' style when \'centered=true\' and \'marquee=true\'', () => {
 		render(
 			<TooltipLabel centered marquee>
 				Label
@@ -56,7 +60,7 @@ describe('TooltipDecorator Specs', () => {
 		expect(actual).toHaveStyle({'text-align': expected});
 	});
 
-	test('should not apply `text-align: center` style when `centered=false`', () => {
+	test('should not apply \'text-align: center\' style when \'centered=false\'', () => {
 		render(
 			<TooltipLabel centered={false}>
 				Label
@@ -69,16 +73,16 @@ describe('TooltipDecorator Specs', () => {
 		expect(actual).not.toHaveStyle({'text-align': expected});
 	});
 
-	test('should have `above` class when `direction=above`', () => {
+	test('should have \'above\' class when \'direction=above\'', () => {
 		const tooltipText = 'This is a tooltip';
 		render(
-			<Root>
+			<FloatingLayerController>
 				<FloatingLayerBase open>
 					<Tooltip data-testid="tooltip" direction="above">
 						{tooltipText}
 					</Tooltip>
 				</FloatingLayerBase>
-			</Root>
+			</FloatingLayerController>
 		);
 
 		const expected = 'above';
@@ -87,16 +91,16 @@ describe('TooltipDecorator Specs', () => {
 		expect(actual).toHaveClass(expected);
 	});
 
-	test('should have `below` class when `direction=below`', () => {
+	test('should have \'below\' class when \'direction=below\'', () => {
 		const tooltipText = 'This is a tooltip';
 		render(
-			<Root>
+			<FloatingLayerController>
 				<FloatingLayerBase open>
 					<Tooltip data-testid="tooltip" direction="below">
 						{tooltipText}
 					</Tooltip>
 				</FloatingLayerBase>
-			</Root>
+			</FloatingLayerController>
 		);
 
 		const expected = 'below';
@@ -105,16 +109,16 @@ describe('TooltipDecorator Specs', () => {
 		expect(actual).toHaveClass(expected);
 	});
 
-	test('should have `left` class when `direction=left`', () => {
+	test('should have \'left\' class when \'direction=left\'', () => {
 		const tooltipText = 'This is a tooltip';
 		render(
-			<Root>
+			<FloatingLayerController>
 				<FloatingLayerBase open>
 					<Tooltip data-testid="tooltip" direction="left">
 						{tooltipText}
 					</Tooltip>
 				</FloatingLayerBase>
-			</Root>
+			</FloatingLayerController>
 		);
 
 		const expected = 'left';
@@ -123,21 +127,222 @@ describe('TooltipDecorator Specs', () => {
 		expect(actual).toHaveClass(expected);
 	});
 
-	test('should have `right` class when `direction=right`', () => {
+	test('should have \'right\' class when \'direction=right\'', () => {
 		const tooltipText = 'This is a tooltip';
 		render(
-			<Root>
+			<FloatingLayerController>
 				<FloatingLayerBase open>
 					<Tooltip data-testid="tooltip" direction="right">
 						{tooltipText}
 					</Tooltip>
 				</FloatingLayerBase>
-			</Root>
+			</FloatingLayerController>
 		);
 
 		const expected = 'right';
 		const actual = screen.getByTestId('tooltip');
 
 		expect(actual).toHaveClass(expected);
+	});
+
+	describe('TooltipLabel', () => {
+		test('should apply alignment when \'centered\' and \'marquee\'', () => {
+			render(<TooltipLabel centered marquee>Label</TooltipLabel>);
+
+			const expected = 'center';
+			const tooltip = screen.getByText('Label');
+
+			expect(tooltip).toHaveStyle({'text-align': expected});
+		});
+
+		test('should not apply alignment when \'centered\' but not \'marquee\'', () => {
+			render(<TooltipLabel centered>Label</TooltipLabel>);
+
+			const unexpected = 'center';
+			const tooltip = screen.getByText('Label');
+
+			expect(tooltip).not.toHaveStyle({'text-align': unexpected});
+		});
+	});
+
+	describe('TooltipDecorator', () => {
+		beforeEach(() => {
+			global.Element.prototype.getBoundingClientRect = jest.fn(() => {
+				return {
+					width: 501,
+					height: 501,
+					top: 99,
+					left: 99,
+					bottom: 0,
+					right: 0
+				};
+			});
+		});
+
+		test('should render a tooltip if hovered', async () => {
+			const tooltipText = 'Tooltip';
+			render(
+				<FloatingLayerController>
+					<TooltipButton tooltipDelay={0} tooltipText={tooltipText}>Label</TooltipButton>
+				</FloatingLayerController>
+			);
+
+			const button = screen.getByRole('button');
+			act(() => button.focus());
+			fireEvent.mouseOver(button);
+
+			await waitFor(() => {
+				expect(screen.getByText('Tooltip')).toBeInTheDocument();
+			});
+		});
+
+		test('should hide tooltip if not hovered', async () => {
+			const tooltipText = 'Tooltip';
+			render(
+				<FloatingLayerController>
+					<TooltipButton tooltipDelay={0} tooltipText={tooltipText}>Label</TooltipButton>
+				</FloatingLayerController>
+			);
+
+			const button = screen.getByRole('button');
+			act(() => button.focus());
+			fireEvent.mouseOver(button);
+
+			await waitFor(() => {
+				expect(screen.getByText('Tooltip')).toBeInTheDocument();
+			});
+
+			act(() => button.blur());
+			fireEvent.mouseOut(button);
+
+			await waitFor(() => {
+				expect(screen.queryByText('Tooltip')).not.toBeInTheDocument();
+			});
+		});
+
+		test('should render a tooltip if hovered for \'tooltipRelative\'', async () => {
+			console.error = jest.fn();	// eslint-disable-line no-console
+			const tooltipText = 'Tooltip';
+			render(
+				<FloatingLayerController>
+					<TooltipButton tooltipDelay={0} tooltipRelative tooltipText={tooltipText}>Label</TooltipButton>
+				</FloatingLayerController>
+			);
+
+			const button = screen.getByRole('button');
+			act(() => button.focus());
+			fireEvent.mouseOver(button);
+
+			await waitFor(() => {
+				expect(screen.getByText('Tooltip')).toBeInTheDocument();
+			});
+		});
+
+		describe('Tooltip position', () => {
+			test('should have \'above\' className when tooltipPosition is set to \'above\'', async () => {
+				const tooltipText = 'Tooltip';
+				render(
+					<FloatingLayerController>
+						<TooltipButton tooltipDelay={0} tooltipPosition="above" tooltipText={tooltipText}>Label</TooltipButton>
+					</FloatingLayerController>
+				);
+
+				const button = screen.getByRole('button');
+
+				button.getBoundingClientRect = jest.fn(() => {
+					return {
+						width: 300,
+						height: 300,
+						top: 600,
+						left: 600,
+						bottom: 0,
+						right: 0
+					};
+				});
+
+				act(() => button.focus());
+				fireEvent.mouseOver(button);
+
+				await waitFor(() => {
+					const tooltipArrow = screen.getByText('Tooltip').parentElement.parentElement;
+					const expected = 'tooltip above';
+
+					expect(tooltipArrow).toHaveClass(expected);
+				});
+			});
+
+			test('should have \'below\' className when tooltipPosition is set to \'below\'', async () => {
+				const tooltipText = 'Tooltip';
+				render(
+					<FloatingLayerController>
+						<TooltipButton tooltipDelay={0} tooltipPosition="below" tooltipText={tooltipText}>Label</TooltipButton>
+					</FloatingLayerController>
+				);
+
+				const button = screen.getByRole('button');
+
+				button.getBoundingClientRect = jest.fn(() => {
+					return {
+						width: 300,
+						height: 300,
+						top: 600,
+						left: 600,
+						bottom: 0,
+						right: 0
+					};
+				});
+
+				act(() => button.focus());
+				fireEvent.mouseOver(button);
+
+				await waitFor(() => {
+					const tooltipArrow = screen.getByText('Tooltip').parentElement.parentElement;
+
+					const expected = 'tooltip below';
+
+					expect(tooltipArrow).toHaveClass(expected);
+				});
+			});
+
+			test('should have \'left middle\' className when tooltipPosition is set to \'left middle\'', async () => {
+				const tooltipText = 'Tooltip';
+				render(
+					<FloatingLayerController>
+						<TooltipButton tooltipDelay={0} tooltipPosition="left middle" tooltipText={tooltipText}>Label</TooltipButton>
+					</FloatingLayerController>
+				);
+
+				const button = screen.getByRole('button');
+				act(() => button.focus());
+				fireEvent.mouseOver(button);
+
+				await waitFor(() => {
+					const tooltipArrow = screen.getByText('Tooltip').parentElement.parentElement;
+					const expected = 'tooltip left middleArrow';
+
+					expect(tooltipArrow).toHaveClass(expected);
+				});
+			});
+
+			test('should have \'right middle\' className when tooltipPosition is set to \'right middle\'', async () => {
+				const tooltipText = 'Tooltip';
+				render(
+					<FloatingLayerController>
+						<TooltipButton tooltipDelay={0} tooltipPosition="right middle" tooltipText={tooltipText}>Label</TooltipButton>
+					</FloatingLayerController>
+				);
+
+				const button = screen.getByRole('button');
+				act(() => button.focus());
+				fireEvent.mouseOver(button);
+
+				await waitFor(() => {
+					const tooltipArrow = screen.getByText('Tooltip').parentElement.parentElement;
+					const expected = 'tooltip right middleArrow';
+
+					expect(tooltipArrow).toHaveClass(expected);
+				});
+			});
+		});
 	});
 });

--- a/TooltipDecorator/tests/TooltipDecorator-specs.js
+++ b/TooltipDecorator/tests/TooltipDecorator-specs.js
@@ -12,141 +12,8 @@ const FloatingLayerController = FloatingLayerDecorator('div');
 const TooltipButton = TooltipDecorator(Button);
 
 describe('TooltipDecorator Specs', () => {
-	test('should render component into FloatingLayer if open', () => {
-		const tooltipText = 'This is a tooltip';
-		render(
-			<FloatingLayerController>
-				<FloatingLayerBase data-testid="floatingLayer" open>
-					<Tooltip>
-						{tooltipText}
-					</Tooltip>
-				</FloatingLayerBase>
-			</FloatingLayerController>
-		);
-
-		const expected = tooltipText;
-		const actual = screen.getByTestId('floatingLayer');
-
-		expect(actual).toHaveTextContent(expected);
-	});
-
-	test('should not render component into FloatingLayer if not open', () => {
-		const tooltipText = 'This is a tooltip';
-		render(
-			<FloatingLayerController>
-				<FloatingLayerBase data-testid="floatingLayer">
-					<Tooltip>
-						{tooltipText}
-					</Tooltip>
-				</FloatingLayerBase>
-			</FloatingLayerController>
-		);
-
-		const actual = screen.queryByText(tooltipText);
-
-		expect(actual).toBeNull();
-	});
-
-	test('should apply \'text-align: center\' style when \'centered=true\' and \'marquee=true\'', () => {
-		render(
-			<TooltipLabel centered marquee>
-				Label
-			</TooltipLabel>
-		);
-
-		const expected = 'center';
-		const actual = screen.getByText('Label');
-
-		expect(actual).toHaveStyle({'text-align': expected});
-	});
-
-	test('should not apply \'text-align: center\' style when \'centered=false\'', () => {
-		render(
-			<TooltipLabel centered={false}>
-				Label
-			</TooltipLabel>
-		);
-
-		const expected = 'center';
-		const actual = screen.getByText('Label');
-
-		expect(actual).not.toHaveStyle({'text-align': expected});
-	});
-
-	test('should have \'above\' class when \'direction=above\'', () => {
-		const tooltipText = 'This is a tooltip';
-		render(
-			<FloatingLayerController>
-				<FloatingLayerBase open>
-					<Tooltip data-testid="tooltip" direction="above">
-						{tooltipText}
-					</Tooltip>
-				</FloatingLayerBase>
-			</FloatingLayerController>
-		);
-
-		const expected = 'above';
-		const actual = screen.getByTestId('tooltip');
-
-		expect(actual).toHaveClass(expected);
-	});
-
-	test('should have \'below\' class when \'direction=below\'', () => {
-		const tooltipText = 'This is a tooltip';
-		render(
-			<FloatingLayerController>
-				<FloatingLayerBase open>
-					<Tooltip data-testid="tooltip" direction="below">
-						{tooltipText}
-					</Tooltip>
-				</FloatingLayerBase>
-			</FloatingLayerController>
-		);
-
-		const expected = 'below';
-		const actual = screen.getByTestId('tooltip');
-
-		expect(actual).toHaveClass(expected);
-	});
-
-	test('should have \'left\' class when \'direction=left\'', () => {
-		const tooltipText = 'This is a tooltip';
-		render(
-			<FloatingLayerController>
-				<FloatingLayerBase open>
-					<Tooltip data-testid="tooltip" direction="left">
-						{tooltipText}
-					</Tooltip>
-				</FloatingLayerBase>
-			</FloatingLayerController>
-		);
-
-		const expected = 'left';
-		const actual = screen.getByTestId('tooltip');
-
-		expect(actual).toHaveClass(expected);
-	});
-
-	test('should have \'right\' class when \'direction=right\'', () => {
-		const tooltipText = 'This is a tooltip';
-		render(
-			<FloatingLayerController>
-				<FloatingLayerBase open>
-					<Tooltip data-testid="tooltip" direction="right">
-						{tooltipText}
-					</Tooltip>
-				</FloatingLayerBase>
-			</FloatingLayerController>
-		);
-
-		const expected = 'right';
-		const actual = screen.getByTestId('tooltip');
-
-		expect(actual).toHaveClass(expected);
-	});
-
 	describe('TooltipLabel', () => {
-		test('should apply alignment when \'centered\' and \'marquee\'', () => {
+		test('should apply alignment when `centered` and `marquee`', () => {
 			render(<TooltipLabel centered marquee>Label</TooltipLabel>);
 
 			const expected = 'center';
@@ -155,7 +22,7 @@ describe('TooltipDecorator Specs', () => {
 			expect(tooltip).toHaveStyle({'text-align': expected});
 		});
 
-		test('should not apply alignment when \'centered\' but not \'marquee\'', () => {
+		test('should not apply alignment when `centered` but not `marquee`', () => {
 			render(<TooltipLabel centered>Label</TooltipLabel>);
 
 			const unexpected = 'center';
@@ -177,6 +44,139 @@ describe('TooltipDecorator Specs', () => {
 					right: 0
 				};
 			});
+		});
+
+		test('should render component into FloatingLayer if open', () => {
+			const tooltipText = 'This is a tooltip';
+			render(
+				<FloatingLayerController>
+					<FloatingLayerBase data-testid="floatingLayer" open>
+						<Tooltip>
+							{tooltipText}
+						</Tooltip>
+					</FloatingLayerBase>
+				</FloatingLayerController>
+			);
+
+			const expected = tooltipText;
+			const actual = screen.getByTestId('floatingLayer');
+
+			expect(actual).toHaveTextContent(expected);
+		});
+
+		test('should not render component into FloatingLayer if not open', () => {
+			const tooltipText = 'This is a tooltip';
+			render(
+				<FloatingLayerController>
+					<FloatingLayerBase data-testid="floatingLayer">
+						<Tooltip>
+							{tooltipText}
+						</Tooltip>
+					</FloatingLayerBase>
+				</FloatingLayerController>
+			);
+
+			const actual = screen.queryByText(tooltipText);
+
+			expect(actual).toBeNull();
+		});
+
+		test('should apply `text-align: center` style when `centered=true` and `marquee=true`', () => {
+			render(
+				<TooltipLabel centered marquee>
+					Label
+				</TooltipLabel>
+			);
+
+			const expected = 'center';
+			const actual = screen.getByText('Label');
+
+			expect(actual).toHaveStyle({'text-align': expected});
+		});
+
+		test('should not apply `text-align: center` style when `centered=false`', () => {
+			render(
+				<TooltipLabel centered={false}>
+					Label
+				</TooltipLabel>
+			);
+
+			const expected = 'center';
+			const actual = screen.getByText('Label');
+
+			expect(actual).not.toHaveStyle({'text-align': expected});
+		});
+
+		test('should have `above` class when `direction=above`', () => {
+			const tooltipText = 'This is a tooltip';
+			render(
+				<FloatingLayerController>
+					<FloatingLayerBase open>
+						<Tooltip data-testid="tooltip" direction="above">
+							{tooltipText}
+						</Tooltip>
+					</FloatingLayerBase>
+				</FloatingLayerController>
+			);
+
+			const expected = 'above';
+			const actual = screen.getByTestId('tooltip');
+
+			expect(actual).toHaveClass(expected);
+		});
+
+		test('should have `below` class when `direction=below`', () => {
+			const tooltipText = 'This is a tooltip';
+			render(
+				<FloatingLayerController>
+					<FloatingLayerBase open>
+						<Tooltip data-testid="tooltip" direction="below">
+							{tooltipText}
+						</Tooltip>
+					</FloatingLayerBase>
+				</FloatingLayerController>
+			);
+
+			const expected = 'below';
+			const actual = screen.getByTestId('tooltip');
+
+			expect(actual).toHaveClass(expected);
+		});
+
+		test('should have `left` class when `direction=left`', () => {
+			const tooltipText = 'This is a tooltip';
+			render(
+				<FloatingLayerController>
+					<FloatingLayerBase open>
+						<Tooltip data-testid="tooltip" direction="left">
+							{tooltipText}
+						</Tooltip>
+					</FloatingLayerBase>
+				</FloatingLayerController>
+			);
+
+			const expected = 'left';
+			const actual = screen.getByTestId('tooltip');
+
+			expect(actual).toHaveClass(expected);
+		});
+
+		test('should have `right` class when `direction=right`', () => {
+			const tooltipText = 'This is a tooltip';
+			render(
+				<FloatingLayerController>
+					<FloatingLayerBase open>
+						<Tooltip data-testid="tooltip" direction="right">
+							{tooltipText}
+						</Tooltip>
+					</FloatingLayerBase>
+				</FloatingLayerController>
+			);
+
+			const expected = 'right';
+			const actual = screen.getByTestId('tooltip');
+
+			expect(actual).toHaveClass(expected);
 		});
 
 		test('should render a tooltip if hovered', async () => {
@@ -220,7 +220,7 @@ describe('TooltipDecorator Specs', () => {
 			});
 		});
 
-		test('should render a tooltip if hovered for \'tooltipRelative\'', async () => {
+		test('should render a tooltip if hovered for `tooltipRelative`', async () => {
 			console.error = jest.fn();	// eslint-disable-line no-console
 			const tooltipText = 'Tooltip';
 			render(
@@ -239,7 +239,7 @@ describe('TooltipDecorator Specs', () => {
 		});
 
 		describe('Tooltip position', () => {
-			test('should have \'above\' className when tooltipPosition is set to \'above\'', async () => {
+			test('should have `above` className when tooltipPosition is set to `above`', async () => {
 				const tooltipText = 'Tooltip';
 				render(
 					<FloatingLayerController>
@@ -271,7 +271,7 @@ describe('TooltipDecorator Specs', () => {
 				});
 			});
 
-			test('should have \'below\' className when tooltipPosition is set to \'below\'', async () => {
+			test('should have `below` className when tooltipPosition is set to `below`', async () => {
 				const tooltipText = 'Tooltip';
 				render(
 					<FloatingLayerController>
@@ -304,7 +304,7 @@ describe('TooltipDecorator Specs', () => {
 				});
 			});
 
-			test('should have \'left middle\' className when tooltipPosition is set to \'left middle\'', async () => {
+			test('should have `left middle` className when tooltipPosition is set to `left middle`', async () => {
 				const tooltipText = 'Tooltip';
 				render(
 					<FloatingLayerController>
@@ -324,7 +324,7 @@ describe('TooltipDecorator Specs', () => {
 				});
 			});
 
-			test('should have \'right middle\' className when tooltipPosition is set to \'right middle\'', async () => {
+			test('should have `right middle` className when tooltipPosition is set to `right middle`', async () => {
 				const tooltipText = 'Tooltip';
 				render(
 					<FloatingLayerController>
@@ -339,6 +339,38 @@ describe('TooltipDecorator Specs', () => {
 				await waitFor(() => {
 					const tooltipArrow = screen.getByText('Tooltip').parentElement.parentElement;
 					const expected = 'tooltip right middleArrow';
+
+					expect(tooltipArrow).toHaveClass(expected);
+				});
+			});
+
+			test('should have `above centerArrow` className when tooltipPosition is set to `left`', async () => {
+				const tooltipText = 'Tooltip';
+				render(
+					<FloatingLayerController>
+						<TooltipButton tooltipDelay={0} tooltipPosition="left" tooltipText={tooltipText}>Label</TooltipButton>
+					</FloatingLayerController>
+				);
+
+				const button = screen.getByRole('button');
+
+				button.getBoundingClientRect = jest.fn(() => {
+					return {
+						width: 300,
+						height: 300,
+						top: 600,
+						left: 600,
+						bottom: 0,
+						right: 0
+					};
+				});
+
+				act(() => button.focus());
+				fireEvent.mouseOver(button);
+
+				await waitFor(() => {
+					const tooltipArrow = screen.getByText('Tooltip').parentElement.parentElement;
+					const expected = 'tooltip above centerArrow';
 
 					expect(tooltipArrow).toHaveClass(expected);
 				});


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Increased code coverage for TooltipDecorator from 14.35% to 90.74%.

Code coverage increase
Tooltip.js 83.33% -> 100%
TooltipDecorator.js 7.01% -> 91.22%
utils.js 7.22% -> 87.95%

![image](https://user-images.githubusercontent.com/63335068/203000569-a5f7912e-6dfd-4f41-8288-cd3fe7971343.png)


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-3065

### Comments
Enact-DCO-1.0-Signed-off-by: Andrei Tirla andrei.tirla@lgepartner.com