### PR TITLE
WRP-4939: TabGroup - onClick is not supplied to Tab

### DIFF
--- a/TabGroup/TabGroup.js
+++ b/TabGroup/TabGroup.js
@@ -10,6 +10,7 @@
  * @exports TabGroupDecorator
  */
 
+import handle, {forward, forwardCustom} from '@enact/core/handle';
 import kind from '@enact/core/kind';
 import {cap} from '@enact/core/util';
 import Group from '@enact/ui/Group';
@@ -73,7 +74,7 @@ const TabBase = kind({
 		 * @type {Function}
 		 * @public
 		 */
-		onClick: PropTypes.func,
+		onTabClick: PropTypes.func,
 
 		/**
 		 * Orientation of the tab.
@@ -102,6 +103,13 @@ const TabBase = kind({
 	styles: {
 		css: componentCss,
 		className: 'tab'
+	},
+
+	handlers: {
+		onClick: handle(
+			forward('onClick'),
+			forwardCustom('onTabClick', (ev, {index}) => ({selected: index}))
+		)
 	},
 
 	computed: {
@@ -137,15 +145,16 @@ const TabBase = kind({
 		}
 	},
 
-	render: ({onClick, orientation, style = {}, tabLabel, ...rest}) => {
+	render: ({orientation, style = {}, tabLabel, ...rest}) => {
 		delete rest.labelPosition;
+		delete rest.onTabClick;
 		delete rest.selected;
 
 		if (orientation === 'horizontal') {
 			style.textAlign = 'center';
 		}
 		return (
-			<Cell {...rest} style={style} onClick={onClick}>
+			<Cell {...rest} style={style}>
 				{tabLabel}
 			</Cell>
 		);
@@ -213,6 +222,18 @@ const TabGroupBase = kind({
 		css: PropTypes.object,
 
 		/**
+		 * Called when an item is selected.
+		 *
+		 * The event payload will be an object with the following members:
+		 * * `data` - The value for the option as received in the `children` prop
+		 * * `selected` - Number representing the selected option, 0 indexed
+		 *
+		 * @type {Function}
+		 * @public
+		 */
+		onSelect: PropTypes.func,
+
+		/**
 		 * Orientation of the tabs.
 		 *
 		 * * Values: `'horizontal'`, `'vertical'`
@@ -260,7 +281,7 @@ const TabGroupBase = kind({
 		})
 	},
 
-	render: ({afterTabs, beforeTabs, className, css, labelPosition, orientation, selectedIndex, style, ...rest}) => {
+	render: ({afterTabs, beforeTabs, className, css, labelPosition, onSelect, orientation, selectedIndex, style, ...rest}) => {
 		delete rest.tabPosition;
 		delete rest.tabs;
 
@@ -281,6 +302,7 @@ const TabGroupBase = kind({
 							orientation,
 							shrink: (orientation === 'vertical')
 						}}
+						onSelect={onSelect}
 						orientation={orientation}
 						select="radio"
 						selected={selectedIndex}

--- a/TabGroup/tests/TabGroup-specs.js
+++ b/TabGroup/tests/TabGroup-specs.js
@@ -1,11 +1,30 @@
 import '@testing-library/jest-dom';
 import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import Button from '../../Button';
 import TabGroup from '../TabGroup';
 import ThemeDecorator from '../../ThemeDecorator';
 
 describe('TabGroup Specs', () => {
+	test('should fire `onTabClick` with `onTabClick` type when a tab is clicked', () => {
+		const handleTabClick = jest.fn();
+		render(
+			<TabGroup
+				tabPosition="before"
+				tabs={[
+					{title: 'Home', icon: 'home', onTabClick: handleTabClick},
+					{title: 'Settings', icon: 'setting'},
+					{title: 'Theme', icon: 'display'}
+				]}
+			/>
+		);
+
+		userEvent.click(screen.getByRole('group').children[0]); // clicking tab
+
+		expect(handleTabClick).toHaveBeenCalled();
+	});
+
 	test('should render three tabs when given three objects in `tabs` prop', () => {
 		render(
 			<TabGroup

--- a/samples/sampler/stories/default/TabGroup.js
+++ b/samples/sampler/stories/default/TabGroup.js
@@ -1,3 +1,4 @@
+import {action} from "@enact/storybook-utils/addons/actions";
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {select} from '@enact/storybook-utils/addons/controls';
 import Button from '@enact/agate/Button';
@@ -13,8 +14,10 @@ export default {
 
 export const _TabGroup = (args) => {
 	const orientation = args['orientation'];
+
 	return (
 		<TabGroup
+			onSelect={action('onSelect')}
 			orientation={orientation}
 			tabPosition={args['tabPosition']}
 			tabs={[


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [ ] UI test was passed or is not needed
* [ ] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Added onSelect function to each Tab inside TabGroup and created a unit test for TabGroup that checks onTabClick.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Each Tab inside TabGroup now have an onSelect function.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-4939

### Comments
Enact-DCO-1.0-Signed-off-by: Andrei Tirla andrei.tirla@lgepartner.com