### PR TITLE
WRP-12450: Adapted DropManager for touchscreen devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 
 ### Fixed
 
+- `agate/DropManager` to work on touchscreen devices
 - `agate/MediaPlayer` active knob size to not overlay the text on Silicon and Carbon skins when `type` is `tiny`
 
 ## [2.0.4] - 2023-02-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ The following is a curated list of changes in the Enact agate module, newest cha
 ### Fixed
 
 - `agate/DropManager` to work on touchscreen devices
-- 
 - `agate/MediaPlayer` active knob size to not overlay the text on Silicon and Carbon skins when `type` is `tiny`
 
 ## [2.0.4] - 2023-02-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 ### Fixed
 
 - `agate/DropManager` to work on touchscreen devices
+- 
 - `agate/MediaPlayer` active knob size to not overlay the text on Silicon and Carbon skins when `type` is `tiny`
 
 ## [2.0.4] - 2023-02-24

--- a/DropManager/DropManager.js
+++ b/DropManager/DropManager.js
@@ -94,6 +94,7 @@ const defaultConfig = {
 // prop, so we can send an arrangement to Rearrangeable, exclusively.
 const fallbackArrangementProp = 'arrangement';
 
+let item = 'test';
 
 const DropManagerContext = createContext(defaultContainerShape);
 
@@ -164,6 +165,38 @@ const DropManager = hoc(defaultConfig, (configHoc, Wrapped) => {
 			this.setState({dragging: true});
 		};
 
+		handleTouchStart = (e) => {
+			item = e.target;
+			forward('onDragStart', e, this.props);
+
+			this.dragOriginNode = e.target;
+			this.setState({dragging: true});
+
+
+// 			let itemDragContainer = document.createElement("div");
+// 			itemDragContainer.style.backgroundColor = window.getComputedStyle(item).backgroundColor;
+// 			itemDragContainer.style.borderRadius = window.getComputedStyle(item).borderRadius;
+// 			itemDragContainer.style.height = item.clientHeight + 'px';
+// 			itemDragContainer.style.width = item.clientWidth + 'px';
+// 			itemDragContainer.textContent =  item.textContent;
+// console.log(itemDragContainer)
+// 			// itemDragContainer.style.bottom = "0px";
+// 			// itemDragContainer.style.left = "0px";
+// 			// itemDragContainer.style.zIndex = '-100';
+//
+//
+// 			// position the image to the touch, can be improve to detect the position of touch inside the image
+// 			let left = e.touches[0].pageX;
+// 			let top = e.touches[0].pageY;
+// 			itemDragContainer.style.position = 'absolute'
+// 			itemDragContainer.style.left = left + 'px';
+// 			itemDragContainer.style.top = top + 'px';
+// 			itemDragContainer.style.opacity = 0.5;
+//
+//
+// 			document.body.appendChild(itemDragContainer);
+		};
+
 		handleDragEnter = (ev) => {
 			this.addDropTarget(ev.target);
 		};
@@ -176,6 +209,11 @@ const DropManager = hoc(defaultConfig, (configHoc, Wrapped) => {
 			ev.preventDefault();
 			// Set the dropEffect to move
 			ev.dataTransfer.dropEffect = 'move';
+		};
+
+		handleTouchMove = (ev) => {
+			//console.log("mouseOver");
+			//ev.preventDefault();
 		};
 
 		handleDrop = (ev) => {
@@ -196,6 +234,73 @@ const DropManager = hoc(defaultConfig, (configHoc, Wrapped) => {
 			// If we dropped directly on an element with a slot defined, just use that directly
 			if (ev.target.dataset.slot) {
 				dragDropNode = ev.target;
+			} else {
+				// If we dropped on a child of a slotted element (like an icon or a div or other
+				// nested component), find the closest ancestor with a slot and use that as the drop element.
+				const closestSlot = ev.target.closest('[data-slot]');
+				if (closestSlot && closestSlot.dataset.slot) {
+					dragDropNode = closestSlot;
+				} else {
+					// We didn't actually find anything, just bail out. The component was dropped in
+					// a place that is unknown.
+					this.setState({dragging: false});
+					return;
+				}
+			}
+
+			this.removeDropTarget(dragDropNode);
+
+			// Get the destination element's slot value, or find its ancestor that has one (in case we drop this on a child or grandchild of the slotted item).
+			// const dragDestination = ev.target.dataset.slot || (ev.target.closest('[data-slot]') && ev.target.closest('[data-slot]').dataset.slot);
+			const dragDestination = dragDropNode.dataset.slot;
+
+			// If the dragged element was dropped back on itself, do nothing and exit.
+			if (dragDestination === dragOrigin) {
+				this.setState({dragging: false});
+				return;
+			}
+
+			this.dragOriginNode.dataset.slot = dragDestination;
+			dragDropNode.dataset.slot = dragOrigin;
+
+			// console.log('from:', dragOrigin, 'to:', dragDestination);
+
+			// We successfully completed the drag, blank-out the node.
+			this.dragOriginNode = null;
+
+			const {arrangement, onArrange} = this.props;
+			const oldD = getKeyByValue(arrangement, dragDestination);
+			const oldO = getKeyByValue(arrangement, dragOrigin);
+
+			arrangement[oldD || dragDestination] = dragOrigin;
+			arrangement[oldO || dragOrigin] = dragDestination;
+
+			if (onArrange) {
+				onArrange({arrangement});
+			}
+
+			this.setState({dragging: false});
+		};
+
+		handleTouchEnd = (ev) => {
+			ev.preventDefault();
+
+			// Bail early if the drag started from some unknown location.
+			if (!this.dragOriginNode) {
+				this.setState({dragging: false});
+				return;
+			}
+
+			// Get the id of the target and add the moved element to the target's DOM
+			// const dragOrigin = ev.dataTransfer.getData('text/plain');
+			const dragOrigin = this.dragOriginNode.dataset.slot;
+
+			let touchEndOverElem = document.elementFromPoint(ev.changedTouches[0].clientX, ev.changedTouches[0].clientY);
+
+			let dragDropNode;
+			// If we dropped directly on an element with a slot defined, just use that directly
+			if (touchEndOverElem.dataset.slot) {
+				dragDropNode = touchEndOverElem;
 			} else {
 				// If we dropped on a child of a slotted element (like an icon or a div or other
 				// nested component), find the closest ancestor with a slot and use that as the drop element.
@@ -265,6 +370,9 @@ const DropManager = hoc(defaultConfig, (configHoc, Wrapped) => {
 				rest.onDragLeave = this.handleDragLeave;
 				rest.onDragOver = this.handleDragOver;
 				rest.onDrop = this.handleDrop;
+				rest.onTouchStart = this.handleTouchStart;
+				rest.onTouchEnd = this.handleTouchEnd;
+				rest.onTouchMove = this.handleTouchMove;
 				// rest.onDragEnd = this.handleDragEnd;
 			}
 

--- a/DropManager/DropManager.js
+++ b/DropManager/DropManager.js
@@ -164,11 +164,6 @@ const DropManager = hoc(defaultConfig, (configHoc, Wrapped) => {
 			this.setState({dragging: true});
 		};
 
-		handleTouchStart = (e) => {
-			this.dragOriginNode = e.target;
-			this.setState({dragging: true});
-		};
-
 		handleDragEnter = (ev) => {
 			this.addDropTarget(ev.target);
 		};
@@ -181,19 +176,6 @@ const DropManager = hoc(defaultConfig, (configHoc, Wrapped) => {
 			ev.preventDefault();
 			// Set the dropEffect to move
 			ev.dataTransfer.dropEffect = 'move';
-		};
-
-		handleTouchMove = (ev) => {
-			let touchMoveOverElem = document.elementFromPoint(ev.changedTouches[0].clientX, ev.changedTouches[0].clientY);
-
-			if (this.state.touchOverElement && this.state.touchOverElement !== touchMoveOverElem) {
-				this.removeDropTarget(this.state.touchOverElement);
-				this.addDropTarget(touchMoveOverElem);
-				this.setState(() => ({touchOverElement: touchMoveOverElem}));
-			} else {
-				this.addDropTarget(touchMoveOverElem);
-				this.setState(() => ({touchOverElement: touchMoveOverElem}));
-			}
 		};
 
 		handleDrop = (ev) => {
@@ -262,12 +244,26 @@ const DropManager = hoc(defaultConfig, (configHoc, Wrapped) => {
 			this.setState({dragging: false});
 		};
 
+		handleTouchStart = (ev) => {
+			this.dragOriginNode = ev.target;
+			this.setState({dragging: true});
+		};
+
+		handleTouchMove = (ev) => {
+			let touchMoveOverElem = document.elementFromPoint(ev.changedTouches[0].clientX, ev.changedTouches[0].clientY);
+
+			if (this.state.touchOverElement && this.state.touchOverElement !== touchMoveOverElem) {
+				this.removeDropTarget(this.state.touchOverElement);
+				this.addDropTarget(touchMoveOverElem);
+				this.setState(() => ({touchOverElement: touchMoveOverElem}));
+			} else {
+				this.addDropTarget(touchMoveOverElem);
+				this.setState(() => ({touchOverElement: touchMoveOverElem}));
+			}
+		};
+
 		handleTouchEnd = (ev) => {
 			ev.preventDefault();
-
-			if (this.state.touchOverElement) {
-				this.removeDropTarget(this.state.touchOverElement);
-			}
 
 			// Bail early if the drag started from some unknown location.
 			if (!this.dragOriginNode) {
@@ -275,16 +271,19 @@ const DropManager = hoc(defaultConfig, (configHoc, Wrapped) => {
 				return;
 			}
 
+			if (this.state.touchOverElement) {
+				this.removeDropTarget(this.state.touchOverElement);
+			}
+
 			// Get the id of the target and add the moved element to the target's DOM
-			// const dragOrigin = ev.dataTransfer.getData('text/plain');
 			const dragOrigin = this.dragOriginNode.dataset.slot;
 
-			let touchEndOverElem = document.elementFromPoint(ev.changedTouches[0].clientX, ev.changedTouches[0].clientY);
+			let dropOverElem = document.elementFromPoint(ev.changedTouches[0].clientX, ev.changedTouches[0].clientY);
 
 			let dragDropNode;
 			// If we dropped directly on an element with a slot defined, just use that directly
-			if (touchEndOverElem.dataset.slot) {
-				dragDropNode = touchEndOverElem;
+			if (dropOverElem.dataset.slot) {
+				dragDropNode = dropOverElem;
 			} else {
 				// If we dropped on a child of a slotted element (like an icon or a div or other
 				// nested component), find the closest ancestor with a slot and use that as the drop element.
@@ -311,8 +310,6 @@ const DropManager = hoc(defaultConfig, (configHoc, Wrapped) => {
 
 			this.dragOriginNode.dataset.slot = dragDestination;
 			dragDropNode.dataset.slot = dragOrigin;
-
-			// console.log('from:', dragOrigin, 'to:', dragDestination);
 
 			// We successfully completed the drag, blank-out the node.
 			this.dragOriginNode = null;
@@ -353,8 +350,8 @@ const DropManager = hoc(defaultConfig, (configHoc, Wrapped) => {
 				rest.onDragOver = this.handleDragOver;
 				rest.onDrop = this.handleDrop;
 				rest.onTouchStart = this.handleTouchStart;
-				rest.onTouchEnd = this.handleTouchEnd;
 				rest.onTouchMove = this.handleTouchMove;
+				rest.onTouchEnd = this.handleTouchEnd;
 				// rest.onDragEnd = this.handleDragEnd;
 			}
 

--- a/DropManager/tests/DropManager-specs.js
+++ b/DropManager/tests/DropManager-specs.js
@@ -126,13 +126,13 @@ describe('DropManager Specs', () => {
 
 		render(
 			<Component arrangeable arrangement={arrangement} data-testid="dropManager">
-				<top is="custom">
+				<top>
 					<div>Drag me top</div>
 				</top>
-				<center is="custom">
+				<center>
 					<div>Drag me center</div>
 				</center>
-				<bottom is="custom">
+				<bottom>
 					<div>Drag me bottom</div>
 				</bottom>
 			</Component>
@@ -211,13 +211,13 @@ describe('DropManager Specs', () => {
 
 		render(
 			<Component arrangeable arrangement={arrangement} data-testid="dropManager">
-				<top is="custom">
+				<top>
 					<div>Drag me top</div>
 				</top>
-				<center is="custom">
+				<center>
 					<div>Drag me center</div>
 				</center>
-				<bottom is="custom">
+				<bottom>
 					<div>Drag me bottom</div>
 				</bottom>
 			</Component>

--- a/DropManager/tests/DropManager-specs.js
+++ b/DropManager/tests/DropManager-specs.js
@@ -1,9 +1,14 @@
 import {Layout, Cell} from '@enact/ui/Layout';
 import '@testing-library/jest-dom';
-import {render, screen} from '@testing-library/react';
+import {fireEvent, render, screen} from '@testing-library/react';
 
 import Button from '../../Button';
 import Droppable, {Draggable, ResponsiveBox} from '../DropManager';
+
+const getElementClientCenter = (element) => {
+	const {left, top, width, height} = element.getBoundingClientRect();
+	return {x: left + width / 2, y: top + height / 2};
+};
 
 describe('DropManager Specs', () => {
 	const allSlotNames = ['bottom', 'center', 'top'];
@@ -23,7 +28,7 @@ describe('DropManager Specs', () => {
 		);
 	});
 
-	const CustomLayoutBase = ({bottom, center, top, ...rest}) => {
+	const CustomResponsiveLayoutBase = ({bottom, center, top, ...rest}) => {
 		return (
 			<Layout {...rest} orientation="vertical">
 				<DraggableCell containerShape={containerShapes.top} name="top">{top}</DraggableCell>
@@ -35,16 +40,27 @@ describe('DropManager Specs', () => {
 		);
 	};
 
-	const Component = Droppable({slots: allSlotNames}, CustomLayoutBase);
+	const CustomLayoutBase = ({bottom, center, top, ...rest}) => {
+		return (
+			<Layout {...rest} orientation="vertical">
+				<DraggableCell containerShape={containerShapes.top} name="top">{top}</DraggableCell>
+				<DraggableCell containerShape={containerShapes.center} name="center">{center}</DraggableCell>
+				<DraggableCell containerShape={containerShapes.bottom} name="bottom">{bottom}</DraggableCell>
+			</Layout>
+		);
+	};
+
+	const ResponsiveComponent = Droppable({slots: allSlotNames}, CustomResponsiveLayoutBase);
+	const BasicComponent = Droppable({slots: allSlotNames}, CustomLayoutBase);
 
 	test('should render `top`, `center` and `bottom` slots', () => {
 		console.error = jest.fn(); // eslint-disable-line no-console
 		render(
-			<Component arrangeable>
+			<ResponsiveComponent arrangeable>
 				<top data-testid="top" />
 				<center data-testid="center" />
 				<bottom data-testid="bottom" />
-			</Component>
+			</ResponsiveComponent>
 		);
 
 		const topSlot = screen.getByTestId('top').parentElement;
@@ -58,11 +74,11 @@ describe('DropManager Specs', () => {
 
 	test('should change `data-slot` value when changing `arrangement`', () => {
 		const {rerender} = render(
-			<Component arrangeable arrangement={{bottom: 'bottom', center: 'center', top: 'top'}} data-testid="dropManager">
+			<ResponsiveComponent arrangeable arrangement={{bottom: 'bottom', center: 'center', top: 'top'}} data-testid="dropManager">
 				<top />
 				<center />
 				<bottom />
-			</Component>
+			</ResponsiveComponent>
 		);
 
 		let topSlot = screen.getByTestId('dropManager').children[0];
@@ -70,11 +86,11 @@ describe('DropManager Specs', () => {
 		expect(topSlot).toHaveAttribute('data-slot', 'top');
 
 		rerender(
-			<Component arrangeable arrangement={{bottom: 'center', center: 'top', top: 'bottom'}} data-testid="dropManager">
+			<ResponsiveComponent arrangeable arrangement={{bottom: 'center', center: 'top', top: 'bottom'}} data-testid="dropManager">
 				<top />
 				<center />
 				<bottom />
-			</Component>
+			</ResponsiveComponent>
 		);
 
 		topSlot = screen.getByTestId('dropManager').children[0];
@@ -84,7 +100,7 @@ describe('DropManager Specs', () => {
 
 	test('should have `responsive layout` with `align-items: center` and `justify-content: space-evenly` style', () => {
 		render(
-			<Component arrangeable>
+			<ResponsiveComponent arrangeable>
 				<top />
 				<center data-testid="center">
 					<ResponsiveLayout>
@@ -97,11 +113,78 @@ describe('DropManager Specs', () => {
 					</ResponsiveLayout>
 				</center>
 				<bottom />
-			</Component>
+			</ResponsiveComponent>
 		);
 
 		const responsiveLayout = screen.getByTestId('center').parentElement.parentElement;
 
 		expect(responsiveLayout).toHaveStyle({alignItems: 'center', justifyContent: 'space-evenly'});
+	});
+
+	test('should should rearrange items on touch', () => {
+		const arrangement = {bottom: "bottom", center: "center", top: "top"};
+
+		render(
+			<BasicComponent arrangeable arrangement={arrangement}>
+				<top data-testid="top" is="custom">
+					<div>Drag me top</div>
+				</top>
+				<center data-testid="center" is="custom">
+					<div>Drag me center</div>
+				</center>
+				<bottom data-testid="bottom" is="custom">
+					<div>Drag me bottom</div>
+				</bottom>
+			</BasicComponent>
+		);
+
+		const topSlot = screen.getByTestId('top').parentElement;
+		const centerSlot = screen.getByTestId('center').parentElement;
+
+		document.elementFromPoint = jest.fn(() => {
+			return centerSlot;
+		});
+
+		topSlot.getBoundingClientRect = jest.fn(() => {
+			return {
+				width: 501,
+				height: 100,
+				top: 0,
+				left: 0,
+				bottom: 0,
+				right: 0
+			};
+		});
+
+		centerSlot.getBoundingClientRect = jest.fn(() => {
+			return {
+				width: 501,
+				height: 150,
+				top: 101,
+				left: 0,
+				bottom: 0,
+				right: 0
+			};
+		});
+
+		const delta = {x: 0, y: 150};
+		const from = getElementClientCenter(topSlot);
+		const to = {x: from.x + delta.x, y: from.y + delta.y};
+		const step = {x: (to.x - from.x), y: (to.y - from.y)};
+		const current = {clientX: from.x, clientY: from.y};
+
+		fireEvent.touchStart(topSlot, {touches: [current]});
+		current.clientX += step.x;
+		current.clientY += step.y;
+
+		fireEvent.touchMove(topSlot, {changedTouches: [current]});
+		fireEvent.touchEnd(topSlot, {changedTouches: [current]});
+
+		const dropManager = screen.getByTestId('top').parentElement.parentElement;
+		const firstChild = dropManager.children.item(0);
+		const secondChild = dropManager.children.item(1);
+
+		expect(firstChild).toHaveAttribute('data-slot', 'center');
+		expect(secondChild).toHaveAttribute('data-slot', 'top');
 	});
 });


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Daniel Stoian [daniel.stoian@lgepartner.com](mailto:daniel.stoian@lgepartner.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
DropManager did not work on touchscreen devices

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added handling for touchStart, touchMove and touchEnd events

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
There is no drag image on touch events, but the drop area is easily visible, thanks to the already available classnames that are assigned to the  drop areas.

### Links
[//]: # (Related issues, references)
WRP-12450

### Comments
