### PR TITLE
WRP-26842: Fixed ui-test fail for VirtualGridList

### DIFF
--- a/tests/ui/specs/VirtualList/VirtualGridList/VirtualGridList-specs.js
+++ b/tests/ui/specs/VirtualList/VirtualGridList/VirtualGridList-specs.js
@@ -54,7 +54,7 @@ describe('Focus after calling scrollTo()', function () {
 			await waitUntilFocused(i * 4);
 			await waitUntilVisible(i * 4);
 		}
-		// await browser.pause(500);
+		await browser.pause(500);
 		// Press 5-way OK.
 		await Page.spotlightSelect();
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Ui-test nightly job on Jenkins for Agate develop branch is failing for VirtualGridList(should focus "item0" but instead it focuses on "item12").

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I added a `browser.pause` before `Page.SpotlightSelect()` in order to wait for the `Page.spotlightDown()` to reach the correct item, in our case, 'item0'.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-26942

### Comments
Enact-DCO-1.0-Signed-off-by: Andrei Tirla andrei.tirla@lgepartner.com