### PR TITLE
WRP-9583: Fixed MediaPlayer knob on focus for type "tiny" 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact agate module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `agate/MediaPlayer` active knob size to not overlay the text on Silicon and Carbon skins when `type` is `tiny`
+
 ## [2.0.4] - 2023-02-24
 
 ### Added
@@ -13,7 +19,6 @@ The following is a curated list of changes in the Enact agate module, newest cha
 ### Fixed
 
 - `agate/Keypad` to fire `onChange` event with a correct value payload
-- `agate/MediaPlayer` active knob size to not overlay the text when `type` is `tiny`
 - `agate/Panels/TabbedPanels` to not show console error when there is no children
 - `agate/SwitchItem` border color for Gallium skin when selected and focused
 - `agate/TabGroup` to pass `onSelect` to `ui/Group`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 ### Fixed
 
 - `agate/Keypad` to fire `onChange` event with a correct value payload
+- `agate/MediaPlayer` active knob size to not overlay the text when `type` is `tiny`
 - `agate/Panels/TabbedPanels` to not show console error when there is no children
 - `agate/SwitchItem` border color for Gallium skin when selected and focused
 - `agate/TabGroup` to pass `onSelect` to `ui/Group`

--- a/MediaPlayer/MediaSlider.module.less
+++ b/MediaPlayer/MediaSlider.module.less
@@ -48,14 +48,43 @@
 			}
 		});
 
+		.spottable({
+			&.tiny {
+				&.pressed,
+				&:focus.activateOnFocus,
+				&:focus.active {
+					.knob::before {
+						height: @agate-slider-active-tiny-knob-height;
+						width: @agate-slider-active-tiny-knob-width;
+					}
+				}
+			}
+
+		});
+
 		&.tiny {
 			&.slider {
 				height: @agate-mediaslider-tiny-height;
 				padding: @agate-mediaslider-tiny-padding;
 
 				.bar,
-				.fill {
+				.fill,
+				.progressBar {
 					height: @agate-mediaslider-tiny-bar-height;
+				}
+
+				&.horizontal {
+					margin: @agate-slider-horizontal-tiny-margin;
+
+					.bar {
+						left: ((@agate-slider-horizontal-tiny-anchorpoint-width / 2) * -1);
+						width: ~"calc(100% + " @agate-slider-horizontal-tiny-anchorpoint-width ~")";
+					}
+				}
+
+				.knob::before {
+					height: @agate-slider-tiny-knob-height;
+					width: @agate-slider-tiny-knob-width;
 				}
 			}
 		}

--- a/MediaPlayer/MediaSlider.module.less
+++ b/MediaPlayer/MediaSlider.module.less
@@ -77,7 +77,7 @@
 					margin: @agate-slider-horizontal-tiny-margin;
 
 					.bar {
-						left: ((@agate-slider-horizontal-tiny-anchorpoint-width / 2) * -1);
+						left: ((@agate-slider-horizontal-tiny-anchorpoint-width / 2) * - 1);
 						width: ~"calc(100% + " @agate-slider-horizontal-tiny-anchorpoint-width ~")";
 					}
 				}

--- a/MediaPlayer/MediaSlider.module.less
+++ b/MediaPlayer/MediaSlider.module.less
@@ -77,7 +77,7 @@
 					margin: @agate-slider-horizontal-tiny-margin;
 
 					.bar {
-						left: ((@agate-slider-horizontal-tiny-anchorpoint-width / 2) * - 1);
+						left: ((@agate-slider-horizontal-tiny-anchorpoint-width / 2) * -1);
 						width: ~"calc(100% + " @agate-slider-horizontal-tiny-anchorpoint-width ~")";
 					}
 				}

--- a/styles/variables-base.less
+++ b/styles/variables-base.less
@@ -721,7 +721,6 @@
 @agate-slider-height: @agate-button-height;
 @agate-slider-horizontal-anchorpoint-height: 0px;  // This is used in `calc` which means it needs the unit specified to work correctly
 @agate-slider-horizontal-anchorpoint-width: 0px;  // This is used in `calc` which means it needs the unit specified to work correctly
-@agate-slider-horizontal-tiny-anchorpoint-height: @agate-slider-horizontal-anchorpoint-height;
 @agate-slider-horizontal-tiny-anchorpoint-width: @agate-slider-horizontal-anchorpoint-width;
 @agate-slider-horizontal-margin: 0 @agate-component-spacing;
 @agate-slider-horizontal-tiny-margin: @agate-slider-horizontal-margin;

--- a/styles/variables-base.less
+++ b/styles/variables-base.less
@@ -714,12 +714,17 @@
 @agate-slider-active-knob-height: @agate-slider-knob-height;
 @agate-slider-active-knob-transform: @agate-slider-knob-transform;
 @agate-slider-active-knob-width: @agate-slider-active-knob-height;
+@agate-slider-active-tiny-knob-height: @agate-slider-active-knob-height;
+@agate-slider-active-tiny-knob-width: @agate-slider-active-knob-width;
 @agate-slider-bg-transform: none;
 @agate-slider-border-radius: @agate-slider-height;
 @agate-slider-height: @agate-button-height;
 @agate-slider-horizontal-anchorpoint-height: 0px;  // This is used in `calc` which means it needs the unit specified to work correctly
 @agate-slider-horizontal-anchorpoint-width: 0px;  // This is used in `calc` which means it needs the unit specified to work correctly
+@agate-slider-horizontal-tiny-anchorpoint-height: @agate-slider-horizontal-anchorpoint-height;
+@agate-slider-horizontal-tiny-anchorpoint-width: @agate-slider-horizontal-anchorpoint-width;
 @agate-slider-horizontal-margin: 0 @agate-component-spacing;
+@agate-slider-horizontal-tiny-margin: @agate-slider-horizontal-margin;
 @agate-slider-horizontal-min-width: auto;
 @agate-slider-horizontal-padding: ((@agate-slider-height - @agate-slider-track-height) / 2) (@agate-slider-height / 2);
 @agate-slider-knob-border-radius: @agate-slider-knob-height;
@@ -728,6 +733,8 @@
 @agate-slider-knob-resting-state-scale: 1;
 @agate-slider-knob-transform: @agate-translate-center;
 @agate-slider-knob-width: @agate-slider-knob-height;
+@agate-slider-tiny-knob-height: @agate-slider-knob-height;
+@agate-slider-tiny-knob-width: @agate-slider-knob-width;
 @agate-slider-tooltip-above-offset: (@agate-slider-knob-height / -3);
 @agate-slider-tooltip-after-offset: (@agate-slider-knob-height / 3);
 @agate-slider-tooltip-before-offset: (@agate-slider-knob-height / -3);

--- a/styles/variables-carbon.less
+++ b/styles/variables-carbon.less
@@ -83,6 +83,8 @@
 
 // Slider
 // ---------------------------------------
+@agate-slider-active-tiny-knob-height:72px;
+@agate-slider-active-tiny-knob-width: @agate-slider-active-tiny-knob-height;
 @agate-slider-active-knob-transform: @agate-translate-center scale(1);
 @agate-slider-knob-border-radius: (@agate-slider-knob-height / 2);
 @agate-slider-knob-border-width: 0;

--- a/styles/variables-carbon.less
+++ b/styles/variables-carbon.less
@@ -83,7 +83,7 @@
 
 // Slider
 // ---------------------------------------
-@agate-slider-active-tiny-knob-height:72px;
+@agate-slider-active-tiny-knob-height: 72px;
 @agate-slider-active-tiny-knob-width: @agate-slider-active-tiny-knob-height;
 @agate-slider-active-knob-transform: @agate-translate-center scale(1);
 @agate-slider-knob-border-radius: (@agate-slider-knob-height / 2);

--- a/styles/variables-silicon.less
+++ b/styles/variables-silicon.less
@@ -463,7 +463,7 @@
 @agate-slider-border-radius: 0;
 @agate-slider-horizontal-anchorpoint-width: (@agate-slider-knob-height * @agate-slider-knob-resting-state-scale - 1px); // just a touch under the resting state scale, to avoid subpixel rendering overflow
 @agate-slider-horizontal-tiny-anchorpoint-width: (@agate-slider-tiny-knob-height * @agate-slider-knob-resting-state-scale - 1px);
-@agate-slider-horizontal-tiny-margin: 0 (@agate-slider-horizontal-tiny-anchorpoint-width / 2) 0 (@agate-slider-horizontal-tiny-anchorpoint-width / 2);
+@agate-slider-horizontal-tiny-margin: 0 (@agate-slider-horizontal-tiny-anchorpoint-width / 2);
 @agate-slider-horizontal-min-width: 420px;
 @agate-slider-horizontal-padding: ((@agate-slider-height - @agate-slider-track-height) / 2) (@agate-slider-active-knob-height / 2);
 @agate-slider-knob-border-radius: (@agate-slider-knob-height / 2);

--- a/styles/variables-silicon.less
+++ b/styles/variables-silicon.less
@@ -458,13 +458,19 @@
 @agate-slider-active-knob-border-radius: (@agate-slider-active-knob-height / 2);
 @agate-slider-active-knob-height: 60px;
 @agate-slider-active-knob-transform: @agate-translate-center scale(@agate-slider-knob-resting-state-scale);
+@agate-slider-active-tiny-knob-height: 21px;
+@agate-slider-active-tiny-knob-width: @agate-slider-active-tiny-knob-height;
 @agate-slider-border-radius: 0;
 @agate-slider-horizontal-anchorpoint-width: (@agate-slider-knob-height * @agate-slider-knob-resting-state-scale - 1px); // just a touch under the resting state scale, to avoid subpixel rendering overflow
+@agate-slider-horizontal-tiny-anchorpoint-width: (@agate-slider-tiny-knob-height * @agate-slider-knob-resting-state-scale - 1px);
+@agate-slider-horizontal-tiny-margin: 0 (@agate-slider-horizontal-tiny-anchorpoint-width / 2) 0 (@agate-slider-horizontal-tiny-anchorpoint-width / 2);
 @agate-slider-horizontal-min-width: 420px;
 @agate-slider-horizontal-padding: ((@agate-slider-height - @agate-slider-track-height) / 2) (@agate-slider-active-knob-height / 2);
 @agate-slider-knob-border-radius: (@agate-slider-knob-height / 2);
 @agate-slider-knob-height: 30px;
 @agate-slider-knob-resting-state-scale: 0.9;
+@agate-slider-tiny-knob-height: 12px;
+@agate-slider-tiny-knob-width: @agate-slider-tiny-knob-height;
 @agate-slider-track-height: 6px;
 @agate-slider-vertical-anchorpoint-height: (@agate-slider-knob-height * @agate-slider-knob-resting-state-scale - 1px); // just a touch under the resting state scale, to avoid subpixel rendering overflow
 @agate-slider-vertical-margin: 6px;


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [X] Documentation was verified or is not changed
* [X] UI test was passed or is not needed
* [X] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fixed MediaPlayer, when type = "tiny" slider knob overlays the text when knob is active and skin is Silicon

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The knob was resized in order not to overlay the text


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
The same problem was found and resolved on the skin Carbon


### Links
[//]: # (Related issues, references)
WRP-9583


### Comments

Enact-DCO-1.0-Signed-off-by: Ion Andrusciac ion.andrusciac@lgepartner.com