### PR TITLE
WRQ-19326 Removed the usage of ReactDOM.findDomNode()

### DIFF
--- a/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -271,7 +271,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 
 			this.overflow = {};
 			this.adjustedDirection = this.props.direction;
-			this.clientNode = createRef();
+			this.clientSiblingRef = createRef();
 
 			this.MARGIN = noArrow ? 0 : ri.scale(9);
 			this.ARROW_WIDTH = noArrow ? 0 : ri.scale(30); // svg arrow width. used for arrow positioning
@@ -553,9 +553,9 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 		 * @returns {undefined}
 		 */
 		positionContextualPopup = () => {
-			if (this.containerNode && this.clientNode.current) {
+			if (this.containerNode && this.clientSiblingRef?.current?.previousElementSibling) {
 				const containerNode = this.containerNode.getBoundingClientRect();
-				const {top, left, bottom, right, width, height} = this.clientNode.current.getBoundingClientRect();
+				const {top, left, bottom, right, width, height} = this.clientSiblingRef.current.previousElementSibling.getBoundingClientRect();
 				const clientNode = {top, left, bottom, right, width, height};
 				clientNode.left = this.props.rtl ? window.innerWidth - right : left;
 				clientNode.right = this.props.rtl ? window.innerWidth - left : right;
@@ -725,9 +725,10 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 							<PopupComponent {...popupPropsRef} />
 						</ContextualPopupContainer>
 					</FloatingLayer>
-					<div ref={this.clientNode}>
+					<>
 						<Wrapped {...rest} />
-					</div>
+						<div style={{display: 'none'}} ref={this.clientSiblingRef} />
+					</>
 				</div>
 			);
 		}

--- a/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -19,8 +19,7 @@ import FloatingLayer from '@enact/ui/FloatingLayer';
 import ri from '@enact/ui/resolution';
 import PropTypes from 'prop-types';
 import compose from 'ramda/src/compose';
-import {Component} from 'react';
-import ReactDOM from 'react-dom';
+import {Component, createRef} from 'react';
 
 import {ContextualPopup} from './ContextualPopup';
 
@@ -272,6 +271,7 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 
 			this.overflow = {};
 			this.adjustedDirection = this.props.direction;
+			this.clientNode = createRef();
 
 			this.MARGIN = noArrow ? 0 : ri.scale(9);
 			this.ARROW_WIDTH = noArrow ? 0 : ri.scale(30); // svg arrow width. used for arrow positioning
@@ -553,9 +553,9 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 		 * @returns {undefined}
 		 */
 		positionContextualPopup = () => {
-			if (this.containerNode && this.clientNode) {
+			if (this.containerNode && this.clientNode.current) {
 				const containerNode = this.containerNode.getBoundingClientRect();
-				const {top, left, bottom, right, width, height} = this.clientNode.getBoundingClientRect();
+				const {top, left, bottom, right, width, height} = this.clientNode.current.getBoundingClientRect();
 				const clientNode = {top, left, bottom, right, width, height};
 				clientNode.left = this.props.rtl ? window.innerWidth - right : left;
 				clientNode.right = this.props.rtl ? window.innerWidth - left : right;
@@ -576,10 +576,6 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		getContainerNode = (node) => {
 			this.containerNode = node;
-		};
-
-		getClientNode = (node) => {
-			this.clientNode = ReactDOM.findDOMNode(node); // eslint-disable-line react/no-find-dom-node
 		};
 
 		handle = handle.bind(this);
@@ -729,7 +725,9 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 							<PopupComponent {...popupPropsRef} />
 						</ContextualPopupContainer>
 					</FloatingLayer>
-					<Wrapped ref={this.getClientNode} {...rest} />
+					<div ref={this.clientNode}>
+						<Wrapped {...rest} />
+					</div>
 				</div>
 			);
 		}

--- a/Dropdown/Dropdown.js
+++ b/Dropdown/Dropdown.js
@@ -54,7 +54,7 @@ const DropdownButtonBase = kind({
 
 	propTypes: /** @lends agate/Dropdown.DropdownButtonBase.prototype */ {
 		/**
-		 * Forwards a reference to the this component.
+		 * Forwards a reference to this component.
 		 *
 		 * @type {Object|Function}
 		 * @private

--- a/Dropdown/DropdownList.js
+++ b/Dropdown/DropdownList.js
@@ -152,13 +152,13 @@ const DropdownListBase = kind({
 		itemSize: ({skin}) => (skin === 'gallium') ? ri.scale(90) : ri.scale(60)
 	},
 
-	render: ({componentRef, dataSize, itemRenderer, itemSize, scrollTo, ...rest}) => {
+	render: ({clientSiblingRef, dataSize, itemRenderer, itemSize, scrollTo, ...rest}) => {
 		delete rest.width;
 		delete rest.direction;
 		delete rest.skin;
 
 		return (
-			<div ref={componentRef}>
+			<>
 				<VirtualList
 					{...rest}
 					cbScrollTo={scrollTo}
@@ -167,7 +167,8 @@ const DropdownListBase = kind({
 					itemRenderer={itemRenderer}
 					itemSize={itemSize}
 				/>
-			</div>
+				<div style={{display: 'none'}} ref={clientSiblingRef}/>
+			</>
 		);
 	}
 });
@@ -224,7 +225,7 @@ const DropdownListSpotlightDecorator = hoc((config, Wrapped) => {
 		}
 
 		componentDidMount () {
-			Spotlight.set(this.componentRef.current.dataset.spotlightId, {
+			Spotlight.set(this.componentRef.current.previousElementSibling.dataset.spotlightId, {
 				defaultElement: '[data-selected="true"]',
 				enterTo: 'default-element'
 			});
@@ -296,7 +297,7 @@ const DropdownListSpotlightDecorator = hoc((config, Wrapped) => {
 		handleFocus = (ev) => {
 			const current = ev.target;
 			if (this.state.ready === ReadyState.DONE && !Spotlight.getPointerMode() &&
-				current.dataset['index'] != null && this.componentRef.current.contains(current)
+				current.dataset['index'] != null && this.componentRef.current.previousElementSibling.contains(current)
 			) {
 				const focusedIndex = Number(current.dataset['index']);
 				const lastFocusedKey = getKey({children: this.props.children, selected: focusedIndex});
@@ -312,7 +313,7 @@ const DropdownListSpotlightDecorator = hoc((config, Wrapped) => {
 			return (
 				<Wrapped
 					{...this.props}
-					componentRef={this.componentRef}
+					clientSiblingRef={this.componentRef}
 					onFocus={this.handleFocus}
 					scrollTo={this.setScrollTo}
 				/>

--- a/Dropdown/DropdownList.js
+++ b/Dropdown/DropdownList.js
@@ -64,7 +64,7 @@ const DropdownListBase = kind({
 		 * @type {Object|Function}
 		 * @public
 		 */
-		componentRef: EnactPropTypes.ref,
+		clientSiblingRef: EnactPropTypes.ref,
 
 		/**
 		 * Placement of the Dropdown List.
@@ -167,7 +167,7 @@ const DropdownListBase = kind({
 					itemRenderer={itemRenderer}
 					itemSize={itemSize}
 				/>
-				<div style={{display: 'none'}} ref={clientSiblingRef}/>
+				<div style={{display: 'none'}} ref={clientSiblingRef} />
 			</>
 		);
 	}

--- a/Dropdown/DropdownList.js
+++ b/Dropdown/DropdownList.js
@@ -166,7 +166,6 @@ const DropdownListBase = kind({
 					focusableScrollbar
 					itemRenderer={itemRenderer}
 					itemSize={itemSize}
-					virtualListRef={componentRef}
 				/>
 			</div>
 		);
@@ -225,7 +224,6 @@ const DropdownListSpotlightDecorator = hoc((config, Wrapped) => {
 		}
 
 		componentDidMount () {
-			console.log(this.componentRef)
 			Spotlight.set(this.componentRef.current.dataset.spotlightId, {
 				defaultElement: '[data-selected="true"]',
 				enterTo: 'default-element'

--- a/VirtualList/VirtualList.js
+++ b/VirtualList/VirtualList.js
@@ -6,7 +6,6 @@
  * @exports VirtualList
  */
 
-import EnactPropTypes from '@enact/core/internal/prop-types';
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import {ResizeContext} from '@enact/ui/Resizable';
@@ -31,7 +30,7 @@ const nop = () => {};
  * @ui
  * @public
  */
-let VirtualList = ({itemSize, role, virtualListRef, ...rest}) => {
+let VirtualList = ({itemSize, role, ...rest}) => {
 	const props = itemSize && itemSize.minSize ?
 		{
 			itemSize: itemSize.minSize,
@@ -73,7 +72,7 @@ let VirtualList = ({itemSize, role, virtualListRef, ...rest}) => {
 
 	return (
 		<ResizeContext.Provider {...resizeContextProps}>
-			<div ref={virtualListRef} {...scrollContainerProps}>
+			<div {...scrollContainerProps}>
 				<div {...scrollInnerContainerProps}>
 					<ScrollContentWrapper {...scrollContentWrapperProps}>
 						<UiVirtualListBasic {...themeScrollContentProps} ref={scrollContentHandle} />
@@ -418,14 +417,6 @@ VirtualList.propTypes = /** @lends agate/VirtualList.VirtualList.prototype */ {
 	 * @public
 	 */
 	verticalScrollbar: PropTypes.oneOf(['auto', 'visible', 'hidden']),
-
-	/**
-	 * Called with the reference to the virtualList node.
-	 *
-	 * @type {Object|Function}
-	 * @public
-	 */
-	virtualListRef: EnactPropTypes.ref,
 
 	/**
 	 * When it's `true` and the spotlight focus cannot move to the given direction anymore by 5-way keys,

--- a/VirtualList/VirtualList.js
+++ b/VirtualList/VirtualList.js
@@ -6,6 +6,7 @@
  * @exports VirtualList
  */
 
+import EnactPropTypes from '@enact/core/internal/prop-types';
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import {ResizeContext} from '@enact/ui/Resizable';
@@ -30,7 +31,7 @@ const nop = () => {};
  * @ui
  * @public
  */
-let VirtualList = ({itemSize, role, ...rest}) => {
+let VirtualList = ({itemSize, role, virtualListRef, ...rest}) => {
 	const props = itemSize && itemSize.minSize ?
 		{
 			itemSize: itemSize.minSize,
@@ -72,7 +73,7 @@ let VirtualList = ({itemSize, role, ...rest}) => {
 
 	return (
 		<ResizeContext.Provider {...resizeContextProps}>
-			<div {...scrollContainerProps}>
+			<div ref={virtualListRef} {...scrollContainerProps}>
 				<div {...scrollInnerContainerProps}>
 					<ScrollContentWrapper {...scrollContentWrapperProps}>
 						<UiVirtualListBasic {...themeScrollContentProps} ref={scrollContentHandle} />
@@ -417,6 +418,14 @@ VirtualList.propTypes = /** @lends agate/VirtualList.VirtualList.prototype */ {
 	 * @public
 	 */
 	verticalScrollbar: PropTypes.oneOf(['auto', 'visible', 'hidden']),
+
+	/**
+	 * Called with the reference to the virtualList node.
+	 *
+	 * @type {Object|Function}
+	 * @public
+	 */
+	virtualListRef: EnactPropTypes.ref,
 
 	/**
 	 * When it's `true` and the spotlight focus cannot move to the given direction anymore by 5-way keys,

--- a/VirtualList/VirtualList.js
+++ b/VirtualList/VirtualList.js
@@ -6,6 +6,7 @@
  * @exports VirtualList
  */
 
+import EnactPropTypes from '@enact/core/internal/prop-types';
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import {ResizeContext} from '@enact/ui/Resizable';
@@ -30,8 +31,52 @@ const nop = () => {};
  * @ui
  * @public
  */
-let VirtualList = ({itemSize, role, ...rest}) => {
-	const props = itemSize && itemSize.minSize ?
+// let VirtualList = ({itemSize, role, ...rest}) => {
+let VirtualList = (props) => {
+
+	const {
+		'data-spotlight-container-disabled': spotlightContainerDisabled =  false,
+		cbScrollTo = nop,
+		direction = 'vertical',
+		focusableScrollbar = false,
+		horizontalScrollbar = 'auto',
+		itemSize,
+		noScrollByWheel = false,
+		onScroll = nop,
+		onScrollStart = nop,
+		onScrollStop = nop,
+		pageScroll = false,
+		preventBubblingOnKeyDown = 'programmatic',
+		ref,
+		role = 'list',
+		scrollMode = 'native',
+		verticalScrollbar = 'auto',
+		wrap = false,
+		...rest
+	} = props;
+
+
+	const virtualListProps  = {
+		'data-spotlight-container-disabled': spotlightContainerDisabled,
+		cbScrollTo,
+		direction,
+		focusableScrollbar,
+		horizontalScrollbar,
+		noScrollByWheel,
+		onScroll,
+		onScrollStart,
+		onScrollStop,
+		pageScroll,
+		preventBubblingOnKeyDown,
+		ref,
+		role,
+		scrollMode,
+		verticalScrollbar,
+		wrap,
+		...rest
+	};
+
+	const itemSizeProps = itemSize && itemSize.minSize ?
 		{
 			itemSize: itemSize.minSize,
 			itemSizes: itemSize.size
@@ -41,7 +86,7 @@ let VirtualList = ({itemSize, role, ...rest}) => {
 		};
 
 	warning(
-		!rest.itemSizes || !rest.cbScrollTo,
+		!virtualListProps.itemSizes || !cbScrollTo,
 		'VirtualList with `minSize` in `itemSize` prop does not support `cbScrollTo` prop'
 	);
 
@@ -62,7 +107,7 @@ let VirtualList = ({itemSize, role, ...rest}) => {
 		scrollContentProps,
 		verticalScrollbarProps,
 		horizontalScrollbarProps
-	} = useScroll({...rest, ...props});
+	} = useScroll({...virtualListProps, ...itemSizeProps});
 
 	const themeScrollContentProps = useThemeVirtualList({
 		...scrollContentProps,
@@ -72,7 +117,7 @@ let VirtualList = ({itemSize, role, ...rest}) => {
 
 	return (
 		<ResizeContext.Provider {...resizeContextProps}>
-			<div {...scrollContainerProps}>
+			<div ref={ref} {...scrollContainerProps}>
 				<div {...scrollInnerContainerProps}>
 					<ScrollContentWrapper {...scrollContentWrapperProps}>
 						<UiVirtualListBasic {...themeScrollContentProps} ref={scrollContentHandle} />
@@ -339,6 +384,14 @@ VirtualList.propTypes = /** @lends agate/VirtualList.VirtualList.prototype */ {
 	preventBubblingOnKeyDown: PropTypes.oneOf(['none', 'programmatic']),
 
 	/**
+	 * Returns a ref to the root node of the virtual list
+	 *
+	 * @type {Component}
+	 * @private
+	 */
+	ref: EnactPropTypes.component,
+
+	/**
 	 * The ARIA role for the list.
 	 *
 	 * @type {String}
@@ -453,24 +506,6 @@ VirtualList = Skinnable(
 	)
 );
 
-VirtualList.defaultProps = {
-	'data-spotlight-container-disabled': false,
-	cbScrollTo: nop,
-	direction: 'vertical',
-	focusableScrollbar: false,
-	horizontalScrollbar: 'auto',
-	noScrollByWheel: false,
-	onScroll: nop,
-	onScrollStart: nop,
-	onScrollStop: nop,
-	pageScroll: false,
-	preventBubblingOnKeyDown: 'programmatic',
-	role: 'list',
-	scrollMode: 'native',
-	verticalScrollbar: 'auto',
-	wrap: false
-};
-
 /**
  * An Agate-styled scrollable and spottable virtual grid list component.
  *
@@ -480,7 +515,45 @@ VirtualList.defaultProps = {
  * @ui
  * @public
  */
-let VirtualGridList = ({role, ...rest}) => {
+// let VirtualGridList = ({role, ...rest}) => {
+let VirtualGridList = (props) => {
+	const {
+		'data-spotlight-container-disabled': spotlightContainerDisabled =  false,
+		cbScrollTo = nop,
+		direction = 'vertical',
+		focusableScrollbar = false,
+		horizontalScrollbar = 'auto',
+		noScrollByWheel = false,
+		onScroll = nop,
+		onScrollStart = nop,
+		onScrollStop = nop,
+		pageScroll = false,
+		preventBubblingOnKeyDown = 'programmatic',
+		role = 'list',
+		scrollMode = 'native',
+		verticalScrollbar = 'auto',
+		wrap = false,
+		...rest
+	} = props;
+
+	const virtualGridListProps = {
+		'data-spotlight-container-disabled': spotlightContainerDisabled,
+		cbScrollTo,
+		direction,
+		focusableScrollbar,
+		horizontalScrollbar,
+		noScrollByWheel,
+		onScroll,
+		onScrollStart,
+		onScrollStop,
+		pageScroll,
+		preventBubblingOnKeyDown,
+		scrollMode,
+		verticalScrollbar,
+		wrap,
+		...rest
+	};
+
 	const {
 		// Variables
 		scrollContentWrapper: ScrollContentWrapper,
@@ -496,7 +569,7 @@ let VirtualGridList = ({role, ...rest}) => {
 		scrollContentProps,
 		verticalScrollbarProps,
 		horizontalScrollbarProps
-	} = useScroll(rest);
+	} = useScroll(virtualGridListProps);
 
 	const themeScrollContentProps = useThemeVirtualList({
 		...scrollContentProps,
@@ -882,24 +955,6 @@ VirtualGridList = Skinnable(
 		)
 	)
 );
-
-VirtualGridList.defaultProps = {
-	'data-spotlight-container-disabled': false,
-	cbScrollTo: nop,
-	direction: 'vertical',
-	focusableScrollbar: false,
-	horizontalScrollbar: 'auto',
-	noScrollByWheel: false,
-	onScroll: nop,
-	onScrollStart: nop,
-	onScrollStop: nop,
-	pageScroll: false,
-	preventBubblingOnKeyDown: 'programmatic',
-	role: 'list',
-	scrollMode: 'native',
-	verticalScrollbar: 'auto',
-	wrap: false
-};
 
 export default VirtualList;
 export {

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     "invariant": "^2.2.4",
     "prop-types": "^15.8.1",
     "ramda": "^0.29.1",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "rc",
+    "react-dom": "rc",
     "warning": "^4.0.3",
     "ilib": "^14.20.0"
   },

--- a/samples/event-logger/package.json
+++ b/samples/event-logger/package.json
@@ -30,8 +30,8 @@
 		"@reduxjs/toolkit": "^2.2.3",
 		"ilib": "^14.20.0",
 		"prop-types": "^15.8.1",
-		"react": "^18.2.0",
-		"react-dom": "^18.2.0",
+		"react": "rc",
+		"react-dom": "rc",
 		"react-redux": "^9.1.1",
 		"redux": "^5.0.1"
 	}

--- a/samples/perf-scroller-native/package.json
+++ b/samples/perf-scroller-native/package.json
@@ -29,7 +29,7 @@
     "@enact/ui": "^4.8.0",
     "classnames": "^2.5.1",
     "ilib": "^14.20.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "rc",
+    "react-dom": "rc"
   }
 }

--- a/samples/perf-scroller-translate/package.json
+++ b/samples/perf-scroller-translate/package.json
@@ -30,7 +30,7 @@
     "@enact/ui": "^4.8.0",
     "classnames": "^2.5.1",
     "ilib": "^14.20.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "rc",
+    "react-dom": "rc"
   }
 }

--- a/samples/perf-virtualgridlist-native/package.json
+++ b/samples/perf-virtualgridlist-native/package.json
@@ -28,7 +28,7 @@
     "@enact/spotlight": "^4.8.0",
     "@enact/ui": "^4.8.0",
     "ilib": "^14.20.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "rc",
+    "react-dom": "rc"
   }
 }

--- a/samples/perf-virtualgridlist-translate/package.json
+++ b/samples/perf-virtualgridlist-translate/package.json
@@ -28,7 +28,7 @@
     "@enact/spotlight": "^4.8.0",
     "@enact/ui": "^4.8.0",
     "ilib": "^14.20.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "rc",
+    "react-dom": "rc"
   }
 }

--- a/samples/perf-virtuallist-native-with-different-item-size/package.json
+++ b/samples/perf-virtuallist-native-with-different-item-size/package.json
@@ -28,7 +28,7 @@
     "@enact/spotlight": "^4.8.0",
     "@enact/ui": "^4.8.0",
     "ilib": "^14.20.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "rc",
+    "react-dom": "rc"
   }
 }

--- a/samples/perf-virtuallist-native/package.json
+++ b/samples/perf-virtuallist-native/package.json
@@ -28,7 +28,7 @@
     "@enact/spotlight": "^4.8.0",
     "@enact/ui": "^4.8.0",
     "ilib": "^14.20.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "rc",
+    "react-dom": "rc"
   }
 }

--- a/samples/perf-virtuallist-translate/package.json
+++ b/samples/perf-virtuallist-translate/package.json
@@ -28,7 +28,7 @@
     "@enact/spotlight": "^4.8.0",
     "@enact/ui": "^4.8.0",
     "ilib": "^14.20.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "rc",
+    "react-dom": "rc"
   }
 }

--- a/samples/qa-a11y/package.json
+++ b/samples/qa-a11y/package.json
@@ -30,7 +30,7 @@
     "@enact/webos": "^4.8.0",
     "ilib": "^14.20.0",
     "prop-types": "^15.8.1",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "rc",
+    "react-dom": "rc"
   }
 }

--- a/samples/qa-drag-and-drop/package.json
+++ b/samples/qa-drag-and-drop/package.json
@@ -30,7 +30,7 @@
     "@enact/webos": "^4.8.0",
     "ilib": "^14.20.0",
     "prop-types": "^15.8.1",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "rc",
+    "react-dom": "rc"
   }
 }

--- a/samples/qa-dropdown/package.json
+++ b/samples/qa-dropdown/package.json
@@ -29,7 +29,7 @@
     "@enact/ui": "^4.8.0",
     "ilib": "^14.20.0",
     "prop-types": "^15.8.1",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "rc",
+    "react-dom": "rc"
   }
 }

--- a/samples/qa-fonts/package.json
+++ b/samples/qa-fonts/package.json
@@ -29,7 +29,7 @@
     "@enact/ui": "^4.8.0",
     "ilib": "^14.20.0",
     "prop-types": "^15.8.1",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "rc",
+    "react-dom": "rc"
   }
 }

--- a/samples/qa-i18n-async/package.json
+++ b/samples/qa-i18n-async/package.json
@@ -29,7 +29,7 @@
     "@enact/ui": "^4.8.0",
     "ilib": "^14.20.0",
     "prop-types": "^15.8.1",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "rc",
+    "react-dom": "rc"
   }
 }

--- a/samples/qa-i18n/package.json
+++ b/samples/qa-i18n/package.json
@@ -30,7 +30,7 @@
     "@enact/webos": "^4.8.0",
     "ilib": "^14.20.0",
     "prop-types": "^15.8.1",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "rc",
+    "react-dom": "rc"
   }
 }

--- a/samples/qa-scroller/package.json
+++ b/samples/qa-scroller/package.json
@@ -29,7 +29,7 @@
     "@enact/ui": "^4.8.0",
     "ilib": "^14.20.0",
     "prop-types": "^15.8.1",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "rc",
+    "react-dom": "rc"
   }
 }

--- a/samples/qa-virtualgridlist/package.json
+++ b/samples/qa-virtualgridlist/package.json
@@ -30,8 +30,8 @@
     "@reduxjs/toolkit": "^2.2.3",
     "ilib": "^14.20.0",
     "prop-types": "^15.8.1",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "rc",
+    "react-dom": "rc",
     "react-redux": "^9.1.1",
     "redux": "^5.0.1"
   }

--- a/samples/qa-virtualgridlistnative-preserve-focus/package.json
+++ b/samples/qa-virtualgridlistnative-preserve-focus/package.json
@@ -30,8 +30,8 @@
     "@reduxjs/toolkit": "^2.2.3",
     "ilib": "^14.20.0",
     "prop-types": "^15.8.1",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "rc",
+    "react-dom": "rc",
     "react-redux": "^9.1.1",
     "redux": "^5.0.1"
   }

--- a/samples/qa-virtuallist/package.json
+++ b/samples/qa-virtuallist/package.json
@@ -30,8 +30,8 @@
     "@reduxjs/toolkit": "^2.2.3",
     "ilib": "^14.20.0",
     "prop-types": "^15.8.1",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "rc",
+    "react-dom": "rc",
     "react-redux": "^9.1.1",
     "redux": "^5.0.1"
   }

--- a/samples/sampler/stories/default/Scroller.js
+++ b/samples/sampler/stories/default/Scroller.js
@@ -22,7 +22,7 @@ export default {
 
 export const _Scroller = (args) => (
 	<Scroller
-		direction="vertical"
+		direction={args['direction']}
 		focusableScrollbar={args['focusableScrollbar']}
 		horizontalScrollbar={args['horizontalScrollbar']}
 		key={args['scrollMode']}

--- a/samples/sampler/stories/default/Scroller.js
+++ b/samples/sampler/stories/default/Scroller.js
@@ -22,7 +22,7 @@ export default {
 
 export const _Scroller = (args) => (
 	<Scroller
-		direction={args['direction']}
+		direction="vertical"
 		focusableScrollbar={args['focusableScrollbar']}
 		horizontalScrollbar={args['horizontalScrollbar']}
 		key={args['scrollMode']}

--- a/useScroll/ScrollButton.js
+++ b/useScroll/ScrollButton.js
@@ -1,7 +1,6 @@
-import ForwardRef from '@enact/ui/ForwardRef';
+import EnactPropTypes from '@enact/core/internal/prop-types';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
-import {useEffect, useRef} from 'react';
 
 import Button from '../Button';
 
@@ -17,46 +16,27 @@ import css from './Scrollbar.module.less';
  * @ui
  * @private
  */
-const ScrollButtonBase = ({active, 'aria-label': ariaLabel, className, forwardRef, ...rest}) => {
-	const clientSiblingRef = useRef();
-
+const ScrollButton = ({active, 'aria-label': ariaLabel, className, ref, ...rest}) => {
 	const calculateAriaLabel = () => {
 		return (active ? null : ariaLabel);
 	};
 
-	useEffect(() => {
-		const current = clientSiblingRef?.current?.previousElementSibling;
-
-		// Safely handle old ref functions and new ref objects
-		switch (typeof forwardRef) {
-			case 'object':
-				forwardRef.current = current;
-				break;
-			case 'function':
-				forwardRef(current);
-				break;
-		}
-	}, [forwardRef]);
-
 	return (
-		<>
-			<Button
-				{...rest}
-				aria-label={calculateAriaLabel()}
-				backgroundOpacity="transparent"
-				className={classnames(className, css.scrollButton)}
-				css={css}
-				ref={forwardRef}
-				size="small"
-			/>
-			<div style={{display: 'none'}} ref={clientSiblingRef} />
-		</>
+		<Button
+			{...rest}
+			aria-label={calculateAriaLabel()}
+			backgroundOpacity="transparent"
+			className={classnames(className, css.scrollButton)}
+			css={css}
+			ref={ref}
+			size="small"
+		/>
 	);
 };
 
-ScrollButtonBase.displayName = 'ScrollButton';
+ScrollButton.displayName = 'ScrollButton';
 
-ScrollButtonBase.propTypes = /** @lends agate/useScroll.ScrollButton.prototype */ {
+ScrollButton.propTypes = /** @lends agate/useScroll.ScrollButton.prototype */ {
 	/**
 	 * Name of icon.
 	 *
@@ -93,20 +73,13 @@ ScrollButtonBase.propTypes = /** @lends agate/useScroll.ScrollButton.prototype *
 	disabled: PropTypes.bool,
 
 	/**
-	 * Returns a ref to the root node of the scroll button
+	 * Returns a ref to the root node of the component
 	 *
-	 * See: https://github.com/facebook/prop-types/issues/240
-	 *
-	 * @type {Function|Object}
+	 * @type {Component}
 	 * @private
 	 */
-	forwardRef: PropTypes.oneOfType([
-		PropTypes.func,
-		PropTypes.shape({current: PropTypes.any})
-	])
+	ref: EnactPropTypes.component
 };
-
-const ScrollButton = ForwardRef(ScrollButtonBase);
 
 export default ScrollButton;
 export {

--- a/useScroll/ScrollButton.js
+++ b/useScroll/ScrollButton.js
@@ -41,11 +41,11 @@ const ScrollButtonBase = ({active, 'aria-label': ariaLabel, className, forwardRe
 	return (
 		<>
 			<Button
-				aria-label={calculateAriaLabel()}
-				css={css}
-				className={classnames(className, css.scrollButton)}
 				{...rest}
+				aria-label={calculateAriaLabel()}
 				backgroundOpacity="transparent"
+				className={classnames(className, css.scrollButton)}
+				css={css}
 				ref={forwardRef}
 				size="small"
 			/>

--- a/useScroll/ScrollButton.js
+++ b/useScroll/ScrollButton.js
@@ -1,6 +1,8 @@
 import kind from '@enact/core/kind';
 import ForwardRef from '@enact/ui/ForwardRef';
+import classnames from 'classnames';
 import PropTypes from 'prop-types';
+import {useRef} from 'react';
 import ReactDOM from 'react-dom';
 
 import Button from '../Button';
@@ -111,7 +113,128 @@ const ScrollButtonBase = kind({
 	}
 });
 
-const ScrollButton = ForwardRef(ScrollButtonBase);
+const ScrollButtonBase1 = ({active, 'aria-label': ariaLabel, className, forwardRef, ...rest}) => {
+	// styles: {
+	// 	css,
+	// 	className: 'scrollButton'
+	// },
+	//
+	// handlers: {
+	// 	forwardRef: (node, {forwardRef}) => {
+	// 		// Allowing findDOMNode in the absence of a means to retrieve a node ref through Button
+	// 		// eslint-disable-next-line react/no-find-dom-node
+	// 		const current = ReactDOM.findDOMNode(node);
+	// 		console.log(current);
+	//
+	// 		// Safely handle old ref functions and new ref objects
+	// 		switch (typeof forwardRef) {
+	// 			case 'object':
+	// 				forwardRef.current = current;
+	// 				break;
+	// 			case 'function':
+	// 				forwardRef(current);
+	// 				break;
+	// 		}
+	// 	}
+	// },
+	//
+	// computed: {
+	// 	'aria-label': ({active, 'aria-label': ariaLabel}) => (active ? null : ariaLabel)
+	// },
+
+	// render: ({forwardRef, ...rest}) => {
+	// 	delete rest.active;
+
+	const buttonRef = useRef();
+
+	const calculateAriaLabel = () => {return (active ? null : ariaLabel)};
+
+	const calculateForwardRef = (node) => {
+		// Allowing findDOMNode in the absence of a means to retrieve a node ref through Button
+		// eslint-disable-next-line react/no-find-dom-node
+		const current = buttonRef.current;
+		console.log(current);
+		console.log(forwardRef);
+console.log(typeof forwardRef)
+
+		// Safely handle old ref functions and new ref objects
+		switch (typeof forwardRef) {
+			case 'object':
+				forwardRef.current = current;
+				break;
+			case 'function':
+				forwardRef(current);
+				break;
+		}
+	};
+
+	return (
+		<Button
+			aria-label={calculateAriaLabel()}
+			css={css}
+			className={classnames(className, css.scrollButton)}
+			{...rest}
+			backgroundOpacity="transparent"
+			ref={calculateForwardRef()}
+			size="small"
+		/>
+	);
+	//}
+};
+
+ScrollButtonBase1.displayName = 'ScrollButton';
+
+ScrollButtonBase1.propTypes = /** @lends agate/useScroll.ScrollButton.prototype */ {
+	/**
+	 * Name of icon.
+	 *
+	 * @type {String}
+	 * @required
+	 * @public
+	 */
+	icon: PropTypes.string.isRequired,
+
+	/**
+	 * Sets the `aria-label`.
+	 *
+	 * @type {Boolean}
+	 * @default false
+	 * @public
+	 */
+	active: PropTypes.bool,
+
+	/**
+	 * Sets the hint string read when focusing the scroll bar button.
+	 *
+	 * @type {String}
+	 * @memberof agate/useScroll.ScrollButton.prototype
+	 * @public
+	 */
+	'aria-label': PropTypes.string,
+
+	/**
+	 * Disables the button.
+	 *
+	 * @type {Boolean}
+	 * @public
+	 */
+	disabled: PropTypes.bool,
+
+	/**
+	 * Returns a ref to the root node of the scroll button
+	 *
+	 * See: https://github.com/facebook/prop-types/issues/240
+	 *
+	 * @type {Function|Object}
+	 * @private
+	 */
+	forwardRef: PropTypes.oneOfType([
+		PropTypes.func,
+		PropTypes.shape({current: PropTypes.any})
+	])
+}
+
+const ScrollButton = ForwardRef(ScrollButtonBase1);
 
 export default ScrollButton;
 export {

--- a/useScroll/ScrollButton.js
+++ b/useScroll/ScrollButton.js
@@ -49,7 +49,7 @@ const ScrollButtonBase = ({active, 'aria-label': ariaLabel, className, forwardRe
 				ref={forwardRef}
 				size="small"
 			/>
-			<div style={{display: 'none'}} ref={clientSiblingRef}/>
+			<div style={{display: 'none'}} ref={clientSiblingRef} />
 		</>
 	);
 	// }

--- a/useScroll/ScrollButton.js
+++ b/useScroll/ScrollButton.js
@@ -1,9 +1,7 @@
-import kind from '@enact/core/kind';
 import ForwardRef from '@enact/ui/ForwardRef';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
-import {useRef} from 'react';
-import ReactDOM from 'react-dom';
+import {useEffect, useRef} from 'react';
 
 import Button from '../Button';
 
@@ -19,143 +17,15 @@ import css from './Scrollbar.module.less';
  * @ui
  * @private
  */
-const ScrollButtonBase = kind({
-	name: 'ScrollButton',
+const ScrollButtonBase = ({active, 'aria-label': ariaLabel, className, forwardRef, ...rest}) => {
+	const clientSiblingRef = useRef();
 
-	propTypes: /** @lends agate/useScroll.ScrollButton.prototype */ {
-		/**
-		 * Name of icon.
-		 *
-		 * @type {String}
-		 * @required
-		 * @public
-		 */
-		icon: PropTypes.string.isRequired,
+	const calculateAriaLabel = () => {
+		return (active ? null : ariaLabel);
+	};
 
-		/**
-		 * Sets the `aria-label`.
-		 *
-		 * @type {Boolean}
-		 * @default false
-		 * @public
-		 */
-		active: PropTypes.bool,
-
-		/**
-		 * Sets the hint string read when focusing the scroll bar button.
-		 *
-		 * @type {String}
-		 * @memberof agate/useScroll.ScrollButton.prototype
-		 * @public
-		 */
-		'aria-label': PropTypes.string,
-
-		/**
-		 * Disables the button.
-		 *
-		 * @type {Boolean}
-		 * @public
-		 */
-		disabled: PropTypes.bool,
-
-		/**
-		 * Returns a ref to the root node of the scroll button
-		 *
-		 * See: https://github.com/facebook/prop-types/issues/240
-		 *
-		 * @type {Function|Object}
-		 * @private
-		 */
-		forwardRef: PropTypes.oneOfType([
-			PropTypes.func,
-			PropTypes.shape({current: PropTypes.any})
-		])
-	},
-
-	styles: {
-		css,
-		className: 'scrollButton'
-	},
-
-	handlers: {
-		forwardRef: (node, {forwardRef}) => {
-			// Allowing findDOMNode in the absence of a means to retrieve a node ref through Button
-			// eslint-disable-next-line react/no-find-dom-node
-			const current = ReactDOM.findDOMNode(node);
-
-			// Safely handle old ref functions and new ref objects
-			switch (typeof forwardRef) {
-				case 'object':
-					forwardRef.current = current;
-					break;
-				case 'function':
-					forwardRef(current);
-					break;
-			}
-		}
-	},
-
-	computed: {
-		'aria-label': ({active, 'aria-label': ariaLabel}) => (active ? null : ariaLabel)
-	},
-
-	render: ({forwardRef, ...rest}) => {
-		delete rest.active;
-
-		return (
-			<Button
-				{...rest}
-				backgroundOpacity="transparent"
-				ref={forwardRef}
-				size="small"
-			/>
-		);
-	}
-});
-
-const ScrollButtonBase1 = ({active, 'aria-label': ariaLabel, className, forwardRef, ...rest}) => {
-	// styles: {
-	// 	css,
-	// 	className: 'scrollButton'
-	// },
-	//
-	// handlers: {
-	// 	forwardRef: (node, {forwardRef}) => {
-	// 		// Allowing findDOMNode in the absence of a means to retrieve a node ref through Button
-	// 		// eslint-disable-next-line react/no-find-dom-node
-	// 		const current = ReactDOM.findDOMNode(node);
-	// 		console.log(current);
-	//
-	// 		// Safely handle old ref functions and new ref objects
-	// 		switch (typeof forwardRef) {
-	// 			case 'object':
-	// 				forwardRef.current = current;
-	// 				break;
-	// 			case 'function':
-	// 				forwardRef(current);
-	// 				break;
-	// 		}
-	// 	}
-	// },
-	//
-	// computed: {
-	// 	'aria-label': ({active, 'aria-label': ariaLabel}) => (active ? null : ariaLabel)
-	// },
-
-	// render: ({forwardRef, ...rest}) => {
-	// 	delete rest.active;
-
-	const buttonRef = useRef();
-
-	const calculateAriaLabel = () => {return (active ? null : ariaLabel)};
-
-	const calculateForwardRef = (node) => {
-		// Allowing findDOMNode in the absence of a means to retrieve a node ref through Button
-		// eslint-disable-next-line react/no-find-dom-node
-		const current = buttonRef.current;
-		console.log(current);
-		console.log(forwardRef);
-console.log(typeof forwardRef)
+	useEffect(() => {
+		const current = clientSiblingRef?.current?.previousElementSibling;
 
 		// Safely handle old ref functions and new ref objects
 		switch (typeof forwardRef) {
@@ -166,25 +36,28 @@ console.log(typeof forwardRef)
 				forwardRef(current);
 				break;
 		}
-	};
+	}, [forwardRef]);
 
 	return (
-		<Button
-			aria-label={calculateAriaLabel()}
-			css={css}
-			className={classnames(className, css.scrollButton)}
-			{...rest}
-			backgroundOpacity="transparent"
-			ref={calculateForwardRef()}
-			size="small"
-		/>
+		<>
+			<Button
+				aria-label={calculateAriaLabel()}
+				css={css}
+				className={classnames(className, css.scrollButton)}
+				{...rest}
+				backgroundOpacity="transparent"
+				ref={forwardRef}
+				size="small"
+			/>
+			<div style={{display: 'none'}} ref={clientSiblingRef}/>
+		</>
 	);
-	//}
+	// }
 };
 
-ScrollButtonBase1.displayName = 'ScrollButton';
+ScrollButtonBase.displayName = 'ScrollButton';
 
-ScrollButtonBase1.propTypes = /** @lends agate/useScroll.ScrollButton.prototype */ {
+ScrollButtonBase.propTypes = /** @lends agate/useScroll.ScrollButton.prototype */ {
 	/**
 	 * Name of icon.
 	 *
@@ -232,9 +105,9 @@ ScrollButtonBase1.propTypes = /** @lends agate/useScroll.ScrollButton.prototype 
 		PropTypes.func,
 		PropTypes.shape({current: PropTypes.any})
 	])
-}
+};
 
-const ScrollButton = ForwardRef(ScrollButtonBase1);
+const ScrollButton = ForwardRef(ScrollButtonBase);
 
 export default ScrollButton;
 export {

--- a/useScroll/ScrollButton.js
+++ b/useScroll/ScrollButton.js
@@ -52,7 +52,6 @@ const ScrollButtonBase = ({active, 'aria-label': ariaLabel, className, forwardRe
 			<div style={{display: 'none'}} ref={clientSiblingRef} />
 		</>
 	);
-	// }
 };
 
 ScrollButtonBase.displayName = 'ScrollButton';

--- a/useScroll/ScrollButtons.js
+++ b/useScroll/ScrollButtons.js
@@ -4,7 +4,6 @@ import {is} from '@enact/core/keymap';
 import Spotlight, {getDirection} from '@enact/spotlight';
 import utilEvent from '@enact/ui/useScroll/utilEvent';
 import {useRef, useState, useEffect} from 'react';
-import ReactDOM from 'react-dom';
 
 const
 	nop = () => {},
@@ -135,7 +134,7 @@ const useScrollButtons = (props) => {
 				if (focusableScrollButtons && !Spotlight.getPointerMode()) {
 					consumeEvent(ev);
 					Spotlight.setPointerMode(false);
-					Spotlight.focus(ReactDOM.findDOMNode(oppositeButton.ref)); // eslint-disable-line react/no-find-dom-node
+					Spotlight.focus(oppositeButton.ref);
 				} else if (!oppositeButton.disabled) {
 					consumeEvent(ev);
 					oppositeButton.click(ev);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [x] Documentation was verified or is not changed
* [x] UI test was passed or is not needed
* [x] Screenshot test was verified or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
findDomNode is removed in React 19

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
 agate/ContextualPopupDecorator: changed to get ref based on a newly added dummy sibling 'div' node
 agate/Dropdown/DropdownList:  changed to get ref based on VirtualList root div
 agate/useScroll/ScrollButton:  Refactored ScrollButtonBase as a functional component in order to use useRef() hook. PAssed ref  directly to Button
 agate/useScroll/ScrollButtons:  React.findDomNode could be easily removed as the used ref was already a DOM node

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Fixed JSDoc text for agate/Dropdown


### Links
[//]: # (Related issues, references)
WRQ-19326

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian [daniel.stoian@lgepartner.com](mailto:daniel.stoian@lgepartner.com)