### PR TITLE
WRP-2681: SliderBehaviorDecorator - Fixed reading of sliderRef node on touchscreen devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The following is a curated list of changes in the Enact agate module, newest cha
 - `agate/IncrementSlider` `sliderRef` prop to pass reference to the slider node
 - `agate/Slider` `sliderRef` prop to pass reference to the slider node
 
+### Fixed
+
+- `agate/Slider` to read the `sliderRef` node correctly on touchscreen devices
+
 ## [2.0.2] - 2022-10-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,6 @@ The following is a curated list of changes in the Enact agate module, newest cha
 - `agate/IncrementSlider` `sliderRef` prop to pass reference to the slider node
 - `agate/Slider` `sliderRef` prop to pass reference to the slider node
 
-### Fixed
-
-- `agate/Slider` to read the `sliderRef` node correctly on touchscreen devices
-
 ## [2.0.2] - 2022-10-28
 
 ### Fixed

--- a/Slider/SliderBehaviorDecorator.js
+++ b/Slider/SliderBehaviorDecorator.js
@@ -117,7 +117,7 @@ const SliderBehaviorDecorator = hoc(defaultConfig, (config, Wrapped) => {
 		}
 
 		focusSlider () {
-			let slider = this.sliderRef.current.node;
+			let slider = this.sliderRef.current;
 			if (slider.getAttribute('role') !== 'slider') {
 				slider = slider.querySelector('[role="slider"]');
 			}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
On touchscreen devices, when dragging the slider, an error was thrown in the console

![image](https://user-images.githubusercontent.com/63335068/206427974-380b67b6-f39c-46ec-98f7-777dfa1b117c.png)


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Updated the focusSlider function to read correctly the reference

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
The fix was debugged on PC ChromeDevTools for mobile device and  on ChromeAndroid

### Links
[//]: # (Related issues, references)
WRP-2681

### Comments
Enact-DCO-1.0-Signed-off-by: Daniel Stoian [daniel.stoian@lgepartner.com](mailto:daniel.stoian@lgepartner.com)