### PR TITLE
WRP-4076:Button: add mising @mixes tag for TooltipDecorator

### DIFF
--- a/Button/Button.js
+++ b/Button/Button.js
@@ -329,6 +329,7 @@ const IconButtonDecorator = hoc((config, Wrapped) => {
  *
  * @hoc
  * @memberof agate/Button
+ * @mixes agate/TooltipDecorator.TooltipDecorator
  * @mixes ui/Button.ButtonDecorator
  * @mixes spotlight/Spottable.Spottable
  * @mixes agate/Skinnable.Skinnable


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] Documentation was verified or is not changed
* [ ] UI test was passed or is not needed
* [ ] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Currently, TooltipDecorator is missing from includes for ButtonDecorator description on enactjs.com.
ButtonDecorator is composed of TooltipDecorator, but @mixes tag for TooltipDecorator is missing in the documentation. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add @mixes tag for TooptipDecorator.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-4076

### Comments
Eanct-DCO-1.0-Signed-off-by: Hoeun Ryu <hoeun.ryu@lge.com>
