### PR TITLE
WRR-9415: Replace .vendor-opacity mixin with the standard opacity attribute

### DIFF
--- a/LabeledIconButton/LabeledIconButton.module.less
+++ b/LabeledIconButton/LabeledIconButton.module.less
@@ -370,12 +370,12 @@
 		};
 
 		.disabled({
-			.vendor-opacity(@agate-disabled-opacity);
+			opacity: @agate-disabled-opacity;
 			cursor: default;
 
 			// Disabled children of disabled components
 			.disabled({
-				.vendor-opacity(1);
+				opacity: 1;
 			}, parent);
 
 			.opaque {

--- a/ThemeDecorator/ThemeDecorator.module.less
+++ b/ThemeDecorator/ThemeDecorator.module.less
@@ -44,13 +44,13 @@
 
 	// Disabled Components
 	.disabled({
-		.vendor-opacity(@agate-disabled-opacity);
+		opacity: @agate-disabled-opacity;
 
 		cursor: default;
 
 		// Disabled children of disabled components
 		.disabled({
-			.vendor-opacity(1);
+			opacity: 1;
 		}, parent);
 	});
 });

--- a/internal/Picker/Picker.module.less
+++ b/internal/Picker/Picker.module.less
@@ -85,7 +85,7 @@
 			}
 
 			&[disabled] {
-				.vendor-opacity(@agate-disabled-opacity);
+				opacity: @agate-disabled-opacity;
 			}
 
 			.focus({


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Some components are using enact/ui's .vendor-opacity() mixin but we don't need it. We normally use the standard opacity CSS attribute and just two components are using the mixin as their code is copied from the old codebase.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Replace .vendor-opacity() mixin with the standard opacity CSS attribute.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-9415

### Comments
Enact-DCO-1.0-Signed-off-by: Seungcheon Baek (sc.baek@lge.com)