### PR TITLE
WRR-12677: Fix node_js to use 'lts/*' and 'node' on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
     - popd
     - git clone --branch=develop --depth 1 https://github.com/enactjs/enact ../enact
     - pushd ../enact
-    - npm uninstall @enact/ui-test-utils -C packages/i18n
+    - npm uninstall @enact/ui-test-utils --prefix packages/i18n
     - npm install
     - npm run lerna exec -- --ignore enact-sampler --concurrency 1 -- npm --no-package-lock install
     - npm run lerna exec -- --ignore enact-sampler --concurrency 1 -- npm --no-package-lock link

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 dist: jammy
 language: node_js
 node_js:
-    - "21"
+    - lts/*
+    - node
 sudo: false
 before_install:
     - curl -fsSL https://www.mongodb.org/static/pgp/server-4.4.asc | sudo gpg -o /usr/share/keyrings/mongodb-server-4.4.gpg --dearmor
@@ -18,12 +19,14 @@ install:
     - popd
     - git clone --branch=develop --depth 1 https://github.com/enactjs/enact ../enact
     - pushd ../enact
+    - npm uninstall @enact/ui-test-utils -C packages/i18n
     - npm install
     - npm run lerna exec -- --ignore enact-sampler --concurrency 1 -- npm --no-package-lock install
     - npm run lerna exec -- --ignore enact-sampler --concurrency 1 -- npm --no-package-lock link
     - npm run interlink
     - popd
     - rm -fr node_modules/@enact
+    - npm uninstall @enact/ui-test-utils
     - npm install
     - enact link
 script:


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When the travis modified to not install @enact/ui-test-utils, which includes node-canvas, the travis passed even in the latest nodejs environment.
diff: https://github.com/enactjs/sandstone/compare/develop...test/travis-fail
travis result: https://app.travis-ci.com/github/enactjs/sandstone/jobs/628577584

After discussion within the team, we decided not to install this module for stable Travis operation.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Fix node_js to use 'lts/*' and 'node' on travis
- Remove @enact/ui-test-utils in node_modules

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-12677

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong ([taeyoung.hong@lge.com](mailto:taeyoung.hong@lge.com))