### PR TITLE
WRQ-7452: fixed JSDoc for `scrollMode` prop of `Scroller` and `VirtualList`

### DIFF
--- a/Scroller/Scroller.js
+++ b/Scroller/Scroller.js
@@ -308,7 +308,7 @@ Scroller.propTypes = /** @lends agate/Scroller.Scroller.prototype */ {
 	 * * `'native'`.
 	 *
 	 * @type {('native'|'translate')}
-	 * @default 'translate'
+	 * @default 'native'
 	 * @public
 	 */
 	scrollMode: PropTypes.oneOf(['native', 'translate']),

--- a/VirtualList/VirtualList.js
+++ b/VirtualList/VirtualList.js
@@ -373,7 +373,7 @@ VirtualList.propTypes = /** @lends agate/VirtualList.VirtualList.prototype */ {
 	 * * `'native'`.
 	 *
 	 * @type {String}
-	 * @default 'translate'
+	 * @default 'native'
 	 * @public
 	 */
 	scrollMode: PropTypes.string,
@@ -802,7 +802,7 @@ VirtualGridList.propTypes = /** @lends agate/VirtualList.VirtualGridList.prototy
 	 * * `'native'`.
 	 *
 	 * @type {String}
-	 * @default 'translate'
+	 * @default 'native'
 	 * @public
 	 */
 	scrollMode: PropTypes.string,


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
The default value of `scrollMode` prop in `Scroller` and `VirtualList` was changed from 'translate' to 'native' in #748, but we missed to update JSDoc for it.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-7452

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)
