### PR TITLE
WRP-27419: A11y - ReadAlert - There is no readalert when checking togglebutton

### DIFF
--- a/samples/qa-a11y/src/views/ReadAlert.js
+++ b/samples/qa-a11y/src/views/ReadAlert.js
@@ -13,7 +13,7 @@ const ReadAlertView = () => {
 	const [toggleDisabled, setToggleDisabled] = useState(true);
 
 	useEffect(() => {
-		if (window.PalmServiceBridge) {
+		if (window.WebOSServiceBridge ?? window.PalmServiceBridge) {
 			new LS2Request().send({
 				service: 'luna://com.webos.settingsservice/',
 				method: 'getSystemSettings',
@@ -35,7 +35,7 @@ const ReadAlertView = () => {
 	const onClick2 = onClick(false);
 
 	const onToggle = useCallback(({selected}) => {
-		if (window.PalmServiceBridge) {
+		if (window.WebOSServiceBridge ?? window.PalmServiceBridge) {
 			setAudioGuidance(selected);
 			new LS2Request().send({
 				service: 'luna://com.webos.settingsservice/',

--- a/samples/qa-a11y/src/views/ReadAlert.js
+++ b/samples/qa-a11y/src/views/ReadAlert.js
@@ -13,7 +13,7 @@ const ReadAlertView = () => {
 	const [toggleDisabled, setToggleDisabled] = useState(true);
 
 	useEffect(() => {
-		if (window.WebOSServiceBridge ?? window.PalmServiceBridge) {
+		if (window.PalmServiceBridge) {
 			new LS2Request().send({
 				service: 'luna://com.webos.settingsservice/',
 				method: 'getSystemSettings',
@@ -27,35 +27,35 @@ const ReadAlertView = () => {
 				}
 			});
 		}
-	});
+	}, []);
 
 	const onClick = (clear) => () => readAlert('Enact is a framework designed to be performant, customizable and well structured.', clear);
 
 	const onClick1 = onClick(true);
 	const onClick2 = onClick(false);
 
-	const onToggle = useCallback(() => {
-		if (window.WebOSServiceBridge ?? window.PalmServiceBridge) {
-			setAudioGuidance(prevAudioGuidance => !prevAudioGuidance);
+	const onToggle = useCallback(({selected}) => {
+		if (window.PalmServiceBridge) {
+			setAudioGuidance(selected);
 			new LS2Request().send({
 				service: 'luna://com.webos.settingsservice/',
 				method: 'setSystemSettings',
 				parameters: {
 					category: 'option',
 					settings: {
-						audioGuidance: audioGuidance ? 'off' : 'on'
+						audioGuidance: selected ? 'on' : 'off'
 					}
 				}
 			});
 		}
-	}, [audioGuidance]);
+	}, []);
 
 	return (
 		<>
 			<Section title="AudioGuidance On or Off">
 				<CheckboxItem
 					alt="Toggle"
-					defaultSelected={audioGuidance}
+					selected={audioGuidance}
 					disabled={toggleDisabled}
 					onToggle={onToggle}
 				>

--- a/samples/qa-a11y/src/views/ReadAlert.js
+++ b/samples/qa-a11y/src/views/ReadAlert.js
@@ -36,14 +36,14 @@ const ReadAlertView = () => {
 
 	const onToggle = useCallback(() => {
 		if (window.WebOSServiceBridge ?? window.PalmServiceBridge) {
-			setAudioGuidance(guidance => setAudioGuidance(!guidance));
+			setAudioGuidance(prevAudioGuidance => !prevAudioGuidance);
 			new LS2Request().send({
 				service: 'luna://com.webos.settingsservice/',
 				method: 'setSystemSettings',
 				parameters: {
 					category: 'option',
 					settings: {
-						audioGuidance: audioGuidance ? 'on' : 'off'
+						audioGuidance: audioGuidance ? 'off' : 'on'
 					}
 				}
 			});


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Adrian Cocoara adrian.cocoara@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fixed audio guidance to work when `Audio Guidance` button is checked

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-27419

### Comments
