### PR TITLE
WRP-21123: Added missing prop from sampler and applied the required css

### DIFF
--- a/Panels/Panels.module.less
+++ b/Panels/Panels.module.less
@@ -62,7 +62,7 @@
 			.remove-margin-on-edge-children();
 		}
 
-		.partial {
+		&.partial {
 			background-color: @agate-panels-partial-bg-color;
 			background-image: @agate-panels-partial-bg-image;
 			height: @agate-panels-partial-height;

--- a/samples/sampler/stories/default/Panels.js
+++ b/samples/sampler/stories/default/Panels.js
@@ -84,7 +84,7 @@ export const _Panels = (args) => (
 	/>
 );
 
-select('cover', _Panels, ['full', 'partial'], Config, ['full']);
+select('cover', _Panels, ['full', 'partial'], Config);
 boolean('noAnimation', _Panels, Config, false);
 boolean('noCloseButton', _Panels, Config, false);
 select('orientation', _Panels, ['horizontal', 'vertical'], Config);

--- a/samples/sampler/stories/default/Panels.js
+++ b/samples/sampler/stories/default/Panels.js
@@ -65,6 +65,7 @@ const BasicPanels = ({...rest}) => {
 };
 
 BasicPanels.propTypes = {
+	cover: PropTypes.string,
 	orientation: PropTypes.string
 };
 
@@ -75,6 +76,7 @@ export default {
 
 export const _Panels = (args) => (
 	<BasicPanels
+		cover={args['cover']}
 		noAnimation={args['noAnimation']}
 		noCloseButton={args['noCloseButton']}
 		onApplicationClose={action('onClose')}
@@ -82,6 +84,7 @@ export const _Panels = (args) => (
 	/>
 );
 
+select('cover', _Panels, ['full', 'partial'], Config, ['full']);
 boolean('noAnimation', _Panels, Config, false);
 boolean('noCloseButton', _Panels, Config, false);
 select('orientation', _Panels, ['horizontal', 'vertical'], Config);

--- a/samples/sampler/stories/qa/Panels.js
+++ b/samples/sampler/stories/qa/Panels.js
@@ -155,17 +155,17 @@ export default {
 
 export const PreserveFocus = (args) => (
 	<BasicPanels
+		cover={args['cover']}
 		noAnimation={args['noAnimation']}
 		noCloseButton={args['noCloseButton']}
 		orientation={args['orientation']}
-		cover={args['cover']}
 	/>
 );
 
+select('cover', PreserveFocus, ['full', 'partial'], Config);
 boolean('noAnimation', PreserveFocus, Config);
 boolean('noCloseButton', PreserveFocus, Config);
 select('orientation', PreserveFocus, ['horizontal', 'vertical'], Config);
-select('cover', PreserveFocus, ['full', 'partial'], Config);
 
 PreserveFocus.storyName = 'preserve focus';
 PreserveFocus.parameters = {

--- a/samples/sampler/stories/qa/Panels.js
+++ b/samples/sampler/stories/qa/Panels.js
@@ -158,12 +158,14 @@ export const PreserveFocus = (args) => (
 		noAnimation={args['noAnimation']}
 		noCloseButton={args['noCloseButton']}
 		orientation={args['orientation']}
+		cover={args['cover']}
 	/>
 );
 
 boolean('noAnimation', PreserveFocus, Config);
 boolean('noCloseButton', PreserveFocus, Config);
 select('orientation', PreserveFocus, ['horizontal', 'vertical'], Config);
+select('cover', PreserveFocus, ['full', 'partial'], Config);
 
 PreserveFocus.storyName = 'preserve focus';
 PreserveFocus.parameters = {

--- a/styles/variables-carbon.less
+++ b/styles/variables-carbon.less
@@ -44,7 +44,7 @@
 @agate-panels-controls-top: (@agate-component-spacing - 6px);
 @agate-panels-panel-padding: 24px;
 @agate-panels-partial-height: 50%;
-@agate-panels-partial-width: auto;
+@agate-panels-partial-width: 890px;
 @agate-panels-tab-margin: 0;
 @agate-panels-tab-padding: 18px 0;
 @agate-panels-tab-separator-border-width: 1px;

--- a/tests/screenshot/apps/components/Panels.js
+++ b/tests/screenshot/apps/components/Panels.js
@@ -17,6 +17,11 @@ const PanelsTests = [
 		title: 'no close button',
 		component: <Panels noCloseButton>{PanelComponents}</Panels>,
 		wrapper: {full: true}
+	},
+	{
+		title: 'cover partial',
+		component: <Panels cover="partial">{PanelComponents}</Panels>,
+		wrapper: {full: true}
 	}
 ];
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Added missing prop `cover` from storybook.
Applied the required css for the prop value `partial`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Panels now displays the prop `cover` on storybook with the required css.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-21123

### Comments
Enact-DCO-1.0-Signed-off-by: Andrei Tirla andrei.tirla@lgepartner.com