### PR TITLE
WRP-12280: Fixed SwitchItem ui tests

### DIFF
--- a/tests/ui/specs/SwitchItem/SwitchItem-specs.js
+++ b/tests/ui/specs/SwitchItem/SwitchItem-specs.js
@@ -52,9 +52,9 @@ describe('SwitchItem', function () {
 			});
 
 			it('should re-unselect the item when clicked twice', async function () {
-				switchItem.self.click();
+				await switchItem.self.click();
 				await browser.pause(500);
-				switchItem.self.click();
+				await switchItem.self.click();
 				expect(await switchItem.isSelected).to.be.false();
 			});
 		});
@@ -94,9 +94,9 @@ describe('SwitchItem', function () {
 			});
 
 			it('should re-select the item when clicked twice', async function () {
-				switchItem.self.click();
+				await switchItem.self.click();
 				await browser.pause(500);
-				switchItem.self.click();
+				await switchItem.self.click();
 				expect(await switchItem.isSelected).to.be.true();
 			});
 		});
@@ -140,9 +140,9 @@ describe('SwitchItem', function () {
 			});
 
 			it('should re-select the item when clicked twice', async function () {
-				switchItem.self.click();
+				await switchItem.self.click();
 				await browser.pause(500);
-				switchItem.self.click();
+				await switchItem.self.click();
 				expect(await switchItem.isSelected).to.be.true();
 			});
 		});

--- a/tests/ui/specs/SwitchItem/SwitchItem-specs.js
+++ b/tests/ui/specs/SwitchItem/SwitchItem-specs.js
@@ -28,6 +28,7 @@ describe('SwitchItem', function () {
 
 			it('should re-unselect the item when selected twice', async function () {
 				await Page.spotlightSelect();
+				await browser.pause(500);
 				await Page.spotlightSelect();
 				expect(await switchItem.isSelected).to.be.false();
 			});
@@ -80,6 +81,7 @@ describe('SwitchItem', function () {
 			it('should re-select the item when selected twice', async function () {
 				await switchItem.focus();
 				await Page.spotlightSelect();
+				await browser.pause(500);
 				await Page.spotlightSelect();
 				expect(await switchItem.isSelected).to.be.true();
 			});
@@ -125,6 +127,7 @@ describe('SwitchItem', function () {
 			it('should re-select the item when selected twice', async function () {
 				await switchItem.focus();
 				await Page.spotlightSelect();
+				await browser.pause(500);
 				await Page.spotlightSelect();
 				expect(await switchItem.isSelected).to.be.true();
 			});

--- a/tests/ui/specs/SwitchItem/SwitchItem-specs.js
+++ b/tests/ui/specs/SwitchItem/SwitchItem-specs.js
@@ -89,7 +89,7 @@ describe('SwitchItem', function () {
 
 		describe('pointer', function () {
 			it('should unselect the item when clicked', async function () {
-				switchItem.self.click();
+				await switchItem.self.click();
 				expect(await switchItem.isSelected).to.be.false();
 			});
 
@@ -135,7 +135,7 @@ describe('SwitchItem', function () {
 
 		describe('pointer', function () {
 			it('should unselect the item when clicked', async function () {
-				switchItem.self.click();
+				await switchItem.self.click();
 				expect(await switchItem.isSelected).to.be.false();
 			});
 
@@ -173,7 +173,7 @@ describe('SwitchItem', function () {
 
 		describe('pointer', function () {
 			it('should not unselect the item when clicked', async function () {
-				switchItem.self.click();
+				await switchItem.self.click();
 				expect(await switchItem.isSelected).to.be.true();
 			});
 		});
@@ -214,7 +214,7 @@ describe('SwitchItem', function () {
 
 		describe('pointer', function () {
 			it('should not unselect the item when clicked', async function () {
-				switchItem.self.click();
+				await switchItem.self.click();
 				expect(await switchItem.isSelected).to.be.true();
 			});
 		});


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Daniel Stoian daniel.stoian@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Ui tests job on Jenkins for Agate develop branch are failing for  SwitchItem (should re-unselect the item when clicked twice).

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added await for each click in the test suite.
I also added a pause between Page.SpotlightSelect() actions in various tests in order to wait for the transition to end

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRP-12280

### Comments
