### PR TITLE
WRR-23385: Remove unused eslint-disable directive 'enact/prop-types'

### DIFF
--- a/Item/Item.js
+++ b/Item/Item.js
@@ -114,7 +114,6 @@ const ItemContent = kind({
 		}
 	},
 
-	// eslint-disable-next-line enact/prop-types
 	render: ({centered, content, css, marqueeOn, label, labelPosition, orientation, styler, ...rest}) => {
 
 		if (!label) {

--- a/SliderButton/SliderButton.js
+++ b/SliderButton/SliderButton.js
@@ -69,7 +69,6 @@ const SliderKnob = kind({
 	},
 	render: ({...rest}) => {
 		delete rest.value;
-		// eslint-disable-next-line enact/prop-types
 		delete rest.tooltipComponent;
 		return (
 			<div
@@ -112,9 +111,7 @@ const SliderProgress = kind({
 		className: 'track'
 	},
 	render: ({children, css, values, ...rest}) => {
-		// eslint-disable-next-line enact/prop-types
 		delete rest.progressAnchor;
-		// eslint-disable-next-line enact/prop-types
 		delete rest.backgroundProgress;
 		return (
 			<Row {...rest} align="center">

--- a/VirtualList/useThemeVirtualList.js
+++ b/VirtualList/useThemeVirtualList.js
@@ -366,7 +366,6 @@ const useThemeVirtualList = (props) => {
 	};
 };
 
-/* eslint-disable enact/prop-types */
 function placeholderRenderer ({
 	handlePlaceholderFocus,
 	primary
@@ -383,7 +382,6 @@ function placeholderRenderer ({
 		/>
 	));
 }
-/* eslint-enable enact/prop-types */
 
 export default useThemeVirtualList;
 export {

--- a/samples/qa-a11y/src/views/Panels.js
+++ b/samples/qa-a11y/src/views/Panels.js
@@ -18,7 +18,7 @@ const PanelsView = () => {
 
 	const nextPanel = () => setIndex(1);
 	const prevPanel = () => setIndex(0);
-	const customItem = ({index: itemIndex, ...rest}) => { // eslint-disable-line enact/prop-types
+	const customItem = ({index: itemIndex, ...rest}) => {
 		return (
 			<Item {...rest} onClick={nextPanel}>
 				{itemList[itemIndex]}

--- a/samples/qa-a11y/src/views/VirtualGridList.js
+++ b/samples/qa-a11y/src/views/VirtualGridList.js
@@ -15,7 +15,6 @@ const svgGenerator = (width, height, bgColor, textColor, customText) => (
 	`%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='36px' fill='%23${textColor}'%3E${customText}%3C/text%3E%3C/svg%3E`
 );
 
-// eslint-disable-next-line enact/prop-types
 const renderItem = ({index, ...rest}) => {
 	const {caption, label, src} = items[index];
 

--- a/samples/qa-a11y/src/views/VirtualList.js
+++ b/samples/qa-a11y/src/views/VirtualList.js
@@ -8,7 +8,6 @@ import ri from '@enact/ui/resolution';
 import {useState} from 'react';
 
 const items = [];
-// eslint-disable-next-line enact/prop-types
 const renderItem = ({index, ...rest}) => (
 	<Item {...rest}>
 		{items[index]}

--- a/samples/sampler/stories/default/VirtualGridList.js
+++ b/samples/sampler/stories/default/VirtualGridList.js
@@ -26,7 +26,6 @@ const
 	shouldAddLongContent = ({index, modIndex}) => (
 		index % modIndex === 0 ? ` ${longContent}` : ''
 	),
-	// eslint-disable-next-line enact/prop-types
 	renderItem = ({index, ...rest}) => {
 		const {text, src} = items[index];
 

--- a/samples/sampler/stories/default/VirtualList.js
+++ b/samples/sampler/stories/default/VirtualList.js
@@ -20,7 +20,7 @@ const
 	},
 	items = [],
 	defaultDataSize = 1000,
-	// eslint-disable-next-line enact/prop-types, enact/display-name
+	// eslint-disable-next-line enact/display-name
 	renderItem = (size) => ({index, ...rest}) => {
 		const itemStyle = {
 			height: ri.unit(size, 'rem')


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
https://ko.react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-deprecated-react-apis
PropTypes were deprecated in April 2017 (v15.5.0).
However, the enact/prop-types rule still exists, so removing PropType causes a linting error.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove unused eslint-disable directive 'enact/prop-types'

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-23385

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)