### PR TITLE
WRQ- 30259: Replaced deprecated `platform.touchscreen` with `platform.touchScreen`

### DIFF
--- a/ArcPicker/ArcPickerBehaviorDecorator.js
+++ b/ArcPicker/ArcPickerBehaviorDecorator.js
@@ -92,7 +92,7 @@ const ArcPickerBehaviorDecorator = hoc((config, Wrapped) => {
 		}
 
 		handleClick = (value) => (ev) => {
-			if (platform.touchscreen) {
+			if (platform.touchScreen) {
 				this.setState({isFocused: true}, () => {
 					setTimeout(() => {
 						this.setState({isFocused: false});
@@ -109,7 +109,7 @@ const ArcPickerBehaviorDecorator = hoc((config, Wrapped) => {
 		};
 
 		handleFocus = () => {
-			if (!platform.touchscreen) {
+			if (!platform.touchScreen) {
 				this.setState({isFocused: true});
 			}
 		};

--- a/Slider/SliderBehaviorDecorator.js
+++ b/Slider/SliderBehaviorDecorator.js
@@ -137,7 +137,7 @@ const SliderBehaviorDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 		handleDragStart () {
 			// on platforms with a touchscreen, we want to focus slider when dragging begins
-			if (platform.touchscreen) {
+			if (platform.touchScreen) {
 				this.focusSlider();
 			}
 			this.paused.pause();

--- a/SliderButton/SliderButtonBehaviorDecorator.js
+++ b/SliderButton/SliderButtonBehaviorDecorator.js
@@ -31,7 +31,7 @@ const SliderButtonBehaviorDecorator = (Wrapped) => {
 
 		const handleDragStart = useCallback(() => {
 			// on platforms with a touchscreen, we want to focus slider when dragging begins
-			if (platform.touchscreen) {
+			if (platform.touchScreen) {
 				ref.current.node.focus();
 			}
 		}, []);

--- a/useScroll/useScroll.js
+++ b/useScroll/useScroll.js
@@ -369,7 +369,7 @@ const useScroll = (props) => {
 		...rest,
 		...scrollProps,
 		assignProperties,
-		noScrollByDrag: !platform.touchscreen,
+		noScrollByDrag: !platform.touchScreen,
 		addEventListeners,
 		handleResizeWindow,
 		horizontalScrollbarHandle,


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
"platform.touchscreen" is removed in enact 5.0.0

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Replaced deprecated `platform.touchscreen` with `platform.touchScreen` available in @enact/core/platform.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRQ- 30259

### Comments
Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com