### PR TITLE
WRQ-31515: Fixed Scroller and VirtualList to set prop value to default value when `undefined` is passed for the prop value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
     - npm install
     - npm link
     - popd
-    - git clone --branch=develop --depth 1 https://github.com/enactjs/enact ../enact
+    - git clone --branch=feature/WRQ-31515 --depth 1 https://github.com/enactjs/enact ../enact
     - pushd ../enact
     - npm install
     - npm run lerna exec -- --ignore enact-sampler --concurrency 1 -- npm --no-package-lock install

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
     - npm install
     - npm link
     - popd
-    - git clone --branch=feature/WRQ-31515-develop --depth 1 https://github.com/enactjs/enact ../enact
+    - git clone --branch=develop --depth 1 https://github.com/enactjs/enact ../enact
     - pushd ../enact
     - npm install
     - npm run lerna exec -- --ignore enact-sampler --concurrency 1 -- npm --no-package-lock install

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
     - npm install
     - npm link
     - popd
-    - git clone --branch=feature/WRQ-31515 --depth 1 https://github.com/enactjs/enact ../enact
+    - git clone --branch=feature/WRQ-31515-develop --depth 1 https://github.com/enactjs/enact ../enact
     - pushd ../enact
     - npm install
     - npm run lerna exec -- --ignore enact-sampler --concurrency 1 -- npm --no-package-lock install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact agate module, newest changes on the top.
 
+## [unreleased]
+
+### Fixed
+
+- `agate/Scroller`, `agate/VirtualList` and `agate/VirtualList.VirtualGridList` to set prop value to default when `undefined` is passed for the prop value
+
 ## [2.0.11] - 2024-07-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact agate module, newest cha
 
 ### Fixed
 
-- `agate/Scroller`, `agate/VirtualList` and `agate/VirtualList.VirtualGridList` to set prop value to default when `undefined` is passed for the prop value
+- `agate/Scroller` and `agate/VirtualList` to have default prop when `undefined` prop is passed
 - `agate/ToggleButton` underline position for `huge`,`small` and `smallest` sizes
 
 ## [2.0.11] - 2024-07-22

--- a/Scroller/Scroller.js
+++ b/Scroller/Scroller.js
@@ -60,7 +60,13 @@ const scrollerDefaultProps = {
  * @public
  */
 let Scroller = (props) => {
-	const scrollerProps = Object.assign({}, scrollerDefaultProps, props);
+	const scrollerProps = Object.assign({}, props);
+	for (const prop in scrollerDefaultProps) {
+		// eslint-disable-next-line no-undefined
+		if (scrollerProps[prop] === undefined) {
+			scrollerProps[prop] = scrollerDefaultProps[prop];
+		}
+	}
 
 	// Hooks
 	const {

--- a/Scroller/Scroller.js
+++ b/Scroller/Scroller.js
@@ -16,6 +16,7 @@
  * @exports Scroller
  */
 
+import {setDefaultProps} from '@enact/core/util';
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import {ResizeContext} from '@enact/ui/Resizable';
@@ -60,13 +61,7 @@ const scrollerDefaultProps = {
  * @public
  */
 let Scroller = (props) => {
-	const scrollerProps = Object.assign({}, props);
-	for (const prop in scrollerDefaultProps) {
-		// eslint-disable-next-line no-undefined
-		if (scrollerProps[prop] === undefined) {
-			scrollerProps[prop] = scrollerDefaultProps[prop];
-		}
-	}
+	const scrollerProps = setDefaultProps(props, scrollerDefaultProps);
 
 	// Hooks
 	const {

--- a/VirtualList/VirtualList.js
+++ b/VirtualList/VirtualList.js
@@ -6,6 +6,7 @@
  * @exports VirtualList
  */
 
+import {setDefaultProps} from '@enact/core/util';
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import {ResizeContext} from '@enact/ui/Resizable';
@@ -49,13 +50,7 @@ const virtualListDefaultProps = {
  * @public
  */
 let VirtualList = (props) => {
-	const virtualListProps = Object.assign({}, props);
-	for (const prop in virtualListDefaultProps) {
-		// eslint-disable-next-line no-undefined
-		if (virtualListProps[prop] === undefined) {
-			virtualListProps[prop] = virtualListDefaultProps[prop];
-		}
-	}
+	const virtualListProps = setDefaultProps(props, virtualListDefaultProps);
 	const {itemSize, role, ...rest} = virtualListProps;
 
 	const itemSizeProps = itemSize && itemSize.minSize ?
@@ -510,13 +505,7 @@ const virtualGridListDefaultProps = {
  * @public
  */
 let VirtualGridList = (props) => {
-	const virtualGridListProps = Object.assign({}, props);
-	for (const prop in virtualGridListDefaultProps) {
-		// eslint-disable-next-line no-undefined
-		if (virtualGridListProps[prop] === undefined) {
-			virtualGridListProps[prop] = virtualGridListDefaultProps[prop];
-		}
-	}
+	const virtualGridListProps = setDefaultProps(props, virtualGridListDefaultProps);
 	const {role, ...rest} = virtualGridListProps;
 
 	const {

--- a/VirtualList/VirtualList.js
+++ b/VirtualList/VirtualList.js
@@ -49,7 +49,13 @@ const virtualListDefaultProps = {
  * @public
  */
 let VirtualList = (props) => {
-	const virtualListProps = Object.assign({}, virtualListDefaultProps, props);
+	const virtualListProps = Object.assign({}, props);
+	for (const prop in virtualListDefaultProps) {
+		// eslint-disable-next-line no-undefined
+		if (virtualListProps[prop] === undefined) {
+			virtualListProps[prop] = virtualListDefaultProps[prop];
+		}
+	}
 	const {itemSize, role, ...rest} = virtualListProps;
 
 	const itemSizeProps = itemSize && itemSize.minSize ?
@@ -504,7 +510,13 @@ const virtualGridListDefaultProps = {
  * @public
  */
 let VirtualGridList = (props) => {
-	const virtualGridListProps = Object.assign({}, virtualGridListDefaultProps, props);
+	const virtualGridListProps = Object.assign({}, props);
+	for (const prop in virtualGridListDefaultProps) {
+		// eslint-disable-next-line no-undefined
+		if (virtualGridListProps[prop] === undefined) {
+			virtualGridListProps[prop] = virtualGridListDefaultProps[prop];
+		}
+	}
 	const {role, ...rest} = virtualGridListProps;
 
 	const {


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Juwon Jeong (juwon.jeong@lge.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
In https://github.com/enactjs/agate/pull/786, we removed defaultProps and implemeted this feature manually.
After this implementation, if `undefined` is passed for a prop value, the prop value remains undefined.
However, defaultProps(https://legacy.reactjs.org/docs/typechecking-with-proptypes.html#default-prop-values) sets prop value to default value when undefined value is passed for the prop.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fix `Scroller`, `VirtualList` and `VirtualGridList` to set prop value to default value when undefined is passed for the prop value

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
I checked React's defaultProps for falsy values(null, undefined, false, NaN, 0, -0, "") and found that it sets the prop value to its default value only when undefined is passed.
- https://react.dev/reference/react/Component#static-defaultprops
### Links
[//]: # (Related issues, references)
WRQ-31515

### Comments
