### PR TITLE
WRP-6254: Scroller/List not scroll with touch when native scroll mode

### DIFF
--- a/html-template.ejs
+++ b/html-template.ejs
@@ -7,7 +7,7 @@
 		<title><%= htmlWebpackPlugin.options.title %></title>
 		<script type="text/javascript">
 				document.addEventListener('touchmove', function (event) {
-				if (event.scale !== 1) event.preventDefault();
+				if (event.touches.length > 1) event.preventDefault();
 		}, {passive: false});
 		</script>
 	</head>


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Scroller/List not scroll with touch when native scroll mode.
Refer to TouchEvent.scale value to prevent zoom.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Touchevent.scale is non-standard. 
So, event.scale becomes 'undefined' in chrome and all touchmove gestures are blocked.
Changed to refer to TouchEvent.touches.length to prevent only the pinch zoom gesture.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-6254

### Comments
Enact-DCO-1.0-Signed-off-by: SJ RO (sj.ro@lge.com)