### PR TITLE
WRP-7672: Fixed border color for selected SwitchItem for Gallium skin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,14 @@ The following is a curated list of changes in the Enact agate module, newest cha
 
 ### Added
 
-- `agate/TabGroup` prop `onSelect` to handle `onClick` event on it
-
-### Added
-
 - `agate/ImageItem` to have `imageItem`, `caption` and `image` publicClassnames
 - `agate/Popup` to have a `content` publicClassname
+- `agate/TabGroup` prop `onSelect` to handle `onClick` event on it
 
 ### Fixed
 
 - `agate/Panels/TabbedPanels` to not show console error when there is no children
+- `agate/SwitchItem` border color for Gallium skin when selected and focused
 - `agate/TabGroup` to pass `onSelect` to `ui/Group`
 
 ## [2.0.3] - 2022-12-14

--- a/SwitchItem/SwitchItem.module.less
+++ b/SwitchItem/SwitchItem.module.less
@@ -36,13 +36,7 @@
 		}
 
 		.focus({
-			&.selected {
-				border-color: @agate-switchitem-selected-border-color;
-
-				.label {
-					color:  @agate-switchitem-label-selected-color;
-				}
-			}
+			border-color: @agate-switchitem-focus-border-color;
 		});
 	});
 }

--- a/SwitchItem/SwitchItem.module.less
+++ b/SwitchItem/SwitchItem.module.less
@@ -36,9 +36,9 @@
 		}
 
 		.focus({
-			border-color: @agate-switchitem-focus-border-color;
-
 			&.selected {
+				border-color: @agate-switchitem-focus-border-color;
+
 				.label {
 					color: @agate-switchitem-label-selected-color;
 				}

--- a/SwitchItem/SwitchItem.module.less
+++ b/SwitchItem/SwitchItem.module.less
@@ -37,6 +37,12 @@
 
 		.focus({
 			border-color: @agate-switchitem-focus-border-color;
+
+			&.selected {
+				.label {
+					color: @agate-switchitem-label-selected-color;
+				}
+			}
 		});
 	});
 }

--- a/styles/colors-base.less
+++ b/styles/colors-base.less
@@ -461,10 +461,11 @@
 
 // SwitchItem
 // ---------------------------------------
+@agate-switchitem-focus-border-color: @agate-item-focus-border-color;
 @agate-switchitem-label-color: @agate-item-label-color;
 @agate-switchitem-label-selected-color: inherit;
 @agate-switchitem-selected-border-color: @agate-item-selected-border-color;
-@agate-switchitem-focus-border-color: @agate-item-focus-border-color;
+
 // ThumbnailItem
 // ---------------------------------------
 @agate-roundthumbnailitem-border-color:  inherit;

--- a/styles/colors-base.less
+++ b/styles/colors-base.less
@@ -464,7 +464,7 @@
 @agate-switchitem-label-color: @agate-item-label-color;
 @agate-switchitem-label-selected-color: inherit;
 @agate-switchitem-selected-border-color: @agate-item-selected-border-color;
-
+@agate-switchitem-focus-border-color: @agate-item-focus-border-color;
 // ThumbnailItem
 // ---------------------------------------
 @agate-roundthumbnailitem-border-color:  inherit;

--- a/tests/screenshot/apps/components/SwitchItem.js
+++ b/tests/screenshot/apps/components/SwitchItem.js
@@ -21,6 +21,16 @@ const SwitchItemTests = [
 		<SwitchItem disabled>Hello SwitchItem</SwitchItem>,
 		// with icon
 		<SwitchItem icon="music">Hello SwitchItem</SwitchItem>
+	]),
+
+	// Focus
+	...withConfig({focus: true}, [
+		<SwitchItem>Hello focused SwitchItem</SwitchItem>,
+		<SwitchItem selected>Hello focused SwitchItem</SwitchItem>,
+		<SwitchItem disabled>Hello focused SwitchItem</SwitchItem>,
+
+		// with icon
+		<SwitchItem icon="music">Hello focused SwitchItem</SwitchItem>
 	])
 ];
 export default SwitchItemTests;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When a SwitchItem with selected=true, there was no border color for Gallium skin on focus

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed border color for selected SwitchItem for Gallium skin by modifying component less styling

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-7672


### Comments
Enact-DCO-1.0-Signed-off-by: Ion Andrusciac (ion.andrusciac@lgepartner.com)