### PR TITLE
WRP-6584: Fixed failed ui tests on Jenkins

### DIFF
--- a/tests/ui/specs/Drawer/Drawer-specs.js
+++ b/tests/ui/specs/Drawer/Drawer-specs.js
@@ -23,10 +23,11 @@ describe('Drawer', function () {
 
 		it('should have correct heading', async function () {
 			await drawerCommon.buttonDrawer1.click();
-
+			await browser.pause(400);
 			await Page.waitForOpen(drawer);
 
 			await expectOpen(drawerCommon);
+			await browser.pause(400);
 			await validateTitle(drawer, 'Drawer with no line');
 		});
 
@@ -96,6 +97,7 @@ describe('Drawer', function () {
 		it('should have correct heading', async function () {
 			await drawerCommon.buttonDrawer2.click();
 			await browser.pause(300); // needed to pass instead of waitTransitionEnd
+
 			await expectOpen(drawerCommon);
 			await validateTitle(drawer, 'Drawer without animation');
 		});
@@ -155,9 +157,11 @@ describe('Drawer', function () {
 
 		it('should have correct heading', async function () {
 			await drawerCommon.buttonDrawer3.click();
+			await browser.pause(400);
 			await Page.waitForOpen(drawer);
 
 			await expectOpen(drawerCommon);
+			await browser.pause(400);
 			await validateTitle(drawer, 'Drawer with transparent scrim');
 		});
 
@@ -222,8 +226,8 @@ describe('Drawer', function () {
 
 		it('should have correct heading', async function () {
 			await drawerCommon.buttonDrawer4.click();
-			await Page.waitForOpen(drawer);
 			await browser.pause(400);
+			await Page.waitForOpen(drawer);
 
 			await expectNoneScrimOpen(drawerCommon);
 			await browser.pause(400);

--- a/tests/ui/specs/Drawer/Drawer-specs.js
+++ b/tests/ui/specs/Drawer/Drawer-specs.js
@@ -89,7 +89,6 @@ describe('Drawer', function () {
 
 		it('should have correct heading', async function () {
 			await drawerCommon.buttonDrawer2.click();
-			// await browser.pause(300); // needed to pass instead of waitTransitionEnd
 
 			await expectOpen(drawerCommon);
 			await validateTitle(drawer, 'Drawer without animation');
@@ -100,7 +99,6 @@ describe('Drawer', function () {
 			it('should open drawer', async function () {
 				await Page.spotlightRight();
 				await Page.spotlightSelect();
-				// await browser.pause(400); // needed to pass instead of waitTransitionEnd
 
 				await expectOpen(drawerCommon);
 				expect(await drawer.isOpen).to.be.true();
@@ -124,19 +122,15 @@ describe('Drawer', function () {
 
 			it('should open the drawer with scrim on click', async function () {
 				await drawerCommon.buttonDrawer2.click();
-				// await browser.pause(400); // needed to pass instead of waitTransitionEnd
 
 				await expectOpen(drawerCommon);
 			});
 
 			it('should close the drawer and scrim on cancel click in drawer container', async function () {
 				await drawerCommon.buttonDrawer2.click();
-				// await browser.pause(400); // needed to pass instead of waitTransitionEnd
-
 				await expectOpen(drawerCommon);
 
 				await drawer.buttonCancel.click();
-				// await browser.pause(400); // needed to pass instead of waitTransitionEnd
 
 				await expectClosed(drawerCommon);
 			});

--- a/tests/ui/specs/Drawer/Drawer-specs.js
+++ b/tests/ui/specs/Drawer/Drawer-specs.js
@@ -223,6 +223,7 @@ describe('Drawer', function () {
 		it('should have correct heading', async function () {
 			await drawerCommon.buttonDrawer4.click();
 			await Page.waitForOpen(drawer);
+			await browser.pause(400);
 
 			await expectNoneScrimOpen(drawerCommon);
 			await validateTitle(drawer, 'Drawer without scrim');

--- a/tests/ui/specs/Drawer/Drawer-specs.js
+++ b/tests/ui/specs/Drawer/Drawer-specs.js
@@ -46,10 +46,9 @@ describe('Drawer', function () {
 				expect(await drawer.isOpen).to.be.true();
 			});
 
-			it('should close drawer with cancel button on 5-way right in drawer container', async function () {
+			it('should close drawer with cancel button on 5-way right in drawer container', async function () {
 				await Page.spotlightSelect();
 				await Page.waitForOpen(drawer);
-				// await browser.pause(400);
 
 				await expectOpen(drawerCommon);
 
@@ -57,7 +56,6 @@ describe('Drawer', function () {
 				await Page.spotlightSelect();
 
 				await Page.waitForClose(drawer);
-				// await browser.pause(400);
 
 				await expectClosed(drawerCommon);
 			});
@@ -76,11 +74,9 @@ describe('Drawer', function () {
 				await Page.waitForOpen(drawer);
 
 				await expectOpen(drawerCommon);
-				// await browser.pause(400);
 
 				await drawer.buttonCancel.click();
 				await Page.waitForClose(drawer);
-				// await browser.pause(400);
 
 				await expectClosed(drawerCommon);
 			});
@@ -93,7 +89,7 @@ describe('Drawer', function () {
 
 		it('should have correct heading', async function () {
 			await drawerCommon.buttonDrawer2.click();
-			await browser.pause(300); // needed to pass instead of waitTransitionEnd
+			// await browser.pause(300); // needed to pass instead of waitTransitionEnd
 
 			await expectOpen(drawerCommon);
 			await validateTitle(drawer, 'Drawer without animation');
@@ -104,7 +100,7 @@ describe('Drawer', function () {
 			it('should open drawer', async function () {
 				await Page.spotlightRight();
 				await Page.spotlightSelect();
-				await browser.pause(400); // needed to pass instead of waitTransitionEnd
+				// await browser.pause(400); // needed to pass instead of waitTransitionEnd
 
 				await expectOpen(drawerCommon);
 				expect(await drawer.isOpen).to.be.true();
@@ -120,7 +116,6 @@ describe('Drawer', function () {
 				await Page.spotlightSelect();
 				await Page.waitForClose(drawer);
 
-				// await browser.pause(400);
 				await expectClosed(drawerCommon);
 			});
 		});
@@ -129,19 +124,19 @@ describe('Drawer', function () {
 
 			it('should open the drawer with scrim on click', async function () {
 				await drawerCommon.buttonDrawer2.click();
-				await browser.pause(400); // needed to pass instead of waitTransitionEnd
+				// await browser.pause(400); // needed to pass instead of waitTransitionEnd
 
 				await expectOpen(drawerCommon);
 			});
 
 			it('should close the drawer and scrim on cancel click in drawer container', async function () {
 				await drawerCommon.buttonDrawer2.click();
-				await browser.pause(400); // needed to pass instead of waitTransitionEnd
+				// await browser.pause(400); // needed to pass instead of waitTransitionEnd
 
 				await expectOpen(drawerCommon);
 
 				await drawer.buttonCancel.click();
-				await browser.pause(400); // needed to pass instead of waitTransitionEnd
+				// await browser.pause(400); // needed to pass instead of waitTransitionEnd
 
 				await expectClosed(drawerCommon);
 			});
@@ -177,7 +172,6 @@ describe('Drawer', function () {
 				await Page.spotlightRight();
 				await Page.spotlightSelect();
 				await Page.waitForOpen(drawer);
-				// await browser.pause(400);
 
 				await expectOpen(drawerCommon);
 
@@ -185,7 +179,6 @@ describe('Drawer', function () {
 				await Page.spotlightSelect();
 
 				await Page.waitForClose(drawer);
-				// await browser.pause(400);
 
 				await expectClosed(drawerCommon);
 			});
@@ -208,7 +201,6 @@ describe('Drawer', function () {
 
 				await drawer.buttonCancel.click();
 				await Page.waitForClose(drawer);
-				// await browser.pause(400);
 
 				await expectClosed(drawerCommon);
 			});
@@ -246,14 +238,12 @@ describe('Drawer', function () {
 				await Page.spotlightRight();
 				await Page.spotlightSelect();
 				await Page.waitForOpen(drawer);
-				// await browser.pause(400);
 
 				await expectNoneScrimOpen(drawerCommon);
 
 				await Page.spotlightRight();
 				await Page.spotlightSelect();
 				await Page.waitForClose(drawer);
-				// await browser.pause(400);
 
 				await expectClosed(drawerCommon);
 			});
@@ -270,13 +260,11 @@ describe('Drawer', function () {
 			it('should close the popup on click in drawer container', async function () {
 				drawerCommon.buttonDrawer4.click();
 				await Page.waitForOpen(drawer);
-				// await browser.pause(400);
 
 				await expectNoneScrimOpen(drawerCommon);
 
 				await drawer.buttonOK.click();
 				await Page.waitForClose(drawer);
-				// await browser.pause(400);
 
 				await expectClosed(drawerCommon);
 			});
@@ -289,7 +277,6 @@ describe('Drawer', function () {
 
 				await drawer.buttonCancel.click();
 				await Page.waitForClose(drawer);
-				// await browser.pause(400);
 
 				await expectClosed(drawerCommon);
 			});

--- a/tests/ui/specs/Drawer/Drawer-specs.js
+++ b/tests/ui/specs/Drawer/Drawer-specs.js
@@ -223,9 +223,10 @@ describe('Drawer', function () {
 		it('should have correct heading', async function () {
 			await drawerCommon.buttonDrawer4.click();
 			await Page.waitForOpen(drawer);
+			await browser.pause(400);
 
 			await expectNoneScrimOpen(drawerCommon);
-			expect(await drawer.isOpen).to.be.true();
+			await browser.pause(400);
 			await validateTitle(drawer, 'Drawer without scrim');
 		});
 

--- a/tests/ui/specs/Drawer/Drawer-specs.js
+++ b/tests/ui/specs/Drawer/Drawer-specs.js
@@ -207,9 +207,11 @@ describe('Drawer', function () {
 
 			it('should close the drawer and scrim on cancel click in drawer container', async function () {
 				await drawerCommon.buttonDrawer3.click();
+				await browser.pause(400);
 				await Page.waitForOpen(drawer);
 
 				await expectOpen(drawerCommon);
+				await browser.pause(400);
 
 				await drawer.buttonCancel.click();
 				await Page.waitForClose(drawer);

--- a/tests/ui/specs/Drawer/Drawer-specs.js
+++ b/tests/ui/specs/Drawer/Drawer-specs.js
@@ -223,9 +223,9 @@ describe('Drawer', function () {
 		it('should have correct heading', async function () {
 			await drawerCommon.buttonDrawer4.click();
 			await Page.waitForOpen(drawer);
-			await browser.pause(400);
 
 			await expectNoneScrimOpen(drawerCommon);
+			expect(await drawer.isOpen).to.be.true();
 			await validateTitle(drawer, 'Drawer without scrim');
 		});
 

--- a/tests/ui/specs/Drawer/Drawer-specs.js
+++ b/tests/ui/specs/Drawer/Drawer-specs.js
@@ -104,7 +104,7 @@ describe('Drawer', function () {
 				expect(await drawer.isOpen).to.be.true();
 			});
 
-			it('should close drawer with cancel button on 5-way right in drawer container', async function () {
+			it('should close drawer with cancel button on 5-way right in drawer container', async function () {
 				await Page.spotlightRight();
 				await Page.spotlightSelect();
 
@@ -161,7 +161,7 @@ describe('Drawer', function () {
 				expect(await drawer.isOpen).to.be.true();
 			});
 
-			it('should close drawer with cancel button on 5-way right in drawer container', async function () {
+			it('should close drawer with cancel button on 5-way right in drawer container', async function () {
 				await Page.spotlightRight();
 				await Page.spotlightRight();
 				await Page.spotlightSelect();
@@ -226,7 +226,7 @@ describe('Drawer', function () {
 				expect(await drawer.isOpen).to.be.true();
 			});
 
-			it('should close drawer with cancel button on 5-way right in drawer container', async function () {
+			it('should close drawer with cancel button on 5-way right in drawer container', async function () {
 				await Page.spotlightRight();
 				await Page.spotlightRight();
 				await Page.spotlightRight();

--- a/tests/ui/specs/Drawer/Drawer-specs.js
+++ b/tests/ui/specs/Drawer/Drawer-specs.js
@@ -23,11 +23,9 @@ describe('Drawer', function () {
 
 		it('should have correct heading', async function () {
 			await drawerCommon.buttonDrawer1.click();
-			await browser.pause(400);
 			await Page.waitForOpen(drawer);
 
 			await expectOpen(drawerCommon);
-			await browser.pause(400);
 			await validateTitle(drawer, 'Drawer with no line');
 		});
 
@@ -157,11 +155,9 @@ describe('Drawer', function () {
 
 		it('should have correct heading', async function () {
 			await drawerCommon.buttonDrawer3.click();
-			await browser.pause(400);
 			await Page.waitForOpen(drawer);
 
 			await expectOpen(drawerCommon);
-			await browser.pause(400);
 			await validateTitle(drawer, 'Drawer with transparent scrim');
 		});
 
@@ -207,11 +203,9 @@ describe('Drawer', function () {
 
 			it('should close the drawer and scrim on cancel click in drawer container', async function () {
 				await drawerCommon.buttonDrawer3.click();
-				await browser.pause(400);
 				await Page.waitForOpen(drawer);
 
 				await expectOpen(drawerCommon);
-				await browser.pause(400);
 
 				await drawer.buttonCancel.click();
 				await Page.waitForClose(drawer);
@@ -228,11 +222,9 @@ describe('Drawer', function () {
 
 		it('should have correct heading', async function () {
 			await drawerCommon.buttonDrawer4.click();
-			await browser.pause(400);
 			await Page.waitForOpen(drawer);
 
 			await expectNoneScrimOpen(drawerCommon);
-			await browser.pause(400);
 			await validateTitle(drawer, 'Drawer without scrim');
 		});
 

--- a/tests/ui/specs/Drawer/Drawer-specs.js
+++ b/tests/ui/specs/Drawer/Drawer-specs.js
@@ -31,7 +31,6 @@ describe('Drawer', function () {
 
 		it('should not have a line under the heading text', async function () {
 			await drawerCommon.buttonDrawer1.click();
-
 			await Page.waitForOpen(drawer);
 
 			await expectOpen(drawerCommon);
@@ -50,7 +49,7 @@ describe('Drawer', function () {
 			it('should close drawer with cancel button on 5-way right in drawer container', async function () {
 				await Page.spotlightSelect();
 				await Page.waitForOpen(drawer);
-				await browser.pause(400);
+				// await browser.pause(400);
 
 				await expectOpen(drawerCommon);
 
@@ -58,7 +57,7 @@ describe('Drawer', function () {
 				await Page.spotlightSelect();
 
 				await Page.waitForClose(drawer);
-				await browser.pause(400);
+				// await browser.pause(400);
 
 				await expectClosed(drawerCommon);
 			});
@@ -77,11 +76,11 @@ describe('Drawer', function () {
 				await Page.waitForOpen(drawer);
 
 				await expectOpen(drawerCommon);
-				await browser.pause(400);
+				// await browser.pause(400);
 
 				await drawer.buttonCancel.click();
 				await Page.waitForClose(drawer);
-				await browser.pause(400);
+				// await browser.pause(400);
 
 				await expectClosed(drawerCommon);
 			});
@@ -121,7 +120,7 @@ describe('Drawer', function () {
 				await Page.spotlightSelect();
 				await Page.waitForClose(drawer);
 
-				await browser.pause(400);
+				// await browser.pause(400);
 				await expectClosed(drawerCommon);
 			});
 		});
@@ -178,7 +177,7 @@ describe('Drawer', function () {
 				await Page.spotlightRight();
 				await Page.spotlightSelect();
 				await Page.waitForOpen(drawer);
-				await browser.pause(400);
+				// await browser.pause(400);
 
 				await expectOpen(drawerCommon);
 
@@ -186,7 +185,7 @@ describe('Drawer', function () {
 				await Page.spotlightSelect();
 
 				await Page.waitForClose(drawer);
-				await browser.pause(400);
+				// await browser.pause(400);
 
 				await expectClosed(drawerCommon);
 			});
@@ -209,7 +208,7 @@ describe('Drawer', function () {
 
 				await drawer.buttonCancel.click();
 				await Page.waitForClose(drawer);
-				await browser.pause(400);
+				// await browser.pause(400);
 
 				await expectClosed(drawerCommon);
 			});
@@ -247,14 +246,14 @@ describe('Drawer', function () {
 				await Page.spotlightRight();
 				await Page.spotlightSelect();
 				await Page.waitForOpen(drawer);
-				await browser.pause(400);
+				// await browser.pause(400);
 
 				await expectNoneScrimOpen(drawerCommon);
 
 				await Page.spotlightRight();
 				await Page.spotlightSelect();
 				await Page.waitForClose(drawer);
-				await browser.pause(400);
+				// await browser.pause(400);
 
 				await expectClosed(drawerCommon);
 			});
@@ -271,13 +270,13 @@ describe('Drawer', function () {
 			it('should close the popup on click in drawer container', async function () {
 				drawerCommon.buttonDrawer4.click();
 				await Page.waitForOpen(drawer);
-				await browser.pause(400);
+				// await browser.pause(400);
 
 				await expectNoneScrimOpen(drawerCommon);
 
 				await drawer.buttonOK.click();
 				await Page.waitForClose(drawer);
-				await browser.pause(400);
+				// await browser.pause(400);
 
 				await expectClosed(drawerCommon);
 			});
@@ -290,7 +289,7 @@ describe('Drawer', function () {
 
 				await drawer.buttonCancel.click();
 				await Page.waitForClose(drawer);
-				await browser.pause(400);
+				// await browser.pause(400);
 
 				await expectClosed(drawerCommon);
 			});

--- a/tests/ui/specs/Drawer/Drawer-specs.js
+++ b/tests/ui/specs/Drawer/Drawer-specs.js
@@ -89,7 +89,7 @@ describe('Drawer', function () {
 
 		it('should have correct heading', async function () {
 			await drawerCommon.buttonDrawer2.click();
-
+			await browser.pause(300); // needed to pass instead of waitTransitionEnd
 			await expectOpen(drawerCommon);
 			await validateTitle(drawer, 'Drawer without animation');
 		});
@@ -99,6 +99,7 @@ describe('Drawer', function () {
 			it('should open drawer', async function () {
 				await Page.spotlightRight();
 				await Page.spotlightSelect();
+				await browser.pause(400); // needed to pass instead of waitTransitionEnd
 
 				await expectOpen(drawerCommon);
 				expect(await drawer.isOpen).to.be.true();
@@ -122,15 +123,19 @@ describe('Drawer', function () {
 
 			it('should open the drawer with scrim on click', async function () {
 				await drawerCommon.buttonDrawer2.click();
+				await browser.pause(400); // needed to pass instead of waitTransitionEnd
 
 				await expectOpen(drawerCommon);
 			});
 
 			it('should close the drawer and scrim on cancel click in drawer container', async function () {
 				await drawerCommon.buttonDrawer2.click();
+				await browser.pause(400); // needed to pass instead of waitTransitionEnd
+
 				await expectOpen(drawerCommon);
 
 				await drawer.buttonCancel.click();
+				await browser.pause(400); // needed to pass instead of waitTransitionEnd
 
 				await expectClosed(drawerCommon);
 			});

--- a/tests/ui/specs/Drawer/DrawerPage.js
+++ b/tests/ui/specs/Drawer/DrawerPage.js
@@ -77,21 +77,21 @@ class DrawerPage extends Page {
 		$('#floatLayer').click();
 	}
 
-	waitForOpen (selector, timeout) {
+	async waitForOpen (selector, timeout) {
 		if (typeof selector !== 'string') {
 			selector = `#${selector.id}`;
 		}
 
-		$(selector).waitForExist({timeout});
-		this.delay(2000);
+		await $(selector).waitForExist({timeout});
+		await this.delay(2000);
 	}
 
-	waitForClose (selector, timeout) {
+	async waitForClose (selector, timeout) {
 		if (typeof selector !== 'string') {
 			selector = `#${selector.id}`;
 		}
 
-		$(selector).waitForExist({timeout, reverse: true});
+		await $(selector).waitForExist({timeout, reverse: true});
 	}
 }
 

--- a/tests/ui/specs/SwitchItem/SwitchItem-specs.js
+++ b/tests/ui/specs/SwitchItem/SwitchItem-specs.js
@@ -79,7 +79,6 @@ describe('SwitchItem', function () {
 			it('should re-select the item when selected twice', async function () {
 				await switchItem.focus();
 				await Page.spotlightSelect();
-				await switchItem.focus();
 				await Page.spotlightSelect();
 				expect(await switchItem.isSelected).to.be.true();
 			});

--- a/tests/ui/specs/SwitchItem/SwitchItem-specs.js
+++ b/tests/ui/specs/SwitchItem/SwitchItem-specs.js
@@ -79,6 +79,7 @@ describe('SwitchItem', function () {
 			it('should re-select the item when selected twice', async function () {
 				await switchItem.focus();
 				await Page.spotlightSelect();
+				await switchItem.focus();
 				await Page.spotlightSelect();
 				expect(await switchItem.isSelected).to.be.true();
 			});

--- a/tests/ui/specs/SwitchItem/SwitchItem-specs.js
+++ b/tests/ui/specs/SwitchItem/SwitchItem-specs.js
@@ -52,6 +52,7 @@ describe('SwitchItem', function () {
 
 			it('should re-unselect the item when clicked twice', async function () {
 				switchItem.self.click();
+				await browser.pause(500);
 				switchItem.self.click();
 				expect(await switchItem.isSelected).to.be.false();
 			});
@@ -79,7 +80,6 @@ describe('SwitchItem', function () {
 			it('should re-select the item when selected twice', async function () {
 				await switchItem.focus();
 				await Page.spotlightSelect();
-				await switchItem.focus();
 				await Page.spotlightSelect();
 				expect(await switchItem.isSelected).to.be.true();
 			});
@@ -93,6 +93,7 @@ describe('SwitchItem', function () {
 
 			it('should re-select the item when clicked twice', async function () {
 				switchItem.self.click();
+				await browser.pause(500);
 				switchItem.self.click();
 				expect(await switchItem.isSelected).to.be.true();
 			});
@@ -137,6 +138,7 @@ describe('SwitchItem', function () {
 
 			it('should re-select the item when clicked twice', async function () {
 				switchItem.self.click();
+				await browser.pause(500);
 				switchItem.self.click();
 				expect(await switchItem.isSelected).to.be.true();
 			});

--- a/tests/ui/specs/TimePicker/TimePicker-specs.js
+++ b/tests/ui/specs/TimePicker/TimePicker-specs.js
@@ -293,6 +293,7 @@ describe('TimePicker', function () {
 			// go to 23 first
 			(await timePicker.decrementer(timePicker.hour)).click();
 			expect((await extractValues(timePicker)).hour).to.equal(23);
+			await browser.pause(500);
 			// now increment
 			(await timePicker.incrementer(timePicker.hour)).click();
 			expect((await extractValues(timePicker)).hour).to.equal(0);


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Ui tests job on Jenkins for Agate develop branch are failing for Drawer (with scrimType - none should have correct heading) and SwitchItem (pointer should re-select the item when clicked twice).

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
For Drawer I changed `waitForOpen` and `waitForClose` to be asyncronous. They both use `waitForExist` command from webdriverio which must be used inside async functions (https://webdriver.io/docs/api/element/waitForExist/).
For SwitchItem I refocused the element before selecting it again.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
When running the changes a new test failed for TimePicker so I added a browser pause to wait for the animation to be completed.

### Links
[//]: # (Related issues, references)
WRP-6584

### Comments
