### PR TITLE
WRQ-2635: [Agate] Dropdown: Dropdown is not adapted by direction.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
     - npm install
     - npm run lerna exec -- --ignore enact-sampler --concurrency 1 -- npm --no-package-lock install
     - npm run lerna exec -- --ignore enact-sampler --concurrency 1 -- npm --no-package-lock link
-    - npm run lerna link
+    - npm run interlink
     - popd
     - rm -fr node_modules/@enact
     - npm install

--- a/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -125,6 +125,8 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			 */
 			offset: PropTypes.oneOf(['none', 'overlap', 'small']),
 
+			onAdjustDirection: PropTypes.func,
+
 			/**
 			 * Called when the user has attempted to close the popup.
 			 *
@@ -551,6 +553,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 
 				this.calcOverflow(containerNode, clientNode);
 				this.adjustDirection();
+				this.props.onAdjustDirection({adjustedDirection: this.adjustedDirection.split(' ')[0] === 'below' ? 'below' : 'above'});
 
 				this.setState({
 					direction: this.adjustedDirection,

--- a/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -125,6 +125,15 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			 */
 			offset: PropTypes.oneOf(['none', 'overlap', 'small']),
 
+			/**
+			 * Called when the direction is adjusted.
+			 *
+			 * This prop is from Dropdown component.
+			 * After adjusting direction, this function passes the adjusted direction to Dropdown.
+			 *
+			 * @type {Function}
+			 * @public
+			 */
 			onAdjustDirection: PropTypes.func,
 
 			/**
@@ -554,7 +563,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 				this.calcOverflow(containerNode, clientNode);
 				this.adjustDirection();
 				if (this.props.onAdjustDirection) {
-					this.props.onAdjustDirection({adjusteddirection: this.adjustedDirection.split(' ')[0] === 'below' ? 'below' : 'above'});
+					this.props.onAdjustDirection({adjustedDirection: this.adjustedDirection.split(' ')[0] === 'below' ? 'below' : 'above'});
 				}
 
 				this.setState({

--- a/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -128,8 +128,8 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			/**
 			 * Called when the direction is adjusted.
 			 *
-			 * This prop is from Dropdown component.
-			 * After adjusting direction, this function passes the adjusted direction to Dropdown.
+			 * After the direction is adjusted, this function is invoked with the new direction as an argument,
+			 * which is then passed back to the Dropdown component.
 			 *
 			 * @type {Function}
 			 * @private

--- a/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -554,7 +554,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 				this.calcOverflow(containerNode, clientNode);
 				this.adjustDirection();
 				if (this.props.onAdjustDirection) {
-					this.props.onAdjustDirection({adjustedDirection: this.adjustedDirection.split(' ')[0] === 'below' ? 'below' : 'above'});
+					this.props.onAdjustDirection({adjusteddirection: this.adjustedDirection.split(' ')[0] === 'below' ? 'below' : 'above'});
 				}
 
 				this.setState({
@@ -682,6 +682,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			}
 
 			delete rest.direction;
+			delete rest.onAdjustDirection;
 			delete rest.onOpen;
 			delete rest.popupSpotlightId;
 			delete rest.rtl;

--- a/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -553,7 +553,9 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 
 				this.calcOverflow(containerNode, clientNode);
 				this.adjustDirection();
-				this.props.onAdjustDirection({adjustedDirection: this.adjustedDirection.split(' ')[0] === 'below' ? 'below' : 'above'});
+				if (this.props.onAdjustDirection) {
+					this.props.onAdjustDirection({adjustedDirection: this.adjustedDirection.split(' ')[0] === 'below' ? 'below' : 'above'});
+				}
 
 				this.setState({
 					direction: this.adjustedDirection,

--- a/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -132,7 +132,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			 * After adjusting direction, this function passes the adjusted direction to Dropdown.
 			 *
 			 * @type {Function}
-			 * @public
+			 * @private
 			 */
 			onAdjustDirection: PropTypes.func,
 

--- a/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -563,7 +563,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 				this.calcOverflow(containerNode, clientNode);
 				this.adjustDirection();
 				if (this.props.onAdjustDirection) {
-					this.props.onAdjustDirection({adjustedDirection: this.adjustedDirection.split(' ')[0] === 'below' ? 'below' : 'above'});
+					this.props.onAdjustDirection({adjustedDirection: this.adjustedDirection.split(' ')[0]});
 				}
 
 				this.setState({

--- a/Dropdown/Dropdown.js
+++ b/Dropdown/Dropdown.js
@@ -124,7 +124,7 @@ const DropdownBase = kind({
 	name: 'Dropdown',
 
 	propTypes: /** @lends agate/Dropdown.DropdownBase.prototype */ {
-		adjustedDirection: PropTypes.oneOf(['above', 'below']),
+		adjusteddirection: PropTypes.oneOf(['above', 'below']),
 
 		/**
 		 * The "aria-label" for the Dropdown.
@@ -324,11 +324,11 @@ const DropdownBase = kind({
 				};
 			});
 		},
-		className: ({adjustedDirection, css, direction, open, width, title, skin, styler}) => {
-			direction = adjustedDirection ? adjustedDirection : direction;
+		className: ({adjusteddirection, css, direction, open, width, title, skin, styler}) => {
+			direction = adjusteddirection ? adjusteddirection : direction;
 			return styler.append(`${width}Width`, {hasTitle: Boolean(title), open}, skin === 'silicon' ? classnames(css.dropdownButton, {[css.upDropdownButton]: direction === 'above'}) : {});
 		},
-		adjustedDirection: ({adjustedDirection}) => `${adjustedDirection} center`,
+		adjusteddirection: ({adjusteddirection}) => `${adjusteddirection} center`,
 		direction: ({direction}) => `${direction} center`,
 		hasChildren: ({children}) => {
 			return children.length > 0;
@@ -343,13 +343,13 @@ const DropdownBase = kind({
 		}
 	},
 
-	render: ({adjustedDirection, 'aria-label': ariaLabel, ariaLabelledBy, children, css, direction, disabled, hasChildren, onAdjustDirection, onClose, onOpen, onSelect, open, selected, skin, title, width, ...rest}) => {
+	render: ({adjusteddirection, 'aria-label': ariaLabel, ariaLabelledBy, children, css, direction, disabled, hasChildren, onAdjustDirection, onClose, onOpen, onSelect, open, selected, skin, title, width, ...rest}) => {
 		delete rest.rtl;
 
 		const ariaProps = extractAriaProps(rest);
 		const calcAriaProps = ariaLabel != null ? null : {role: 'region', 'aria-labelledby': ariaLabelledBy};
 
-		const popupProps = {adjustedDirection, 'aria-live': null, children, direction, disabled, onSelect, open, selected, skin, skinVariants: skin === 'silicon' ? {'night': false} : {}, width, role: null};
+		const popupProps = {adjusteddirection, 'aria-live': null, children, direction, disabled, onSelect, open, selected, skin, skinVariants: skin === 'silicon' ? {'night': false} : {}, width, role: null};
 
 		// `ui/Group`/`ui/Repeater` will throw an error if empty so we disable the Dropdown and
 		// prevent Dropdown to open if there are no children.
@@ -406,7 +406,7 @@ const DropdownDecorator = compose(
 		generateProp: null,
 		prefix: 'd_'
 	}),
-	Changeable({change: 'onAdjustDirection', prop: 'adjustedDirection'}),
+	Changeable({change: 'onAdjustDirection', prop: 'adjusteddirection'}),
 	Changeable({change: 'onSelect', prop: 'selected'}),
 	Toggleable({
 		activate: 'onOpen',

--- a/Dropdown/Dropdown.js
+++ b/Dropdown/Dropdown.js
@@ -129,7 +129,7 @@ const DropdownBase = kind({
 		 *
 		 * @type {('above'|'below')}
 		 * @default 'below'
-		 * @public
+		 * @private
 		 */
 		adjustedDirection: PropTypes.oneOf(['above', 'below']),
 
@@ -198,7 +198,7 @@ const DropdownBase = kind({
 		 * Called when the direction is adjusted.
 		 *
 		 * @type {Function}
-		 * @public
+		 * @private
 		 */
 		onAdjustDirection: PropTypes.func,
 

--- a/Dropdown/Dropdown.js
+++ b/Dropdown/Dropdown.js
@@ -338,7 +338,6 @@ const DropdownBase = kind({
 			});
 		},
 		className: ({adjustedDirection, css, open, width, title, skin, styler}) => styler.append(`${width}Width`, {hasTitle: Boolean(title), open}, skin === 'silicon' ? classnames(css.dropdownButton, {[css.upDropdownButton]: adjustedDirection === 'above'}) : {}),
-		adjustedDirection: ({adjustedDirection}) => `${adjustedDirection} center`,
 		direction: ({direction}) => `${direction} center`,
 		hasChildren: ({children}) => {
 			return children.length > 0;
@@ -359,7 +358,7 @@ const DropdownBase = kind({
 		const ariaProps = extractAriaProps(rest);
 		const calcAriaProps = ariaLabel != null ? null : {role: 'region', 'aria-labelledby': ariaLabelledBy};
 
-		const popupProps = {'aria-live': null, children, direction: adjustedDirection, disabled, onSelect, open, selected, skin, skinVariants: skin === 'silicon' ? {'night': false} : {}, width, role: null};
+		const popupProps = {'aria-live': null, children, direction: `${adjustedDirection} center`, disabled, onSelect, open, selected, skin, skinVariants: skin === 'silicon' ? {'night': false} : {}, width, role: null};
 
 		// `ui/Group`/`ui/Repeater` will throw an error if empty so we disable the Dropdown and
 		// prevent Dropdown to open if there are no children.

--- a/Dropdown/Dropdown.js
+++ b/Dropdown/Dropdown.js
@@ -125,7 +125,8 @@ const DropdownBase = kind({
 
 	propTypes: /** @lends agate/Dropdown.DropdownBase.prototype */ {
 		/**
-		 * The direction which is adjusted if original direction is not appropriate.
+		 * The direction of the Dropdown, which is adjusted when the original direction
+		 * cannot be used.
 		 *
 		 * @type {('above'|'below')}
 		 * @default 'below'

--- a/Dropdown/Dropdown.js
+++ b/Dropdown/Dropdown.js
@@ -124,7 +124,14 @@ const DropdownBase = kind({
 	name: 'Dropdown',
 
 	propTypes: /** @lends agate/Dropdown.DropdownBase.prototype */ {
-		adjusteddirection: PropTypes.oneOf(['above', 'below']),
+		/**
+		 * The direction which is adjusted if original direction is not appropriate. 
+		 *
+		 * @type {('above'|'below')}
+		 * @default 'below'
+		 * @public
+		 */
+		adjustedDirection: PropTypes.oneOf(['above', 'below']),
 
 		/**
 		 * The "aria-label" for the Dropdown.
@@ -188,14 +195,19 @@ const DropdownBase = kind({
 		id: PropTypes.string,
 
 		/**
+		 * Called when the direction is adjusted.
+		 *
+		 * @type {Function}
+		 * @public
+		 */
+		onAdjustDirection: PropTypes.func,
+
+		/**
 		 * Called when the Dropdown is closing.
 		 *
 		 * @type {Function}
 		 * @public
 		 */
-
-		onAdjustDirection: PropTypes.func,
-
 		onClose: PropTypes.func,
 
 		/**
@@ -271,6 +283,7 @@ const DropdownBase = kind({
 	},
 
 	defaultProps: {
+		adjustedDirection: 'below',
 		direction: 'below',
 		width: 'medium'
 	},
@@ -324,11 +337,8 @@ const DropdownBase = kind({
 				};
 			});
 		},
-		className: ({adjusteddirection, css, direction, open, width, title, skin, styler}) => {
-			direction = adjusteddirection ? adjusteddirection : direction;
-			return styler.append(`${width}Width`, {hasTitle: Boolean(title), open}, skin === 'silicon' ? classnames(css.dropdownButton, {[css.upDropdownButton]: direction === 'above'}) : {});
-		},
-		adjusteddirection: ({adjusteddirection}) => `${adjusteddirection} center`,
+		className: ({adjustedDirection, css, open, width, title, skin, styler}) => styler.append(`${width}Width`, {hasTitle: Boolean(title), open}, skin === 'silicon' ? classnames(css.dropdownButton, {[css.upDropdownButton]: adjustedDirection === 'above'}) : {}),
+		adjustedDirection: ({adjustedDirection}) => `${adjustedDirection} center`,
 		direction: ({direction}) => `${direction} center`,
 		hasChildren: ({children}) => {
 			return children.length > 0;
@@ -343,13 +353,13 @@ const DropdownBase = kind({
 		}
 	},
 
-	render: ({adjusteddirection, 'aria-label': ariaLabel, ariaLabelledBy, children, css, direction, disabled, hasChildren, onAdjustDirection, onClose, onOpen, onSelect, open, selected, skin, title, width, ...rest}) => {
+	render: ({adjustedDirection, 'aria-label': ariaLabel, ariaLabelledBy, children, css, direction, disabled, hasChildren, onAdjustDirection, onClose, onOpen, onSelect, open, selected, skin, title, width, ...rest}) => {
 		delete rest.rtl;
 
 		const ariaProps = extractAriaProps(rest);
 		const calcAriaProps = ariaLabel != null ? null : {role: 'region', 'aria-labelledby': ariaLabelledBy};
 
-		const popupProps = {adjusteddirection, 'aria-live': null, children, direction, disabled, onSelect, open, selected, skin, skinVariants: skin === 'silicon' ? {'night': false} : {}, width, role: null};
+		const popupProps = {'aria-live': null, children, direction: adjustedDirection, disabled, onSelect, open, selected, skin, skinVariants: skin === 'silicon' ? {'night': false} : {}, width, role: null};
 
 		// `ui/Group`/`ui/Repeater` will throw an error if empty so we disable the Dropdown and
 		// prevent Dropdown to open if there are no children.
@@ -406,7 +416,7 @@ const DropdownDecorator = compose(
 		generateProp: null,
 		prefix: 'd_'
 	}),
-	Changeable({change: 'onAdjustDirection', prop: 'adjusteddirection'}),
+	Changeable({change: 'onAdjustDirection', prop: 'adjustedDirection'}),
 	Changeable({change: 'onSelect', prop: 'selected'}),
 	Toggleable({
 		activate: 'onOpen',

--- a/Dropdown/Dropdown.js
+++ b/Dropdown/Dropdown.js
@@ -125,7 +125,7 @@ const DropdownBase = kind({
 
 	propTypes: /** @lends agate/Dropdown.DropdownBase.prototype */ {
 		/**
-		 * The direction which is adjusted if original direction is not appropriate. 
+		 * The direction which is adjusted if original direction is not appropriate.
 		 *
 		 * @type {('above'|'below')}
 		 * @default 'below'

--- a/Dropdown/Dropdown.js
+++ b/Dropdown/Dropdown.js
@@ -124,6 +124,8 @@ const DropdownBase = kind({
 	name: 'Dropdown',
 
 	propTypes: /** @lends agate/Dropdown.DropdownBase.prototype */ {
+		adjustedDirection: PropTypes.oneOf(['above', 'below']),
+
 		/**
 		 * The "aria-label" for the Dropdown.
 		 *
@@ -191,6 +193,9 @@ const DropdownBase = kind({
 		 * @type {Function}
 		 * @public
 		 */
+
+		onAdjustDirection: PropTypes.func,
+
 		onClose: PropTypes.func,
 
 		/**
@@ -319,7 +324,11 @@ const DropdownBase = kind({
 				};
 			});
 		},
-		className: ({css, direction, open, width, title, skin, styler}) => styler.append(`${width}Width`, {hasTitle: Boolean(title), open}, skin === 'silicon' ? classnames(css.dropdownButton, {[css.upDropdownButton]: direction === 'above'}) : {}),
+		className: ({adjustedDirection, css, direction, open, width, title, skin, styler}) => {
+			direction = adjustedDirection ? adjustedDirection : direction;
+			return styler.append(`${width}Width`, {hasTitle: Boolean(title), open}, skin === 'silicon' ? classnames(css.dropdownButton, {[css.upDropdownButton]: direction === 'above'}) : {});
+		},
+		adjustedDirection: ({adjustedDirection}) => `${adjustedDirection} center`,
 		direction: ({direction}) => `${direction} center`,
 		hasChildren: ({children}) => {
 			return children.length > 0;
@@ -334,13 +343,13 @@ const DropdownBase = kind({
 		}
 	},
 
-	render: ({'aria-label': ariaLabel, ariaLabelledBy, children, css, direction, disabled, hasChildren, onClose, onOpen, onSelect, open, selected, skin, title, width, ...rest}) => {
+	render: ({adjustedDirection, 'aria-label': ariaLabel, ariaLabelledBy, children, css, direction, disabled, hasChildren, onAdjustDirection, onClose, onOpen, onSelect, open, selected, skin, title, width, ...rest}) => {
 		delete rest.rtl;
 
 		const ariaProps = extractAriaProps(rest);
 		const calcAriaProps = ariaLabel != null ? null : {role: 'region', 'aria-labelledby': ariaLabelledBy};
 
-		const popupProps = {'aria-live': null, children, direction, disabled, onSelect, open, selected, skin, skinVariants: skin === 'silicon' ? {'night': false} : {}, width, role: null};
+		const popupProps = {adjustedDirection, 'aria-live': null, children, direction, disabled, onSelect, open, selected, skin, skinVariants: skin === 'silicon' ? {'night': false} : {}, width, role: null};
 
 		// `ui/Group`/`ui/Repeater` will throw an error if empty so we disable the Dropdown and
 		// prevent Dropdown to open if there are no children.
@@ -354,6 +363,7 @@ const DropdownBase = kind({
 					direction={direction}
 					disabled={hasChildren ? disabled : true}
 					icon={openDropdown ? 'arrowlargeup' : 'arrowlargedown'}
+					onAdjustDirection={onAdjustDirection}
 					onClick={onOpen}
 					onClose={onClose}
 					offset="none"
@@ -396,6 +406,7 @@ const DropdownDecorator = compose(
 		generateProp: null,
 		prefix: 'd_'
 	}),
+	Changeable({change: 'onAdjustDirection', prop: 'adjustedDirection'}),
 	Changeable({change: 'onSelect', prop: 'selected'}),
 	Toggleable({
 		activate: 'onOpen',

--- a/Dropdown/DropdownList.js
+++ b/Dropdown/DropdownList.js
@@ -46,6 +46,8 @@ const DropdownListBase = kind({
 	name: 'DropdownListBase',
 
 	propTypes: /** @lends agate/Dropdown.DropdownListBase.prototype */ {
+		adjustedDirection: PropTypes.string,
+
 		/**
 		 * The selections for Dropdown
 		 *
@@ -139,7 +141,10 @@ const DropdownListBase = kind({
 	},
 
 	computed: {
-		className: ({direction, skin, width, styler}) => styler.append(direction.substr(0, direction.indexOf(' ')), width, {dropdownListWithCustomizedScroller: skin === 'silicon'}),
+		className: ({adjustedDirection, direction, skin, width, styler}) => {
+			direction = adjustedDirection ? adjustedDirection : direction;
+			return styler.append(direction.substr(0, direction.indexOf(' ')), width, {dropdownListWithCustomizedScroller: skin === 'silicon'});
+		},
 		dataSize: ({children}) => children ? children.length : 0,
 		// Note: Retaining this in case we need to support different item sizes for large text mode:
 		itemSize: ({skin}) => (skin === 'gallium') ? ri.scale(90) : ri.scale(60)

--- a/Dropdown/DropdownList.js
+++ b/Dropdown/DropdownList.js
@@ -46,7 +46,7 @@ const DropdownListBase = kind({
 	name: 'DropdownListBase',
 
 	propTypes: /** @lends agate/Dropdown.DropdownListBase.prototype */ {
-		adjustedDirection: PropTypes.string,
+		adjusteddirection: PropTypes.string,
 
 		/**
 		 * The selections for Dropdown
@@ -141,8 +141,8 @@ const DropdownListBase = kind({
 	},
 
 	computed: {
-		className: ({adjustedDirection, direction, skin, width, styler}) => {
-			direction = adjustedDirection ? adjustedDirection : direction;
+		className: ({adjusteddirection, direction, skin, width, styler}) => {
+			direction = adjusteddirection ? adjusteddirection : direction;
 			return styler.append(direction.substr(0, direction.indexOf(' ')), width, {dropdownListWithCustomizedScroller: skin === 'silicon'});
 		},
 		dataSize: ({children}) => children ? children.length : 0,

--- a/Dropdown/DropdownList.js
+++ b/Dropdown/DropdownList.js
@@ -46,8 +46,6 @@ const DropdownListBase = kind({
 	name: 'DropdownListBase',
 
 	propTypes: /** @lends agate/Dropdown.DropdownListBase.prototype */ {
-		adjusteddirection: PropTypes.string,
-
 		/**
 		 * The selections for Dropdown
 		 *
@@ -141,10 +139,7 @@ const DropdownListBase = kind({
 	},
 
 	computed: {
-		className: ({adjusteddirection, direction, skin, width, styler}) => {
-			direction = adjusteddirection ? adjusteddirection : direction;
-			return styler.append(direction.substr(0, direction.indexOf(' ')), width, {dropdownListWithCustomizedScroller: skin === 'silicon'});
-		},
+		className: ({direction, skin, width, styler}) => styler.append(direction.substr(0, direction.indexOf(' ')), width, {dropdownListWithCustomizedScroller: skin === 'silicon'}),
 		dataSize: ({children}) => children ? children.length : 0,
 		// Note: Retaining this in case we need to support different item sizes for large text mode:
 		itemSize: ({skin}) => (skin === 'gallium') ? ri.scale(90) : ri.scale(60)

--- a/tests/screenshot/apps/components/Dropdown.js
+++ b/tests/screenshot/apps/components/Dropdown.js
@@ -17,6 +17,7 @@ const DropdownTests = [
 	<div style={{'height': '700px'}}>
 		<Dropdown direction="above" open style={{'margin-top': '300px'}} title="Select your option">{['Option 1', 'Option 2', 'Option 3']}</Dropdown>
 	</div>,
+	<Dropdown direction="above" open title="Select your option">{['Option 1', 'Option 2', 'Option 3']}</Dropdown>,
 	<Dropdown defaultSelected={1} open>{['Option 1', 'Option 2', 'Option 3']}</Dropdown>,
 	<Dropdown disabled open title="Select your option">{['Option 1', 'Option 2', 'Option 3']}</Dropdown>,
 	// long options text


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Opened dropdown is not adapted by direction in a certain skin of Agate Dropdown.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
I added 'onAdjustDirection' Changeable function and 'adjustedDirection' property to Dropdown.
'adjustedDirection' fixes the direction of the opened dropdown. 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-2635


### Comments
Enact-DCO-1.0-Signed-off-by: Jiye Kim ([jiye.kim@lge.com](mailto:jiye.kim@lge.com))
