### PR TITLE
WRP-9586: Fixed "not wrapped in act()" console error for unit tests

### DIFF
--- a/Input/tests/Input-specs.js
+++ b/Input/tests/Input-specs.js
@@ -131,25 +131,6 @@ describe('Input Specs', () => {
 		expect(actual).toBeTruthy();
 	});
 
-	test('should not bubble the native event when stopPropagation from onChange is called', () => {
-		const handleChange = jest.fn();
-		const value = 'smt';
-		function stop (ev) {
-			ev.stopPropagation();
-		}
-
-		render(
-			<div onChange={handleChange}>
-				<Input onChange={stop} />
-			</div>
-		);
-		const inputText = screen.getByLabelText('Input field').children[0];
-
-		userEvent.type(inputText, value);
-
-		expect(handleChange).not.toHaveBeenCalled();
-	});
-
 	test('should blur input on enter if `dismissOnEnter`', () => {
 		const handleChange = jest.fn();
 		render(<Input dismissOnEnter onBlur={handleChange} />);
@@ -172,19 +153,6 @@ describe('Input Specs', () => {
 		expect(handleChange).not.toHaveBeenCalled();
 	});
 
-	test('should callback onBeforeChange before the text changes', () => {
-		const handleBeforeChange = jest.fn();
-		const value = 'blah';
-		render(<Input onBeforeChange={handleBeforeChange} />);
-		const inputText = screen.getByLabelText('Input field').children[0];
-
-		userEvent.type(inputText, value);
-		// bluring input onSpotlightLeft for code coverage purposes
-		pressLeftKey(inputText);
-
-		expect(handleBeforeChange).toHaveBeenCalled();
-	});
-
 	test('should prevent onChange if onBeforeChange prevents', () => {
 		const handleBeforeChange = jest.fn(ev => ev.preventDefault());
 		const handleChange = jest.fn();
@@ -202,6 +170,38 @@ describe('Input Specs', () => {
 		pressRightKey(inputText);
 
 		expect(handleChange).not.toHaveBeenCalled();
+	});
+
+	test('should not bubble the native event when stopPropagation from onChange is called', () => {
+		const handleChange = jest.fn();
+		const value = 'smt';
+		function stop (ev) {
+			ev.stopPropagation();
+		}
+
+		render(
+			<div onChange={handleChange}>
+				<Input onChange={stop} />
+			</div>
+		);
+		const inputText = screen.getByLabelText('Input field').children[0];
+
+		userEvent.type(inputText, value);
+
+		expect(handleChange).not.toHaveBeenCalled();
+	});
+
+	test('should callback onBeforeChange before the text changes', () => {
+		const handleBeforeChange = jest.fn();
+		const value = 'blah';
+		render(<Input onBeforeChange={handleBeforeChange} />);
+		const inputText = screen.getByLabelText('Input field').children[0];
+
+		userEvent.type(inputText, value);
+		// bluring input onSpotlightLeft for code coverage purposes
+		pressLeftKey(inputText);
+
+		expect(handleBeforeChange).toHaveBeenCalled();
 	});
 
 	test('should activate input on enter', () => {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When running unit tests for Agate/Input, some console errors are shown although the tests passed. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
By reordering the problematic tests, we were able to prevent the console errors from being triggered.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
We couldn't find the root cause of the problem at this moment, we tried implementing some solutions found online but they did not work and weren't applicable.

### Links
[//]: # (Related issues, references)
WRP-9586

### Comments
Enact-DCO-1.0-Signed-off-by: Andrei Tirla andrei.tirla@lgepartner.com