### PR TITLE
WRP-10590: Update ilib v14.17.0 and fix unit test errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_install:
     - sudo apt-get update
     - sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 install:
+    - npm cache verify
     - npm config set prefer-offline false
     - npm install -g codecov
     - git clone --branch=develop --depth 1 https://github.com/enactjs/cli ../cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ before_install:
     - sudo apt-get update
     - sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 install:
-    - npm cache verify
     - npm config set prefer-offline false
     - npm install -g codecov
     - git clone --branch=develop --depth 1 https://github.com/enactjs/cli ../cli

--- a/TimePicker/tests/TimePicker-specs.js
+++ b/TimePicker/tests/TimePicker-specs.js
@@ -158,7 +158,7 @@ describe('TimePicker', () => {
 			ilib.setLocale('en-US');
 			const date = new Date(2000, 0, 1);
 
-			const expected = '12:00 AM';
+			const expected = '12:00 AM';
 			const actual = timeToLocaleString(date);
 
 			expect(actual).toBe(expected);

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "warning": "^4.0.3",
-    "ilib": "^14.15.1"
+    "ilib": "^14.17.0"
   },
   "peerDependencies": {
     "ilib": "^14.15.1 || ^14.15.1-webos1"
@@ -61,6 +61,6 @@
     "@enact/docs-utils": "^0.4.0",
     "@enact/ui-test-utils": "^1.0.2",
     "eslint-config-enact-proxy": "^1.0.5",
-    "ilib": "^14.15.1"
+    "ilib": "^14.17.0"
   }
 }

--- a/samples/sampler/package.json
+++ b/samples/sampler/package.json
@@ -26,7 +26,7 @@
     "@enact/spotlight": "^4.6.0",
     "@enact/ui": "^4.6.0",
     "dotenv": "^16.0.3",
-    "ilib": "^14.15.1",
+    "ilib": "^14.17.0",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"


### PR DESCRIPTION
### Checklist

* [ ] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Unit test fails occur on Enact Frameworks(sandstone, moonstone, agate)

Reason: 
Since [ilib v14.17.0](https://github.com/iLib-js/iLib/releases/tag/v14.17.0), the whitespace in locale value has been changed to prevent ui issues.
This is an intended action so the changed whitespace should be applied to the test scripts in the enact framework.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Update ilib v14.17.0
- Fix unit test errors: remove the normalize option in `getByText` function to support the changed whitespace
(https://testing-library.com/docs/queries/about/#normalization)

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-10590

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)