### PR TITLE
WRQ-19325: Updated Panels' Header to work with changed DOM structure of Spottable

### DIFF
--- a/ColorPicker/tests/ColorPicker-specs.js
+++ b/ColorPicker/tests/ColorPicker-specs.js
@@ -18,7 +18,7 @@ describe('ColorPicker', () => {
 			</ColorPicker>
 		);
 
-		const actual = screen.getAllByRole('button')[0].nextElementSibling;
+		const actual = screen.getAllByRole('button')[0].nextElementSibling.nextElementSibling; // there is a dummy sibling by Spottable
 		const expected = 'right';
 
 		expect(actual).toHaveClass(expected);
@@ -31,7 +31,7 @@ describe('ColorPicker', () => {
 			</ColorPicker>
 		);
 
-		const actual = screen.getAllByRole('button')[0].nextElementSibling;
+		const actual = screen.getAllByRole('button')[0].nextElementSibling.nextElementSibling; // there is a dummy sibling by Spottable
 		const expected = 'down';
 
 		expect(actual).toHaveClass(expected);
@@ -44,7 +44,7 @@ describe('ColorPicker', () => {
 			</ColorPicker>
 		);
 
-		const actual = screen.getAllByRole('button')[0].nextElementSibling;
+		const actual = screen.getAllByRole('button')[0].nextElementSibling.nextElementSibling; // there is a dummy sibling by Spottable
 		const expected = 'up';
 
 		expect(actual).toHaveClass(expected);
@@ -168,7 +168,7 @@ describe('ColorPicker', () => {
 		// Extend color picker
 		await user.click(screen.getAllByRole('button')[0]);
 
-		const actual = screen.getAllByRole('button')[0].nextElementSibling;
+		const actual = screen.getAllByRole('button')[0].nextElementSibling.nextElementSibling; // there is a dummy sibling by Spottable
 		const expected = 'shown';
 
 		expect(actual).toHaveClass(expected);

--- a/MediaPlayer/tests/MediaPlayer-specs.js
+++ b/MediaPlayer/tests/MediaPlayer-specs.js
@@ -277,7 +277,7 @@ describe('MediaPlayer', () => {
 				</MediaPlayer>
 			);
 			const repeatButton = screen.getByLabelText('Repeat');
-			const controlsFrame = screen.getByTestId('media-player').children.item(3);
+			const controlsFrame = screen.getByTestId('media-player').children.item(4);
 
 			await user.click(repeatButton);
 
@@ -292,7 +292,7 @@ describe('MediaPlayer', () => {
 				</MediaPlayer>
 			);
 			const repeatButton = screen.getByLabelText('Repeat');
-			const controlsFrame = screen.getByTestId('media-player').children.item(3);
+			const controlsFrame = screen.getByTestId('media-player').children.item(4);
 
 			await user.click(repeatButton);
 			await user.click(repeatButton);
@@ -308,7 +308,7 @@ describe('MediaPlayer', () => {
 				</MediaPlayer>
 			);
 			const repeatButton = screen.getByLabelText('Repeat');
-			const controlsFrame = screen.getByTestId('media-player').children.item(3);
+			const controlsFrame = screen.getByTestId('media-player').children.item(4);
 
 			await user.click(repeatButton);
 			await user.click(repeatButton);

--- a/Panels/Panels.module.less
+++ b/Panels/Panels.module.less
@@ -59,7 +59,14 @@
 			top: @agate-panels-controls-top;
 			.position-start-end(auto, @agate-panel-h-padding);
 			.padding-start-end(@agate-panels-controls-padding-start, initial);
-			.remove-margin-on-edge-children();
+
+			> :first-child {
+				-webkit-margin-start: 0;
+			}
+
+			> :nth-last-child(2) {
+				-webkit-margin-end: 0;
+			}
 		}
 
 		&.partial {

--- a/TabGroup/tests/TabGroup-specs.js
+++ b/TabGroup/tests/TabGroup-specs.js
@@ -40,7 +40,7 @@ describe('TabGroup Specs', () => {
 
 		const expectedClass = 'tabGroup';
 
-		const expectedTabNumber = 3;
+		const expectedTabNumber = 3 * 2; // each tab has two children due to a dummy sibling by Spottable
 		const tabGroup = screen.getByRole('group');
 
 		expect(tabGroup).toHaveClass(expectedClass);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
As DOM structure of ui/Spottable is updated in enactjs/enact/pull/3243, the corresponding internal style sheet needs to be updated.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Updated the related styles.
Also, unit tests for ColorPicker, MediaPlayer, and TabGroup are updated due to DOM structure changes.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-19325
enactjs/enact/pull/3243

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)
