### PR TITLE
WRP-9587: ToggleButton - center the text on Silicon skin when underline=false

### DIFF
--- a/ToggleButton/ToggleButton.module.less
+++ b/ToggleButton/ToggleButton.module.less
@@ -19,6 +19,10 @@
 		}
 
 		&.underline {
+			.client {
+				padding-left: @agate-togglebutton-client-padding-left;
+			}
+
 			&::after {
 				content: "";
 			}
@@ -71,7 +75,6 @@
 
 		.client {
 			color: @agate-togglebutton-color;
-			padding-left: @agate-togglebutton-client-padding-left;
 		}
 
 		&.selected {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
On ToggleButton, when underline property is set to "false" and skin=Silicon, the toggle indicator is not visible, but the children remain uncentered

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Changed ToggleButton css module to remove the left padding of the children when underline=false but kept it for underline=true.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-9587

### Comments
Enact-DCO-1.0-Signed-off-by: Andrei Tirla andrei.tirla@lgepartner.com