### PR TITLE
WRP-9583: Fixed MediaPlayer knob on focus for type "tiny"

### DIFF
--- a/styles/variables-carbon.less
+++ b/styles/variables-carbon.less
@@ -129,6 +129,7 @@
 // ---------------------------------------
 @agate-mediacontrols-playpause-button-bg-border-radius: 90px;
 @agate-mediaplayer-times-margin: 6px 45px;
+@agate-mediaplayer-tiny-times-padding: 9px 0;
 
 // SliderButton
 // ---------------------------------------

--- a/styles/variables-silicon.less
+++ b/styles/variables-silicon.less
@@ -374,7 +374,7 @@
 @agate-mediaslider-tiny-bar-height: 3px;
 @agate-mediaslider-tiny-height: 36px;
 @agate-mediaslider-tiny-padding: 15px 45px;
-@agate-mediaplayer-tiny-times-padding: 0 45px;
+@agate-mediaplayer-tiny-times-padding: 21px 45px;
 
 // Panels
 // ---------------------------------------


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [X] Documentation was verified or is not changed
* [X] UI test was passed or is not needed
* [X] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fixed MediaPlayer, when type = "tiny" slider knob overlays the text when knob is active and skin is Silicon and Carbon

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added extra space between knob and time


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-9583


### Comments

Enact-DCO-1.0-Signed-off-by: Ion Andrusciac ion.andrusciac@lgepartner.com