### PR TITLE
WRP-5951: Refine `scrollContainerHandle` of `useScroll` to be clearly understandable

### DIFF
--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -279,33 +279,33 @@ const useScroll = (props) => {
 
 	const [themeScrollContentHandle, setThemeScrollContentHandle] = useThemeScrollContentHandle();
 
-	const scrollContainerHandle = useRef({
-		animator: null,
-		bounds: null,
-		calculateDistanceByWheel: null,
-		canScrollHorizontally: null,
-		canScrollVertically: null,
-		getScrollBounds: null,
-		isDragging: null,
-		isFlicked: null,
-		isScrollAnimationTargetAccumulated: null,
-		lastInputType: null,
-		rtl: null,
-		scrollBounds: null,
-		scrollHeight: null,
-		scrolling: null,
-		scrollLeft: null,
-		scrollPos: null,
-		scrollTo: null,
-		scrollToAccumulatedTarget: null,
-		scrollToInfo: null,
-		scrollTop: null,
-		showScrollbarTrack: null,
-		start: null,
-		startHidingScrollbarTrack: null,
-		stop: null,
-		wheelDirection: null
-	});
+	const scrollContainerHandle = useRef({}); // An empty object for safty of referencing before `setScrollContainerHandle` call.
+	/* following properties should be in scrollContainerHandle
+		animator
+		bounds
+		calculateDistanceByWheel
+		canScrollHorizontally
+		canScrollVertically
+		getScrollBounds
+		isDragging
+		isFlicked
+		isScrollAnimationTargetAccumulated
+		lastInputType
+		rtl
+		scrollBounds
+		scrollHeight
+		scrolling
+		scrollLeft
+		scrollTo
+		scrollToAccumulatedTarget
+		scrollToInfo
+		scrollTop
+		showScrollbarTrack
+		start
+		startHidingScrollbarTrack
+		stop
+		wheelDirection
+	*/
 
 	const setScrollContainerHandle = (handle) => {
 		scrollContainerHandle.current = handle;

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -279,7 +279,7 @@ const useScroll = (props) => {
 
 	const [themeScrollContentHandle, setThemeScrollContentHandle] = useThemeScrollContentHandle();
 
-	const scrollContainerHandle = useRef({}); // // To prevent referencing errors before calling `setScrollContainerHandle`, an empty object is provided as a default.
+	const scrollContainerHandle = useRef({}); // To prevent referencing errors before calling `setScrollContainerHandle`, an empty object is provided as a default.
 	/* Properties in `scrollContainerHandle` provided by `setScrollContainerHandle`
 		animator
 		bounds

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -279,8 +279,8 @@ const useScroll = (props) => {
 
 	const [themeScrollContentHandle, setThemeScrollContentHandle] = useThemeScrollContentHandle();
 
-	const scrollContainerHandle = useRef({}); // An empty object for safty of referencing before `setScrollContainerHandle` call.
-	/* following properties should be in scrollContainerHandle
+	const scrollContainerHandle = useRef({}); // // To prevent referencing errors before calling `setScrollContainerHandle`, an empty object is provided as a default.
+	/* Properties in `scrollContainerHandle` provided by `setScrollContainerHandle`
 		animator
 		bounds
 		calculateDistanceByWheel


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`scrollContainerHandle` has a initial object having several properties, but its `current` object is replaced by `setScrollContainerHandle` in the first rendering cycle. So, it looks better to make the initial object empty for better understanding in later visits.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Make the initial object empty, then add comments about properties that should be inside `scrollContainerHandle`.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I found that `scrollPos` does not exist in the handle.

### Links
[//]: # (Related issues, references)
WRP-5951

### Comments
