### PR TITLE
NXT-3374: Fixed failed `ui-test`

### DIFF
--- a/tests/ui/specs/DatePicker/DatePicker-specs.js
+++ b/tests/ui/specs/DatePicker/DatePicker-specs.js
@@ -26,7 +26,7 @@ describe('DatePicker', function () {
 					expect(await datePicker.decrementer('month').isFocused()).toBe(true);
 					await Page.spotlightDown();
 					await Page.spotlightSelect();
-					await Page.delay(200);
+					await Page.delay(300);
 					const {month: value} = await extractValues(datePicker);
 					const expected = month < 12 ? month + 1 : 1;
 					expect(value).toBe(expected);
@@ -36,7 +36,7 @@ describe('DatePicker', function () {
 					const {month} = await extractValues(datePicker);
 					expect(await datePicker.decrementer('month').isFocused()).toBe(true);
 					await Page.spotlightSelect();
-					await Page.delay(200);
+					await Page.delay(300);
 					const {month: value} = await extractValues(datePicker);
 					const expected = month > 1 ? month - 1 : 12;
 					expect(value).toBe(expected);
@@ -49,7 +49,7 @@ describe('DatePicker', function () {
 					expect(await datePicker.decrementer('day').isFocused()).toBe(true);
 					await Page.spotlightDown();
 					await Page.spotlightSelect();
-					await Page.delay(200);
+					await Page.delay(300);
 					const {day: value} = await extractValues(datePicker);
 					const expected = day !== numDays ? day + 1 : 1;
 					expect(value).toBe(expected);
@@ -61,7 +61,7 @@ describe('DatePicker', function () {
 					await Page.spotlightRight();
 					expect(await datePicker.decrementer('day').isFocused()).toBe(true);
 					await Page.spotlightSelect();
-					await Page.delay(200);
+					await Page.delay(300);
 					const {day: value} = await extractValues(datePicker);
 					const expected = day !== 1 ? day - 1 : numDays;
 					expect(value).toBe(expected);
@@ -74,7 +74,7 @@ describe('DatePicker', function () {
 					expect(await datePicker.decrementer('year').isFocused()).toBe(true);
 					await Page.spotlightDown();
 					await Page.spotlightSelect();
-					await Page.delay(200);
+					await Page.delay(300);
 					const {year: value} = await extractValues(datePicker);
 					const expected = year + 1;
 					expect(value).toBe(expected);
@@ -86,7 +86,7 @@ describe('DatePicker', function () {
 					await Page.spotlightRight();
 					expect(await datePicker.decrementer('year').isFocused()).toBe(true);
 					await Page.spotlightSelect();
-					await Page.delay(200);
+					await Page.delay(300);
 					const {year: value} = await extractValues(datePicker);
 					const expected = year - 1;
 					expect(value).toBe(expected);
@@ -97,7 +97,7 @@ describe('DatePicker', function () {
 				it('should increase the month when incrementing the picker', async function () {
 					const {month} = await extractValues(datePicker);
 					await datePicker.incrementer('month').click();
-					await Page.delay(200);
+					await Page.delay(500);
 					expect(await datePicker.incrementer('month').isFocused()).toBe(true);
 					const {month: value} = await extractValues(datePicker);
 					const expected = month < 12 ? month + 1 : 1;
@@ -107,7 +107,7 @@ describe('DatePicker', function () {
 				it('should decrease the month when decrementing the picker', async function () {
 					const {month} = await extractValues(datePicker);
 					await datePicker.decrementer('month').click();
-					await Page.delay(200);
+					await Page.delay(300);
 					expect(await datePicker.decrementer('month').isFocused()).toBe(true);
 					const {month: value} = await extractValues(datePicker);
 					const expected = month > 1 ? month - 1 : 12;
@@ -118,7 +118,7 @@ describe('DatePicker', function () {
 					const {day, month, year} = await extractValues(datePicker);
 					const numDays = daysInMonth({month, year});
 					await datePicker.incrementer('day').click();
-					await Page.delay(200);
+					await Page.delay(500);
 					expect(await datePicker.incrementer('day').isFocused()).toBe(true);
 					const {day: value} = await extractValues(datePicker);
 					const expected = day !== numDays ? day + 1 : 1;
@@ -129,7 +129,7 @@ describe('DatePicker', function () {
 					const {day, month, year} = await extractValues(datePicker);
 					const numDays = daysInMonth({month, year});
 					await datePicker.decrementer('day').click();
-					await Page.delay(200);
+					await Page.delay(300);
 					expect(await datePicker.decrementer('day').isFocused()).toBe(true);
 					const {day: value} = await extractValues(datePicker);
 					const expected = day !== 1 ? day - 1 : numDays;
@@ -139,7 +139,7 @@ describe('DatePicker', function () {
 				it('should increase the year when incrementing the picker', async function () {
 					const {year} = await extractValues(datePicker);
 					await datePicker.incrementer('year').click();
-					await Page.delay(200);
+					await Page.delay(300);
 					expect(await datePicker.incrementer('year').isFocused()).toBe(true);
 					const {year: value} = await extractValues(datePicker);
 					const expected = year + 1;
@@ -149,7 +149,7 @@ describe('DatePicker', function () {
 				it('should decrease the year when decrementing the picker', async function () {
 					const {year} = await extractValues(datePicker);
 					await datePicker.decrementer('year').click();
-					await Page.delay(200);
+					await Page.delay(300);
 					expect(await datePicker.decrementer('year').isFocused()).toBe(true);
 					const {year: value} = await extractValues(datePicker);
 					const expected = year - 1;
@@ -166,7 +166,7 @@ describe('DatePicker', function () {
 				it('should not update on select', async function () {
 					await datePicker.focus();
 					await Page.spotlightSelect();
-					await Page.delay(200);
+					await Page.delay(300);
 
 					const {day, month, year} = await extractValues(datePicker);
 
@@ -183,13 +183,13 @@ describe('DatePicker', function () {
 
 			it('should focus the disabled month picker', async function () {
 				await datePicker.decrementer('month').click();
-				await Page.delay(200);
+				await Page.delay(300);
 				expect(await datePicker.decrementer('month').isFocused()).toBe(true);
 			});
 
 			it('should not increase the day when incrementing disabled picker', async function () {
 				await datePicker.incrementer('day').click();
-				await Page.delay(200);
+				await Page.delay(500);
 				expect(await datePicker.incrementer('day').isFocused()).toBe(true);
 				const {day: value} = await extractValues(datePicker);
 				expect(value).toBe(1);
@@ -197,7 +197,7 @@ describe('DatePicker', function () {
 
 			it('should not decrease the day when decrementing disabled picker', async function () {
 				await datePicker.decrementer('day').click();
-				await Page.delay(200);
+				await Page.delay(500);
 				expect(await datePicker.decrementer('day').isFocused()).toBe(true);
 				const {day: value} = await extractValues(datePicker);
 				expect(value).toBe(1);
@@ -219,15 +219,15 @@ describe('DatePicker', function () {
 			it('should not update \'defaultValue\' on decrementing disabled picker', async function () {
 				const {day, month, year} = await extractValues(datePicker);
 				await datePicker.decrementer('month').click();
-				await Page.delay(200);
+				await Page.delay(300);
 				expect(await datePicker.decrementer('month').isFocused()).toBe(true);
 
 				await datePicker.decrementer('day').click();
-				await Page.delay(200);
+				await Page.delay(300);
 				expect(await datePicker.decrementer('day').isFocused()).toBe(true);
 
 				await datePicker.decrementer('year').click();
-				await Page.delay(200);
+				await Page.delay(300);
 				expect(await datePicker.decrementer('year').isFocused()).toBe(true);
 
 				await Page.delay(500);
@@ -241,15 +241,15 @@ describe('DatePicker', function () {
 				const {day, month, year} = await extractValues(datePicker);
 
 				await datePicker.incrementer('month').click();
-				await Page.delay(200);
+				await Page.delay(300);
 				expect(await datePicker.incrementer('month').isFocused()).toBe(true);
 
 				await datePicker.incrementer('day').click();
-				await Page.delay(200);
+				await Page.delay(300);
 				expect(await datePicker.incrementer('day').isFocused()).toBe(true);
 
 				await datePicker.incrementer('day').click();
-				await Page.delay(200);
+				await Page.delay(300);
 				expect(await datePicker.incrementer('day').isFocused()).toBe(true);
 
 				await Page.delay(500);

--- a/tests/ui/specs/DatePicker/DatePicker-specs.js
+++ b/tests/ui/specs/DatePicker/DatePicker-specs.js
@@ -26,6 +26,7 @@ describe('DatePicker', function () {
 					expect(await datePicker.decrementer('month').isFocused()).toBe(true);
 					await Page.spotlightDown();
 					await Page.spotlightSelect();
+					await Page.delay(200);
 					const {month: value} = await extractValues(datePicker);
 					const expected = month < 12 ? month + 1 : 1;
 					expect(value).toBe(expected);
@@ -35,6 +36,7 @@ describe('DatePicker', function () {
 					const {month} = await extractValues(datePicker);
 					expect(await datePicker.decrementer('month').isFocused()).toBe(true);
 					await Page.spotlightSelect();
+					await Page.delay(200);
 					const {month: value} = await extractValues(datePicker);
 					const expected = month > 1 ? month - 1 : 12;
 					expect(value).toBe(expected);
@@ -47,6 +49,7 @@ describe('DatePicker', function () {
 					expect(await datePicker.decrementer('day').isFocused()).toBe(true);
 					await Page.spotlightDown();
 					await Page.spotlightSelect();
+					await Page.delay(200);
 					const {day: value} = await extractValues(datePicker);
 					const expected = day !== numDays ? day + 1 : 1;
 					expect(value).toBe(expected);
@@ -58,6 +61,7 @@ describe('DatePicker', function () {
 					await Page.spotlightRight();
 					expect(await datePicker.decrementer('day').isFocused()).toBe(true);
 					await Page.spotlightSelect();
+					await Page.delay(200);
 					const {day: value} = await extractValues(datePicker);
 					const expected = day !== 1 ? day - 1 : numDays;
 					expect(value).toBe(expected);
@@ -70,6 +74,7 @@ describe('DatePicker', function () {
 					expect(await datePicker.decrementer('year').isFocused()).toBe(true);
 					await Page.spotlightDown();
 					await Page.spotlightSelect();
+					await Page.delay(200);
 					const {year: value} = await extractValues(datePicker);
 					const expected = year + 1;
 					expect(value).toBe(expected);
@@ -81,6 +86,7 @@ describe('DatePicker', function () {
 					await Page.spotlightRight();
 					expect(await datePicker.decrementer('year').isFocused()).toBe(true);
 					await Page.spotlightSelect();
+					await Page.delay(200);
 					const {year: value} = await extractValues(datePicker);
 					const expected = year - 1;
 					expect(value).toBe(expected);
@@ -91,7 +97,7 @@ describe('DatePicker', function () {
 				it('should increase the month when incrementing the picker', async function () {
 					const {month} = await extractValues(datePicker);
 					await datePicker.incrementer('month').click();
-					await browser.pause(500);
+					await Page.delay(200);
 					expect(await datePicker.incrementer('month').isFocused()).toBe(true);
 					const {month: value} = await extractValues(datePicker);
 					const expected = month < 12 ? month + 1 : 1;
@@ -101,6 +107,7 @@ describe('DatePicker', function () {
 				it('should decrease the month when decrementing the picker', async function () {
 					const {month} = await extractValues(datePicker);
 					await datePicker.decrementer('month').click();
+					await Page.delay(200);
 					expect(await datePicker.decrementer('month').isFocused()).toBe(true);
 					const {month: value} = await extractValues(datePicker);
 					const expected = month > 1 ? month - 1 : 12;
@@ -111,7 +118,7 @@ describe('DatePicker', function () {
 					const {day, month, year} = await extractValues(datePicker);
 					const numDays = daysInMonth({month, year});
 					await datePicker.incrementer('day').click();
-					await browser.pause(500);
+					await Page.delay(200);
 					expect(await datePicker.incrementer('day').isFocused()).toBe(true);
 					const {day: value} = await extractValues(datePicker);
 					const expected = day !== numDays ? day + 1 : 1;
@@ -122,6 +129,7 @@ describe('DatePicker', function () {
 					const {day, month, year} = await extractValues(datePicker);
 					const numDays = daysInMonth({month, year});
 					await datePicker.decrementer('day').click();
+					await Page.delay(200);
 					expect(await datePicker.decrementer('day').isFocused()).toBe(true);
 					const {day: value} = await extractValues(datePicker);
 					const expected = day !== 1 ? day - 1 : numDays;
@@ -131,6 +139,7 @@ describe('DatePicker', function () {
 				it('should increase the year when incrementing the picker', async function () {
 					const {year} = await extractValues(datePicker);
 					await datePicker.incrementer('year').click();
+					await Page.delay(200);
 					expect(await datePicker.incrementer('year').isFocused()).toBe(true);
 					const {year: value} = await extractValues(datePicker);
 					const expected = year + 1;
@@ -140,6 +149,7 @@ describe('DatePicker', function () {
 				it('should decrease the year when decrementing the picker', async function () {
 					const {year} = await extractValues(datePicker);
 					await datePicker.decrementer('year').click();
+					await Page.delay(200);
 					expect(await datePicker.decrementer('year').isFocused()).toBe(true);
 					const {year: value} = await extractValues(datePicker);
 					const expected = year - 1;
@@ -156,6 +166,7 @@ describe('DatePicker', function () {
 				it('should not update on select', async function () {
 					await datePicker.focus();
 					await Page.spotlightSelect();
+					await Page.delay(200);
 
 					const {day, month, year} = await extractValues(datePicker);
 
@@ -172,21 +183,22 @@ describe('DatePicker', function () {
 
 			it('should focus the disabled month picker', async function () {
 				await datePicker.decrementer('month').click();
+				await Page.delay(200);
 				expect(await datePicker.decrementer('month').isFocused()).toBe(true);
 			});
 
 			it('should not increase the day when incrementing disabled picker', async function () {
 				await datePicker.incrementer('day').click();
+				await Page.delay(200);
 				expect(await datePicker.incrementer('day').isFocused()).toBe(true);
-				await browser.pause(500);
 				const {day: value} = await extractValues(datePicker);
 				expect(value).toBe(1);
 			});
 
 			it('should not decrease the day when decrementing disabled picker', async function () {
 				await datePicker.decrementer('day').click();
+				await Page.delay(200);
 				expect(await datePicker.decrementer('day').isFocused()).toBe(true);
-				await browser.pause(500);
 				const {day: value} = await extractValues(datePicker);
 				expect(value).toBe(1);
 			});
@@ -207,15 +219,18 @@ describe('DatePicker', function () {
 			it('should not update \'defaultValue\' on decrementing disabled picker', async function () {
 				const {day, month, year} = await extractValues(datePicker);
 				await datePicker.decrementer('month').click();
+				await Page.delay(200);
 				expect(await datePicker.decrementer('month').isFocused()).toBe(true);
 
 				await datePicker.decrementer('day').click();
+				await Page.delay(200);
 				expect(await datePicker.decrementer('day').isFocused()).toBe(true);
 
 				await datePicker.decrementer('year').click();
+				await Page.delay(200);
 				expect(await datePicker.decrementer('year').isFocused()).toBe(true);
 
-				await browser.pause(500);
+				await Page.delay(500);
 
 				expect(day).toBe(6);
 				expect(month).toBe(6);
@@ -226,15 +241,18 @@ describe('DatePicker', function () {
 				const {day, month, year} = await extractValues(datePicker);
 
 				await datePicker.incrementer('month').click();
+				await Page.delay(200);
 				expect(await datePicker.incrementer('month').isFocused()).toBe(true);
 
 				await datePicker.incrementer('day').click();
+				await Page.delay(200);
 				expect(await datePicker.incrementer('day').isFocused()).toBe(true);
 
 				await datePicker.incrementer('day').click();
+				await Page.delay(200);
 				expect(await datePicker.incrementer('day').isFocused()).toBe(true);
 
-				await browser.pause(500);
+				await Page.delay(500);
 
 				expect(day).toBe(6);
 				expect(month).toBe(6);

--- a/tests/ui/specs/DateTimePicker/DateTimePicker-specs.js
+++ b/tests/ui/specs/DateTimePicker/DateTimePicker-specs.js
@@ -137,6 +137,7 @@ describe('DateTimePicker', function () {
 					const {year} = await extractValues(dateTimePicker);
 					await dateTimePicker.dateIncrementer('year').click();
 					expect(await dateTimePicker.dateIncrementer('year').isFocused()).toBe(true);
+					await browser.pause(500);
 					const {year: value} = await extractValues(dateTimePicker);
 					const expected = year + 1;
 					expect(value).toBe(expected);

--- a/tests/ui/specs/DateTimePicker/DateTimePicker-specs.js
+++ b/tests/ui/specs/DateTimePicker/DateTimePicker-specs.js
@@ -45,7 +45,7 @@ describe('DateTimePicker', function () {
 				it('should increase the hour when incrementing the picker', async function () {
 					const {hour} = await extractValues(dateTimePicker);
 					await dateTimePicker.timeIncrementer('hour').click();
-					await Page.delay(200);
+					await Page.delay(300);
 					const {hour: value} = await extractValues(dateTimePicker);
 					const expected = hour < 12 ? hour + 1 : 1;
 					expect(value).toBe(expected);
@@ -54,7 +54,7 @@ describe('DateTimePicker', function () {
 				it('should decrease the hour when decrementing the picker', async function () {
 					const {hour} = await extractValues(dateTimePicker);
 					await dateTimePicker.timeDecrementer('hour').click();
-					await Page.delay(200);
+					await Page.delay(300);
 					const {hour: value} = await extractValues(dateTimePicker);
 					const expected = hour > 1 ? hour - 1 : 12;
 					expect(value).toBe(expected);
@@ -63,7 +63,7 @@ describe('DateTimePicker', function () {
 				it('should increase the minute when incrementing the picker', async function () {
 					const {minute} = await extractValues(dateTimePicker);
 					await dateTimePicker.timeIncrementer('minute').click();
-					await Page.delay(200);
+					await Page.delay(300);
 					await browser.waitUntil(async () => await dateTimePicker.timeIncrementer('minute').isFocused(), {timeout: 1500,  interval: 100});
 					const {minute: value} = await extractValues(dateTimePicker);
 					const expected = minute !== 59 ? minute + 1 : 0;
@@ -73,7 +73,7 @@ describe('DateTimePicker', function () {
 				it('should decrease the minute when decrementing the picker', async function () {
 					const {minute} = await extractValues(dateTimePicker);
 					await dateTimePicker.timeDecrementer('minute').click();
-					await Page.delay(200);
+					await Page.delay(300);
 					await browser.waitUntil(async () => await dateTimePicker.timeDecrementer('minute').isFocused(), {timeout: 1500,  interval: 100});
 					const {minute: value} = await extractValues(dateTimePicker);
 					const expected = minute !== 0 ? minute - 1 : 59;
@@ -86,13 +86,13 @@ describe('DateTimePicker', function () {
 						// 12 hours ought to change the value text if meridiem changes
 						for (let i = 12; i; i -= 1) {
 							await dateTimePicker.timeIncrementer('hour').click();
-							await Page.delay(200);
+							await Page.delay(300);
 						}
 					} else {
 						// 12 hours ought to change the value text if meridiem changes
 						for (let i = 12; i; i -= 1) {
 							await dateTimePicker.timeDecrementer('hour').click();
-							await Page.delay(200);
+							await Page.delay(300);
 						}
 					}
 
@@ -103,7 +103,7 @@ describe('DateTimePicker', function () {
 				it('should increase the month when incrementing the picker', async function () {
 					const {month} = await extractValues(dateTimePicker);
 					await dateTimePicker.dateIncrementer('month').click();
-					await Page.delay(200);
+					await Page.delay(300);
 					expect(await dateTimePicker.dateIncrementer('month').isFocused()).toBe(true);
 					const {month: value} = await extractValues(dateTimePicker);
 					const expected = month < 12 ? month + 1 : 1;
@@ -113,7 +113,7 @@ describe('DateTimePicker', function () {
 				it('should decrease the month when decrementing the picker', async function () {
 					const {month} = await extractValues(dateTimePicker);
 					await dateTimePicker.dateDecrementer('month').click();
-					await Page.delay(200);
+					await Page.delay(300);
 					expect(await dateTimePicker.dateDecrementer('month').isFocused()).toBe(true);
 					const {month: value} = await extractValues(dateTimePicker);
 					const expected = month > 1 ? month - 1 : 12;
@@ -124,7 +124,7 @@ describe('DateTimePicker', function () {
 					const {day, month, year} = await extractValues(dateTimePicker);
 					const numDays = daysInMonth({month, year});
 					await dateTimePicker.dateIncrementer('day').click();
-					await Page.delay(200);
+					await Page.delay(500);
 					expect(await dateTimePicker.dateIncrementer('day').isFocused()).toBe(true);
 					const {day: value} = await extractValues(dateTimePicker);
 					const expected = day !== numDays ? day + 1 : 1;
@@ -135,7 +135,7 @@ describe('DateTimePicker', function () {
 					const {day, month, year} = await extractValues(dateTimePicker);
 					const numDays = daysInMonth({month, year});
 					await dateTimePicker.dateDecrementer('day').click();
-					await Page.delay(200);
+					await Page.delay(300);
 					expect(await dateTimePicker.dateDecrementer('day').isFocused()).toBe(true);
 					const {day: value} = await extractValues(dateTimePicker);
 					const expected = day !== 1 ? day - 1 : numDays;
@@ -145,7 +145,7 @@ describe('DateTimePicker', function () {
 				it('should increase the year when incrementing the picker', async function () {
 					const {year} = await extractValues(dateTimePicker);
 					await dateTimePicker.dateIncrementer('year').click();
-					await Page.delay(200);
+					await Page.delay(300);
 					expect(await dateTimePicker.dateIncrementer('year').isFocused()).toBe(true);
 					const {year: value} = await extractValues(dateTimePicker);
 					const expected = year + 1;
@@ -155,7 +155,7 @@ describe('DateTimePicker', function () {
 				it('should decrease the year when decrementing the picker', async function () {
 					const {year} = await extractValues(dateTimePicker);
 					await dateTimePicker.dateDecrementer('year').click();
-					await Page.delay(200);
+					await Page.delay(300);
 					expect(await dateTimePicker.dateDecrementer('year').isFocused()).toBe(true);
 					const {year: value} = await extractValues(dateTimePicker);
 					const expected = year - 1;
@@ -172,7 +172,7 @@ describe('DateTimePicker', function () {
 				it('should not update on select', async function () {
 					await dateTimePicker.focus();
 					await Page.spotlightSelect();
-					await Page.delay(200);
+					await Page.delay(300);
 
 					const {day, hour, minute, meridiem,  month, year} = await extractValues(dateTimePicker);
 
@@ -192,7 +192,7 @@ describe('DateTimePicker', function () {
 
 			it('should not increase the day when incrementing disabled picker', async function () {
 				await dateTimePicker.dateIncrementer('day').click();
-				await Page.delay(200);
+				await Page.delay(500);
 				expect(await dateTimePicker.dateIncrementer('day').isFocused()).toBe(true);
 				const {day: value} = await extractValues(dateTimePicker);
 				expect(value).toBe(1);
@@ -200,7 +200,7 @@ describe('DateTimePicker', function () {
 
 			it('should not decrease the day when decrementing disabled picker', async function () {
 				await dateTimePicker.dateDecrementer('day').click();
-				await Page.delay(200);
+				await Page.delay(300);
 				expect(await dateTimePicker.dateDecrementer('day').isFocused()).toBe(true);
 				const {day: value} = await extractValues(dateTimePicker);
 				expect(value).toBe(1);
@@ -209,7 +209,7 @@ describe('DateTimePicker', function () {
 			it('should not update hour on click', async function () {
 				const {hour} = await extractValues(dateTimePicker);
 				await dateTimePicker.timeDecrementer('hour').click();
-				await Page.delay(200);
+				await Page.delay(300);
 				expect(await dateTimePicker.timeDecrementer('hour').isFocused()).toBe(true);
 				const {hour: value} = await extractValues(dateTimePicker);
 				expect(value).toBe(hour);
@@ -234,32 +234,32 @@ describe('DateTimePicker', function () {
 			it('should not update \'defaultValue\' on on click', async function () {
 				const {day, hour, meridiem, minute, month, year} = await extractValues(dateTimePicker);
 				await dateTimePicker.dateDecrementer('month').click();
-				await Page.delay(200);
+				await Page.delay(300);
 				expect(await dateTimePicker.dateDecrementer('month').isFocused()).toBe(true);
 
 				await dateTimePicker.dateDecrementer('day').click();
-				await Page.delay(200);
+				await Page.delay(300);
 				expect(await dateTimePicker.dateDecrementer('day').isFocused()).toBe(true);
 
 				await dateTimePicker.dateDecrementer('year').click();
-				await Page.delay(200);
+				await Page.delay(300);
 				expect(await dateTimePicker.dateDecrementer('year').isFocused()).toBe(true);
 
 				await dateTimePicker.timeDecrementer('minute').click();
-				await Page.delay(200);
+				await Page.delay(300);
 				expect(await dateTimePicker.timeDecrementer('minute').isFocused()).toBe(true);
 
 				await dateTimePicker.timeDecrementer('hour').click();
-				await Page.delay(200);
+				await Page.delay(300);
 				expect(await dateTimePicker.timeDecrementer('hour').isFocused()).toBe(true);
 
 				if (meridiem === 'AM') {
 					await dateTimePicker.timeIncrementer('meridiem').click();
-					await Page.delay(200);
+					await Page.delay(300);
 					expect(await dateTimePicker.timeIncrementer('meridiem').isFocused()).toBe(true);
 				} else {
 					await dateTimePicker.timeDecrementer('meridiem').click();
-					await Page.delay(200);
+					await Page.delay(300);
 					expect(await dateTimePicker.timeDecrementer('meridiem').isFocused()).toBe(true);
 				}
 
@@ -334,7 +334,7 @@ describe('DateTimePicker', function () {
 
 		it('should display hours in 24-hour format', async function () {
 			await dateTimePicker.timeIncrementer('hour').click();
-			await Page.delay(200);
+			await Page.delay(300);
 			expect((await extractValues(dateTimePicker)).hour).toBe(13);
 		});
 
@@ -342,13 +342,13 @@ describe('DateTimePicker', function () {
 			// go to 23 first
 			for (let i = 11; i; i -= 1) {
 				await dateTimePicker.timeIncrementer('hour').click();
-				await Page.delay(200);
+				await Page.delay(300);
 			}
 			await Page.delay(500);
 			expect((await extractValues(dateTimePicker)).hour).toBe(23);
 			// now increment
 			await dateTimePicker.timeIncrementer('hour').click();
-			await Page.delay(200);
+			await Page.delay(500);
 			expect((await extractValues(dateTimePicker)).hour).toBe(0);
 		});
 
@@ -356,11 +356,11 @@ describe('DateTimePicker', function () {
 			// go to 0 first
 			for (let i = 12; i; i -= 1) {
 				await dateTimePicker.timeDecrementer('hour').click();
-				await Page.delay(200);
+				await Page.delay(300);
 			}
 			expect((await extractValues(dateTimePicker)).hour).toBe(0);
 			await dateTimePicker.timeDecrementer('hour').click();
-			await Page.delay(200);
+			await Page.delay(300);
 			expect((await extractValues(dateTimePicker)).hour).toBe(23);
 		});
 	});

--- a/tests/ui/specs/DateTimePicker/DateTimePicker-specs.js
+++ b/tests/ui/specs/DateTimePicker/DateTimePicker-specs.js
@@ -45,6 +45,7 @@ describe('DateTimePicker', function () {
 				it('should increase the hour when incrementing the picker', async function () {
 					const {hour} = await extractValues(dateTimePicker);
 					await dateTimePicker.timeIncrementer('hour').click();
+					await Page.delay(200);
 					const {hour: value} = await extractValues(dateTimePicker);
 					const expected = hour < 12 ? hour + 1 : 1;
 					expect(value).toBe(expected);
@@ -53,6 +54,7 @@ describe('DateTimePicker', function () {
 				it('should decrease the hour when decrementing the picker', async function () {
 					const {hour} = await extractValues(dateTimePicker);
 					await dateTimePicker.timeDecrementer('hour').click();
+					await Page.delay(200);
 					const {hour: value} = await extractValues(dateTimePicker);
 					const expected = hour > 1 ? hour - 1 : 12;
 					expect(value).toBe(expected);
@@ -61,6 +63,7 @@ describe('DateTimePicker', function () {
 				it('should increase the minute when incrementing the picker', async function () {
 					const {minute} = await extractValues(dateTimePicker);
 					await dateTimePicker.timeIncrementer('minute').click();
+					await Page.delay(200);
 					await browser.waitUntil(async () => await dateTimePicker.timeIncrementer('minute').isFocused(), {timeout: 1500,  interval: 100});
 					const {minute: value} = await extractValues(dateTimePicker);
 					const expected = minute !== 59 ? minute + 1 : 0;
@@ -70,6 +73,7 @@ describe('DateTimePicker', function () {
 				it('should decrease the minute when decrementing the picker', async function () {
 					const {minute} = await extractValues(dateTimePicker);
 					await dateTimePicker.timeDecrementer('minute').click();
+					await Page.delay(200);
 					await browser.waitUntil(async () => await dateTimePicker.timeDecrementer('minute').isFocused(), {timeout: 1500,  interval: 100});
 					const {minute: value} = await extractValues(dateTimePicker);
 					const expected = minute !== 0 ? minute - 1 : 59;
@@ -82,11 +86,13 @@ describe('DateTimePicker', function () {
 						// 12 hours ought to change the value text if meridiem changes
 						for (let i = 12; i; i -= 1) {
 							await dateTimePicker.timeIncrementer('hour').click();
+							await Page.delay(200);
 						}
 					} else {
 						// 12 hours ought to change the value text if meridiem changes
 						for (let i = 12; i; i -= 1) {
 							await dateTimePicker.timeDecrementer('hour').click();
+							await Page.delay(200);
 						}
 					}
 
@@ -97,6 +103,7 @@ describe('DateTimePicker', function () {
 				it('should increase the month when incrementing the picker', async function () {
 					const {month} = await extractValues(dateTimePicker);
 					await dateTimePicker.dateIncrementer('month').click();
+					await Page.delay(200);
 					expect(await dateTimePicker.dateIncrementer('month').isFocused()).toBe(true);
 					const {month: value} = await extractValues(dateTimePicker);
 					const expected = month < 12 ? month + 1 : 1;
@@ -106,6 +113,7 @@ describe('DateTimePicker', function () {
 				it('should decrease the month when decrementing the picker', async function () {
 					const {month} = await extractValues(dateTimePicker);
 					await dateTimePicker.dateDecrementer('month').click();
+					await Page.delay(200);
 					expect(await dateTimePicker.dateDecrementer('month').isFocused()).toBe(true);
 					const {month: value} = await extractValues(dateTimePicker);
 					const expected = month > 1 ? month - 1 : 12;
@@ -116,7 +124,7 @@ describe('DateTimePicker', function () {
 					const {day, month, year} = await extractValues(dateTimePicker);
 					const numDays = daysInMonth({month, year});
 					await dateTimePicker.dateIncrementer('day').click();
-					await browser.pause(500);
+					await Page.delay(200);
 					expect(await dateTimePicker.dateIncrementer('day').isFocused()).toBe(true);
 					const {day: value} = await extractValues(dateTimePicker);
 					const expected = day !== numDays ? day + 1 : 1;
@@ -127,6 +135,7 @@ describe('DateTimePicker', function () {
 					const {day, month, year} = await extractValues(dateTimePicker);
 					const numDays = daysInMonth({month, year});
 					await dateTimePicker.dateDecrementer('day').click();
+					await Page.delay(200);
 					expect(await dateTimePicker.dateDecrementer('day').isFocused()).toBe(true);
 					const {day: value} = await extractValues(dateTimePicker);
 					const expected = day !== 1 ? day - 1 : numDays;
@@ -136,8 +145,8 @@ describe('DateTimePicker', function () {
 				it('should increase the year when incrementing the picker', async function () {
 					const {year} = await extractValues(dateTimePicker);
 					await dateTimePicker.dateIncrementer('year').click();
+					await Page.delay(200);
 					expect(await dateTimePicker.dateIncrementer('year').isFocused()).toBe(true);
-					await browser.pause(500);
 					const {year: value} = await extractValues(dateTimePicker);
 					const expected = year + 1;
 					expect(value).toBe(expected);
@@ -146,6 +155,7 @@ describe('DateTimePicker', function () {
 				it('should decrease the year when decrementing the picker', async function () {
 					const {year} = await extractValues(dateTimePicker);
 					await dateTimePicker.dateDecrementer('year').click();
+					await Page.delay(200);
 					expect(await dateTimePicker.dateDecrementer('year').isFocused()).toBe(true);
 					const {year: value} = await extractValues(dateTimePicker);
 					const expected = year - 1;
@@ -162,6 +172,7 @@ describe('DateTimePicker', function () {
 				it('should not update on select', async function () {
 					await dateTimePicker.focus();
 					await Page.spotlightSelect();
+					await Page.delay(200);
 
 					const {day, hour, minute, meridiem,  month, year} = await extractValues(dateTimePicker);
 
@@ -181,16 +192,16 @@ describe('DateTimePicker', function () {
 
 			it('should not increase the day when incrementing disabled picker', async function () {
 				await dateTimePicker.dateIncrementer('day').click();
+				await Page.delay(200);
 				expect(await dateTimePicker.dateIncrementer('day').isFocused()).toBe(true);
-				await browser.pause(500);
 				const {day: value} = await extractValues(dateTimePicker);
 				expect(value).toBe(1);
 			});
 
 			it('should not decrease the day when decrementing disabled picker', async function () {
 				await dateTimePicker.dateDecrementer('day').click();
+				await Page.delay(200);
 				expect(await dateTimePicker.dateDecrementer('day').isFocused()).toBe(true);
-				await browser.pause(500);
 				const {day: value} = await extractValues(dateTimePicker);
 				expect(value).toBe(1);
 			});
@@ -198,8 +209,8 @@ describe('DateTimePicker', function () {
 			it('should not update hour on click', async function () {
 				const {hour} = await extractValues(dateTimePicker);
 				await dateTimePicker.timeDecrementer('hour').click();
+				await Page.delay(200);
 				expect(await dateTimePicker.timeDecrementer('hour').isFocused()).toBe(true);
-				await browser.pause(500);
 				const {hour: value} = await extractValues(dateTimePicker);
 				expect(value).toBe(hour);
 			});
@@ -223,29 +234,36 @@ describe('DateTimePicker', function () {
 			it('should not update \'defaultValue\' on on click', async function () {
 				const {day, hour, meridiem, minute, month, year} = await extractValues(dateTimePicker);
 				await dateTimePicker.dateDecrementer('month').click();
+				await Page.delay(200);
 				expect(await dateTimePicker.dateDecrementer('month').isFocused()).toBe(true);
 
 				await dateTimePicker.dateDecrementer('day').click();
+				await Page.delay(200);
 				expect(await dateTimePicker.dateDecrementer('day').isFocused()).toBe(true);
 
 				await dateTimePicker.dateDecrementer('year').click();
+				await Page.delay(200);
 				expect(await dateTimePicker.dateDecrementer('year').isFocused()).toBe(true);
 
 				await dateTimePicker.timeDecrementer('minute').click();
+				await Page.delay(200);
 				expect(await dateTimePicker.timeDecrementer('minute').isFocused()).toBe(true);
 
 				await dateTimePicker.timeDecrementer('hour').click();
+				await Page.delay(200);
 				expect(await dateTimePicker.timeDecrementer('hour').isFocused()).toBe(true);
 
 				if (meridiem === 'AM') {
 					await dateTimePicker.timeIncrementer('meridiem').click();
+					await Page.delay(200);
 					expect(await dateTimePicker.timeIncrementer('meridiem').isFocused()).toBe(true);
 				} else {
 					await dateTimePicker.timeDecrementer('meridiem').click();
+					await Page.delay(200);
 					expect(await dateTimePicker.timeDecrementer('meridiem').isFocused()).toBe(true);
 				}
 
-				await browser.pause(500);
+				await Page.delay(500);
 
 				expect(day).toBe(6);
 				expect(month).toBe(6);
@@ -316,6 +334,7 @@ describe('DateTimePicker', function () {
 
 		it('should display hours in 24-hour format', async function () {
 			await dateTimePicker.timeIncrementer('hour').click();
+			await Page.delay(200);
 			expect((await extractValues(dateTimePicker)).hour).toBe(13);
 		});
 
@@ -323,12 +342,13 @@ describe('DateTimePicker', function () {
 			// go to 23 first
 			for (let i = 11; i; i -= 1) {
 				await dateTimePicker.timeIncrementer('hour').click();
+				await Page.delay(200);
 			}
-			await browser.pause(500);
+			await Page.delay(500);
 			expect((await extractValues(dateTimePicker)).hour).toBe(23);
 			// now increment
 			await dateTimePicker.timeIncrementer('hour').click();
-			await browser.pause(500);
+			await Page.delay(200);
 			expect((await extractValues(dateTimePicker)).hour).toBe(0);
 		});
 
@@ -336,9 +356,11 @@ describe('DateTimePicker', function () {
 			// go to 0 first
 			for (let i = 12; i; i -= 1) {
 				await dateTimePicker.timeDecrementer('hour').click();
+				await Page.delay(200);
 			}
 			expect((await extractValues(dateTimePicker)).hour).toBe(0);
 			await dateTimePicker.timeDecrementer('hour').click();
+			await Page.delay(200);
 			expect((await extractValues(dateTimePicker)).hour).toBe(23);
 		});
 	});

--- a/tests/ui/specs/DateTimePicker/DateTimePicker-specs.js
+++ b/tests/ui/specs/DateTimePicker/DateTimePicker-specs.js
@@ -200,7 +200,7 @@ describe('DateTimePicker', function () {
 
 			it('should not decrease the day when decrementing disabled picker', async function () {
 				await dateTimePicker.dateDecrementer('day').click();
-				await Page.delay(300);
+				await Page.delay(500);
 				expect(await dateTimePicker.dateDecrementer('day').isFocused()).toBe(true);
 				const {day: value} = await extractValues(dateTimePicker);
 				expect(value).toBe(1);
@@ -209,7 +209,7 @@ describe('DateTimePicker', function () {
 			it('should not update hour on click', async function () {
 				const {hour} = await extractValues(dateTimePicker);
 				await dateTimePicker.timeDecrementer('hour').click();
-				await Page.delay(300);
+				await Page.delay(500);
 				expect(await dateTimePicker.timeDecrementer('hour').isFocused()).toBe(true);
 				const {hour: value} = await extractValues(dateTimePicker);
 				expect(value).toBe(hour);

--- a/tests/ui/specs/Picker/Picker-specs.js
+++ b/tests/ui/specs/Picker/Picker-specs.js
@@ -16,7 +16,7 @@ describe('Picker', function () {
 					it('should change the value forward when incrementing the picker', async function () {
 						expect(await picker.incrementer().isFocused()).toBe(true);
 						await Page.spotlightSelect();
-						await Page.delay(200);
+						await Page.delay(500);
 						const newValue = await extractValue(picker);
 						expect(newValue).toBe('Banana');
 					});
@@ -24,11 +24,11 @@ describe('Picker', function () {
 					it('should change the value backward when decrementing the picker', async function () {
 						expect(await picker.incrementer().isFocused()).toBe(true);
 						await Page.spotlightSelect();
-						await Page.delay(200);
+						await Page.delay(300);
 						await Page.spotlightUp();
 						expect(await picker.decrementer().isFocused()).toBe(true);
 						await Page.spotlightSelect();
-						await Page.delay(200);
+						await Page.delay(500);
 						const newValue = await extractValue(picker);
 						expect(newValue).toBe('Apple');
 					});
@@ -37,17 +37,17 @@ describe('Picker', function () {
 				describe('pointer', function () {
 					it('should increase the value when incrementing the picker', async function () {
 						await picker.incrementer().click();
-						await Page.delay(200);
+						await Page.delay(500);
 						const newValue = await extractValue(picker);
 						expect(newValue).toBe('Banana');
 					});
 
 					it('should decrease the value when decrementing the picker', async function () {
 						await picker.incrementer().click();
-						await Page.delay(200);
+						await Page.delay(300);
 						expect(await picker.incrementer().isFocused()).toBe(true);
 						await picker.decrementer().click();
-						await Page.delay(200);
+						await Page.delay(500);
 						const newValue = await extractValue(picker);
 						expect(newValue).toBe('Apple');
 					});
@@ -71,7 +71,7 @@ describe('Picker', function () {
 					it('should not update on select', async function () {
 						const oldValue = await extractValue(picker);
 						await Page.spotlightSelect();
-						await Page.delay(200);
+						await Page.delay(500);
 						await picker.focus();
 						const newValue = await extractValue(picker);
 						expect(newValue).toBe(oldValue);
@@ -82,7 +82,7 @@ describe('Picker', function () {
 					it('should not increase the value when clicking the incrementer', async function () {
 						const oldValue = await extractValue(picker);
 						await picker.incrementer().click();
-						await Page.delay(200);
+						await Page.delay(500);
 						const newValue = await extractValue(picker);
 						expect(newValue).toBe(oldValue);
 					});
@@ -90,7 +90,7 @@ describe('Picker', function () {
 					it('should not decrease the value when clicking the decrementer', async function () {
 						const oldValue = await extractValue(picker);
 						await picker.decrementer().click();
-						await Page.delay(200);
+						await Page.delay(500);
 						const newValue = await extractValue(picker);
 						expect(newValue).toBe(oldValue);
 					});
@@ -109,7 +109,7 @@ describe('Picker', function () {
 							await Page.spotlightDown();
 						}
 						await Page.spotlightSelect();
-						await Page.delay(200);
+						await Page.delay(500);
 						const newValue = await extractValue(picker);
 						expect(newValue).toBe('Banana');
 					});
@@ -120,10 +120,10 @@ describe('Picker', function () {
 							await Page.spotlightDown();
 						}
 						await Page.spotlightSelect();
-						await Page.delay(200);
+						await Page.delay(500);
 						await Page.spotlightLeft();
 						await Page.spotlightSelect();
-						await Page.delay(200);
+						await Page.delay(500);
 						const newValue = await extractValue(picker);
 						expect(newValue).toBe('Apple');
 					});
@@ -132,17 +132,17 @@ describe('Picker', function () {
 				describe('pointer', function () {
 					it('should increase the value when incrementing the picker', async function () {
 						await picker.incrementer().click();
-						await Page.delay(200);
+						await Page.delay(500);
 						const newValue = await extractValue(picker);
 						expect(newValue).toBe('Banana');
 					});
 
 					it('should decrease the value when decrementing the picker', async function () {
 						await picker.incrementer().click();
-						await Page.delay(200);
+						await Page.delay(300);
 						expect(await picker.incrementer().isFocused()).toBe(true);
 						await picker.decrementer().click();
-						await Page.delay(200);
+						await Page.delay(500);
 						const newValue = await extractValue(picker);
 						expect(newValue).toBe('Apple');
 					});
@@ -168,12 +168,12 @@ describe('Picker', function () {
 						// 5-way down to increment button of horizontal default picker increment button
 						for (let i = 0; i <= 6; i++) {
 							await Page.spotlightSelect();
-							await Page.delay(200);
+							await Page.delay(300);
 						}
 						// focus decrement button of horizontal disabled picker and 5-way Select
 						await Page.spotlightRight();
 						await Page.spotlightSelect();
-						await Page.delay(200);
+						await Page.delay(300);
 						const newValue = await extractValue(picker);
 						expect(newValue).toBe(oldValue);
 					});
@@ -183,7 +183,7 @@ describe('Picker', function () {
 					it('should not increase the value when clicking the incrementer', async function () {
 						const oldValue = await extractValue(picker);
 						await picker.incrementer().click();
-						await Page.delay(200);
+						await Page.delay(500);
 						const newValue = await extractValue(picker);
 						expect(newValue).toBe(oldValue);
 					});
@@ -191,7 +191,7 @@ describe('Picker', function () {
 					it('should not decrease the value when decrementing the picker', async function () {
 						const oldValue = await extractValue(picker);
 						await picker.decrementer().click();
-						await Page.delay(200);
+						await Page.delay(500);
 						const newValue = await extractValue(picker);
 						expect(newValue).toBe(oldValue);
 					});
@@ -212,7 +212,7 @@ describe('Picker', function () {
 				it('should change the value forward when incrementing the picker', async function () {
 					expect(await picker.incrementer().isFocused()).toBe(true);
 					await Page.spotlightSelect();
-					await Page.delay(200);
+					await Page.delay(500);
 					const newValue = await extractValue(picker);
 					expect(newValue).toBe('Banana');
 				});
@@ -220,11 +220,11 @@ describe('Picker', function () {
 				it('should change the value backward when decrementing the picker', async function () {
 					expect(await picker.incrementer().isFocused()).toBe(true);
 					await Page.spotlightSelect();
-					await Page.delay(200);
+					await Page.delay(await browser.pause(500););
 					await Page.spotlightUp();
 					expect(await picker.decrementer().isFocused()).toBe(true);
 					await Page.spotlightSelect();
-					await Page.delay(200);
+					await Page.delay(500);
 					const newValue = await extractValue(picker);
 					expect(newValue).toBe('Apple');
 				});
@@ -233,17 +233,17 @@ describe('Picker', function () {
 			describe('pointer', function () {
 				it('should increase the value when incrementing the picker', async function () {
 					await picker.incrementer().click();
-					await Page.delay(200);
+					await Page.delay(500);
 					const newValue = await extractValue(picker);
 					expect(newValue).toBe('Banana');
 				});
 
 				it('should decrease the value when decrementing the picker', async function () {
 					await picker.incrementer().click();
-					await Page.delay(200);
+					await Page.delay(300);
 					expect(await picker.incrementer().isFocused()).toBe(true);
 					await picker.decrementer().click();
-					await Page.delay(200);
+					await Page.delay(500);
 					const newValue = await extractValue(picker);
 					expect(newValue).toBe('Apple');
 				});
@@ -260,7 +260,7 @@ describe('Picker', function () {
 						await Page.spotlightDown();
 					}
 					await Page.spotlightSelect();
-					await Page.delay(200);
+					await Page.delay(500);
 					const newValue = await extractValue(picker);
 					expect(newValue).toBe('Banana');
 				});
@@ -271,10 +271,10 @@ describe('Picker', function () {
 						await Page.spotlightDown();
 					}
 					await Page.spotlightSelect();
-					await Page.delay(200);
+					await Page.delay(500);
 					await Page.spotlightRight();
 					await Page.spotlightSelect();
-					await Page.delay(200);
+					await Page.delay(500);
 					const newValue = await extractValue(picker);
 					expect(newValue).toBe('Apple');
 				});
@@ -283,17 +283,17 @@ describe('Picker', function () {
 			describe('pointer', function () {
 				it('should increase the value when incrementing the picker', async function () {
 					await picker.incrementer().click();
-					await Page.delay(200);
+					await Page.delay(500);
 					const newValue = await extractValue(picker);
 					expect(newValue).toBe('Banana');
 				});
 
 				it('should decrease the value when decrementing the picker', async function () {
 					await picker.incrementer().click();
-					await Page.delay(200);
+					await Page.delay(300);
 					expect(await picker.incrementer().isFocused()).toBe(true);
 					await picker.decrementer().click();
-					await Page.delay(200);
+					await Page.delay(500);
 					const newValue = await extractValue(picker);
 					expect(newValue).toBe('Apple');
 				});

--- a/tests/ui/specs/Picker/Picker-specs.js
+++ b/tests/ui/specs/Picker/Picker-specs.js
@@ -16,7 +16,7 @@ describe('Picker', function () {
 					it('should change the value forward when incrementing the picker', async function () {
 						expect(await picker.incrementer().isFocused()).toBe(true);
 						await Page.spotlightSelect();
-						await browser.pause(500);
+						await Page.delay(200);
 						const newValue = await extractValue(picker);
 						expect(newValue).toBe('Banana');
 					});
@@ -24,10 +24,11 @@ describe('Picker', function () {
 					it('should change the value backward when decrementing the picker', async function () {
 						expect(await picker.incrementer().isFocused()).toBe(true);
 						await Page.spotlightSelect();
+						await Page.delay(200);
 						await Page.spotlightUp();
 						expect(await picker.decrementer().isFocused()).toBe(true);
 						await Page.spotlightSelect();
-						await browser.pause(500);
+						await Page.delay(200);
 						const newValue = await extractValue(picker);
 						expect(newValue).toBe('Apple');
 					});
@@ -36,16 +37,17 @@ describe('Picker', function () {
 				describe('pointer', function () {
 					it('should increase the value when incrementing the picker', async function () {
 						await picker.incrementer().click();
-						await browser.pause(500);
+						await Page.delay(200);
 						const newValue = await extractValue(picker);
 						expect(newValue).toBe('Banana');
 					});
 
 					it('should decrease the value when decrementing the picker', async function () {
 						await picker.incrementer().click();
+						await Page.delay(200);
 						expect(await picker.incrementer().isFocused()).toBe(true);
 						await picker.decrementer().click();
-						await browser.pause(500);
+						await Page.delay(200);
 						const newValue = await extractValue(picker);
 						expect(newValue).toBe('Apple');
 					});
@@ -69,8 +71,8 @@ describe('Picker', function () {
 					it('should not update on select', async function () {
 						const oldValue = await extractValue(picker);
 						await Page.spotlightSelect();
+						await Page.delay(200);
 						await picker.focus();
-						await browser.pause(500);
 						const newValue = await extractValue(picker);
 						expect(newValue).toBe(oldValue);
 					});
@@ -80,7 +82,7 @@ describe('Picker', function () {
 					it('should not increase the value when clicking the incrementer', async function () {
 						const oldValue = await extractValue(picker);
 						await picker.incrementer().click();
-						browser.pause(500);
+						await Page.delay(200);
 						const newValue = await extractValue(picker);
 						expect(newValue).toBe(oldValue);
 					});
@@ -88,7 +90,7 @@ describe('Picker', function () {
 					it('should not decrease the value when clicking the decrementer', async function () {
 						const oldValue = await extractValue(picker);
 						await picker.decrementer().click();
-						await browser.pause(500);
+						await Page.delay(200);
 						const newValue = await extractValue(picker);
 						expect(newValue).toBe(oldValue);
 					});
@@ -107,7 +109,7 @@ describe('Picker', function () {
 							await Page.spotlightDown();
 						}
 						await Page.spotlightSelect();
-						await browser.pause(500);
+						await Page.delay(200);
 						const newValue = await extractValue(picker);
 						expect(newValue).toBe('Banana');
 					});
@@ -118,10 +120,10 @@ describe('Picker', function () {
 							await Page.spotlightDown();
 						}
 						await Page.spotlightSelect();
-						await browser.pause(500);
+						await Page.delay(200);
 						await Page.spotlightLeft();
 						await Page.spotlightSelect();
-						await browser.pause(500);
+						await Page.delay(200);
 						const newValue = await extractValue(picker);
 						expect(newValue).toBe('Apple');
 					});
@@ -130,16 +132,17 @@ describe('Picker', function () {
 				describe('pointer', function () {
 					it('should increase the value when incrementing the picker', async function () {
 						await picker.incrementer().click();
-						await browser.pause(500);
+						await Page.delay(200);
 						const newValue = await extractValue(picker);
 						expect(newValue).toBe('Banana');
 					});
 
 					it('should decrease the value when decrementing the picker', async function () {
 						await picker.incrementer().click();
+						await Page.delay(200);
 						expect(await picker.incrementer().isFocused()).toBe(true);
 						await picker.decrementer().click();
-						await browser.pause(500);
+						await Page.delay(200);
 						const newValue = await extractValue(picker);
 						expect(newValue).toBe('Apple');
 					});
@@ -165,10 +168,12 @@ describe('Picker', function () {
 						// 5-way down to increment button of horizontal default picker increment button
 						for (let i = 0; i <= 6; i++) {
 							await Page.spotlightSelect();
+							await Page.delay(200);
 						}
 						// focus decrement button of horizontal disabled picker and 5-way Select
 						await Page.spotlightRight();
 						await Page.spotlightSelect();
+						await Page.delay(200);
 						const newValue = await extractValue(picker);
 						expect(newValue).toBe(oldValue);
 					});
@@ -178,7 +183,7 @@ describe('Picker', function () {
 					it('should not increase the value when clicking the incrementer', async function () {
 						const oldValue = await extractValue(picker);
 						await picker.incrementer().click();
-						browser.pause(500);
+						await Page.delay(200);
 						const newValue = await extractValue(picker);
 						expect(newValue).toBe(oldValue);
 					});
@@ -186,7 +191,7 @@ describe('Picker', function () {
 					it('should not decrease the value when decrementing the picker', async function () {
 						const oldValue = await extractValue(picker);
 						await picker.decrementer().click();
-						await browser.pause(500);
+						await Page.delay(200);
 						const newValue = await extractValue(picker);
 						expect(newValue).toBe(oldValue);
 					});
@@ -207,7 +212,7 @@ describe('Picker', function () {
 				it('should change the value forward when incrementing the picker', async function () {
 					expect(await picker.incrementer().isFocused()).toBe(true);
 					await Page.spotlightSelect();
-					await browser.pause(500);
+					await Page.delay(200);
 					const newValue = await extractValue(picker);
 					expect(newValue).toBe('Banana');
 				});
@@ -215,10 +220,11 @@ describe('Picker', function () {
 				it('should change the value backward when decrementing the picker', async function () {
 					expect(await picker.incrementer().isFocused()).toBe(true);
 					await Page.spotlightSelect();
+					await Page.delay(200);
 					await Page.spotlightUp();
 					expect(await picker.decrementer().isFocused()).toBe(true);
 					await Page.spotlightSelect();
-					await browser.pause(500);
+					await Page.delay(200);
 					const newValue = await extractValue(picker);
 					expect(newValue).toBe('Apple');
 				});
@@ -227,16 +233,17 @@ describe('Picker', function () {
 			describe('pointer', function () {
 				it('should increase the value when incrementing the picker', async function () {
 					await picker.incrementer().click();
-					await browser.pause(500);
+					await Page.delay(200);
 					const newValue = await extractValue(picker);
 					expect(newValue).toBe('Banana');
 				});
 
 				it('should decrease the value when decrementing the picker', async function () {
 					await picker.incrementer().click();
+					await Page.delay(200);
 					expect(await picker.incrementer().isFocused()).toBe(true);
 					await picker.decrementer().click();
-					await browser.pause(500);
+					await Page.delay(200);
 					const newValue = await extractValue(picker);
 					expect(newValue).toBe('Apple');
 				});
@@ -253,7 +260,7 @@ describe('Picker', function () {
 						await Page.spotlightDown();
 					}
 					await Page.spotlightSelect();
-					await browser.pause(500);
+					await Page.delay(200);
 					const newValue = await extractValue(picker);
 					expect(newValue).toBe('Banana');
 				});
@@ -264,10 +271,10 @@ describe('Picker', function () {
 						await Page.spotlightDown();
 					}
 					await Page.spotlightSelect();
-					await browser.pause(500);
+					await Page.delay(200);
 					await Page.spotlightRight();
 					await Page.spotlightSelect();
-					await browser.pause(500);
+					await Page.delay(200);
 					const newValue = await extractValue(picker);
 					expect(newValue).toBe('Apple');
 				});
@@ -276,16 +283,17 @@ describe('Picker', function () {
 			describe('pointer', function () {
 				it('should increase the value when incrementing the picker', async function () {
 					await picker.incrementer().click();
-					await browser.pause(500);
+					await Page.delay(200);
 					const newValue = await extractValue(picker);
 					expect(newValue).toBe('Banana');
 				});
 
 				it('should decrease the value when decrementing the picker', async function () {
 					await picker.incrementer().click();
+					await Page.delay(200);
 					expect(await picker.incrementer().isFocused()).toBe(true);
 					await picker.decrementer().click();
-					await browser.pause(500);
+					await Page.delay(200);
 					const newValue = await extractValue(picker);
 					expect(newValue).toBe('Apple');
 				});

--- a/tests/ui/specs/Picker/Picker-specs.js
+++ b/tests/ui/specs/Picker/Picker-specs.js
@@ -220,7 +220,7 @@ describe('Picker', function () {
 				it('should change the value backward when decrementing the picker', async function () {
 					expect(await picker.incrementer().isFocused()).toBe(true);
 					await Page.spotlightSelect();
-					await Page.delay(await browser.pause(500););
+					await Page.delay(300);
 					await Page.spotlightUp();
 					expect(await picker.decrementer().isFocused()).toBe(true);
 					await Page.spotlightSelect();

--- a/tests/ui/specs/RangePicker/RangePicker-specs.js
+++ b/tests/ui/specs/RangePicker/RangePicker-specs.js
@@ -253,7 +253,7 @@ describe('RangePicker', function () {
 					const oldValue = await extractValue(rangePicker);
 					expect(oldValue).toBe(10);
 					await rangePicker.incrementer().click();
-					await Page.delay(300);
+					await Page.delay(500);
 					expect(await rangePicker.incrementer().isFocused()).toBe(true);
 					const newValue = extractValue(rangePicker);
 					expect(await newValue).toBe(0);
@@ -322,7 +322,7 @@ describe('RangePicker', function () {
 						await Page.spotlightDown();
 					}
 					await Page.spotlightSelect();
-					await Page.delay(300);
+					await Page.delay(500);
 					const newValue = await extractValue(rangePicker);
 					expect(newValue).toBe(5);
 				});

--- a/tests/ui/specs/RangePicker/RangePicker-specs.js
+++ b/tests/ui/specs/RangePicker/RangePicker-specs.js
@@ -14,10 +14,10 @@ describe('RangePicker', function () {
 
 				describe('5-way', function () {
 					it('should change the value forward when incrementing the rangePicker', async function () {
-						rangePicker.incrementer().focus();
+						await rangePicker.incrementer().focus();
 						expect(await rangePicker.incrementer().isFocused()).toBe(true);
 						await Page.spotlightSelect();
-						await browser.pause(5000);
+						await Page.delay(200);
 						const newValue = await extractValue(rangePicker);
 						expect(newValue).toBe(5);
 					});
@@ -25,10 +25,11 @@ describe('RangePicker', function () {
 					it('should change the value backward when decrementing the rangePicker', async function () {
 						expect(await rangePicker.incrementer().isFocused()).toBe(true);
 						await Page.spotlightSelect();
+						await Page.delay(200);
 						await Page.spotlightUp();
 						expect(await rangePicker.decrementer().isFocused()).toBe(true);
 						await Page.spotlightSelect();
-						await browser.pause(500);
+						await Page.delay(200);
 						const newValue = await extractValue(rangePicker);
 						expect(newValue).toBe(0);
 					});
@@ -37,16 +38,17 @@ describe('RangePicker', function () {
 				describe('pointer', function () {
 					it('should increase the value when incrementing the rangePicker', async function () {
 						await rangePicker.incrementer().click();
-						await browser.pause(500);
+						await Page.delay(200);
 						const newValue = await extractValue(rangePicker);
 						expect(newValue).toBe(5);
 					});
 
 					it('should decrease the value when decrementing the rangePicker', async function () {
 						await rangePicker.incrementer().click();
+						await Page.delay(200);
 						expect(await rangePicker.incrementer().isFocused()).toBe(true);
 						await rangePicker.decrementer().click();
-						await browser.pause(500);
+						await Page.delay(200);
 						const newValue = await extractValue(rangePicker);
 						expect(newValue).toBe(0);
 					});
@@ -60,8 +62,8 @@ describe('RangePicker', function () {
 					it('should not update on select', async function () {
 						const oldValue = await extractValue(rangePicker);
 						await Page.spotlightSelect();
+						await Page.delay(200);
 						await rangePicker.focus();
-						await browser.pause(500);
 						const newValue = await extractValue(rangePicker);
 						expect(newValue).toBe(oldValue);
 					});
@@ -71,7 +73,7 @@ describe('RangePicker', function () {
 					it('should not increase the value when clicking the incrementer', async function () {
 						const oldValue = await extractValue(rangePicker);
 						await rangePicker.incrementer().click();
-						await browser.pause(500);
+						await Page.delay(200);
 						const newValue = await extractValue(rangePicker);
 						expect(newValue).toBe(oldValue);
 					});
@@ -79,7 +81,7 @@ describe('RangePicker', function () {
 					it('should not decrease the value when clicking the decrementer', async function () {
 						const oldValue = await extractValue(rangePicker);
 						await rangePicker.decrementer().click();
-						await browser.pause(500);
+						await Page.delay(200);
 						const newValue = await extractValue(rangePicker);
 						expect(newValue).toBe(oldValue);
 					});
@@ -96,7 +98,7 @@ describe('RangePicker', function () {
 
 				it('should decrement to negative number', async function () {
 					await rangePicker.decrementer().click();
-					await browser.pause(500);
+					await Page.delay(200);
 					const newValue = await extractValue(rangePicker);
 					expect(newValue).toBe(-1);
 				});
@@ -109,7 +111,7 @@ describe('RangePicker', function () {
 					const oldValue = await extractValue(rangePicker);
 					expect(oldValue).toBe(0);
 					await rangePicker.decrementer().click();
-					await browser.pause(500);
+					await Page.delay(200);
 					const newValue = await extractValue(rangePicker);
 					expect(newValue).toBe(10);
 				});
@@ -117,13 +119,13 @@ describe('RangePicker', function () {
 				it('should increase to min value', async function () {
 					for (let i = 0; i < 10; i++) {
 						await rangePicker.incrementer().click();
-						await browser.pause(100);
+						await Page.delay(200);
 					}
 					const oldValue = await extractValue(rangePicker);
 					expect(oldValue).toBe(10);
 					await rangePicker.incrementer().click();
+					await Page.delay(200);
 					expect(await rangePicker.incrementer().isFocused()).toBe(true);
-					await browser.pause(500);
 					const newValue = extractValue(rangePicker);
 					expect(await newValue).toBe(0);
 				});
@@ -141,7 +143,7 @@ describe('RangePicker', function () {
 							await Page.spotlightDown();
 						}
 						await Page.spotlightSelect();
-						await browser.pause(500);
+						await Page.delay(200);
 						const newValue = await extractValue(rangePicker);
 						expect(newValue).toBe(5);
 					});
@@ -152,10 +154,10 @@ describe('RangePicker', function () {
 							await Page.spotlightDown();
 						}
 						await Page.spotlightSelect();
-						await browser.pause(500);
+						await Page.delay(200);
 						await Page.spotlightLeft();
 						await Page.spotlightSelect();
-						await browser.pause(500);
+						await Page.delay(200);
 						const newValue = await extractValue(rangePicker);
 						expect(newValue).toBe(0);
 					});
@@ -164,16 +166,17 @@ describe('RangePicker', function () {
 				describe('pointer', function () {
 					it('should increase the value when incrementing the range picker', async function () {
 						await rangePicker.incrementer().click();
-						await browser.pause(500);
+						await Page.delay(200);
 						const newValue = await extractValue(rangePicker);
 						expect(newValue).toBe(5);
 					});
 
 					it('should decrease the value when decrementing the range picker', async function () {
 						await rangePicker.incrementer().click();
+						await Page.delay(200);
 						expect(await rangePicker.incrementer().isFocused()).toBe(true);
 						await rangePicker.decrementer().click();
-						await browser.pause(500);
+						await Page.delay(200);
 						const newValue = await extractValue(rangePicker);
 						expect(newValue).toBe(0);
 					});
@@ -187,8 +190,8 @@ describe('RangePicker', function () {
 					it('should not update on select', async function () {
 						const oldValue = await extractValue(rangePicker);
 						await Page.spotlightSelect();
+						await Page.delay(200);
 						await rangePicker.focus();
-						await browser.pause(500);
 						const newValue = await extractValue(rangePicker);
 						expect(newValue).toBe(oldValue);
 					});
@@ -198,7 +201,7 @@ describe('RangePicker', function () {
 					it('should not increase the value when clicking the incrementer', async function () {
 						const oldValue = await extractValue(rangePicker);
 						await rangePicker.incrementer().click();
-						await browser.pause(500);
+						await Page.delay(200);
 						const newValue = await extractValue(rangePicker);
 						expect(newValue).toBe(oldValue);
 					});
@@ -206,7 +209,7 @@ describe('RangePicker', function () {
 					it('should not decrease the value when clicking the decrementer', async function () {
 						const oldValue = await extractValue(rangePicker);
 						await rangePicker.decrementer().click();
-						await browser.pause(500);
+						await Page.delay(200);
 						const newValue = await extractValue(rangePicker);
 						expect(newValue).toBe(oldValue);
 					});
@@ -223,7 +226,7 @@ describe('RangePicker', function () {
 
 				it('should decrement to negative number', async function () {
 					await rangePicker.decrementer().click();
-					await browser.pause(500);
+					await Page.delay(200);
 					const newValue = await extractValue(rangePicker);
 					expect(newValue).toBe(-1);
 				});
@@ -236,7 +239,7 @@ describe('RangePicker', function () {
 					const oldValue = await extractValue(rangePicker);
 					expect(oldValue).toBe(0);
 					await rangePicker.decrementer().click();
-					await browser.pause(500);
+					await Page.delay(200);
 					const newValue = await extractValue(rangePicker);
 					expect(newValue).toBe(10);
 				});
@@ -244,13 +247,14 @@ describe('RangePicker', function () {
 				it('should increase to min value', async function () {
 					for (let i = 0; i < 10; i++) {
 						await rangePicker.incrementer().click();
+						await Page.delay(200);
 					}
-					await browser.pause(500);
+					await Page.delay(500);
 					const oldValue = await extractValue(rangePicker);
 					expect(oldValue).toBe(10);
 					await rangePicker.incrementer().click();
+					await Page.delay(200);
 					expect(await rangePicker.incrementer().isFocused()).toBe(true);
-					await browser.pause(500);
 					const newValue = extractValue(rangePicker);
 					expect(await newValue).toBe(0);
 				});
@@ -270,7 +274,7 @@ describe('RangePicker', function () {
 				it('should change the value forward when incrementing the range picker', async function () {
 					expect(await rangePicker.incrementer().isFocused()).toBe(true);
 					await Page.spotlightSelect();
-					await browser.pause(500);
+					await Page.delay(200);
 					const newValue = await extractValue(rangePicker);
 					expect(newValue).toBe(5);
 				});
@@ -278,10 +282,11 @@ describe('RangePicker', function () {
 				it('should change the value backward when decrementing the range picker', async function () {
 					expect(await rangePicker.incrementer().isFocused()).toBe(true);
 					await Page.spotlightSelect();
+					await Page.delay(200);
 					await Page.spotlightUp();
 					expect(await rangePicker.decrementer().isFocused()).toBe(true);
 					await Page.spotlightSelect();
-					await browser.pause(500);
+					await Page.delay(200);
 					const newValue = await extractValue(rangePicker);
 					expect(newValue).toBe(0);
 				});
@@ -290,16 +295,17 @@ describe('RangePicker', function () {
 			describe('pointer', function () {
 				it('should increase the value when incrementing the range picker', async function () {
 					await rangePicker.incrementer().click();
-					await browser.pause(500);
+					await Page.delay(200);
 					const newValue = await extractValue(rangePicker);
 					expect(newValue).toBe(5);
 				});
 
 				it('should decrease the value when decrementing the range picker', async function () {
 					await rangePicker.incrementer().click();
+					await Page.delay(200);
 					expect(await rangePicker.incrementer().isFocused()).toBe(true);
 					await rangePicker.decrementer().click();
-					await browser.pause(500);
+					await Page.delay(200);
 					const newValue = await extractValue(rangePicker);
 					expect(newValue).toBe(0);
 				});
@@ -316,7 +322,7 @@ describe('RangePicker', function () {
 						await Page.spotlightDown();
 					}
 					await Page.spotlightSelect();
-					await browser.pause(500);
+					await Page.delay(200);
 					const newValue = await extractValue(rangePicker);
 					expect(newValue).toBe(5);
 				});
@@ -327,9 +333,10 @@ describe('RangePicker', function () {
 						await Page.spotlightDown();
 					}
 					await Page.spotlightSelect();
+					await Page.delay(200);
 					await Page.spotlightRight();
 					await Page.spotlightSelect();
-					await browser.pause(500);
+					await Page.delay(200);
 					const newValue = await extractValue(rangePicker);
 					expect(newValue).toBe(0);
 				});
@@ -338,16 +345,17 @@ describe('RangePicker', function () {
 			describe('pointer', async function () {
 				it('should increase the value when incrementing the range picker', async function () {
 					await rangePicker.incrementer().click();
-					await browser.pause(500);
+					await Page.delay(200);
 					const newValue = await extractValue(rangePicker);
 					expect(newValue).toBe(5);
 				});
 
 				it('should decrease the value when decrementing the range picker', async function () {
 					await rangePicker.incrementer().click();
+					await Page.delay(200);
 					expect(await rangePicker.incrementer().isFocused()).toBe(true);
 					await rangePicker.decrementer().click();
-					await browser.pause(500);
+					await Page.delay(200);
 					const newValue = await extractValue(rangePicker);
 					expect(newValue).toBe(0);
 				});

--- a/tests/ui/specs/RangePicker/RangePicker-specs.js
+++ b/tests/ui/specs/RangePicker/RangePicker-specs.js
@@ -17,7 +17,7 @@ describe('RangePicker', function () {
 						await rangePicker.focusIncrementer();
 						expect(await rangePicker.incrementer().isFocused()).toBe(true);
 						await Page.spotlightSelect();
-						await Page.delay(200);
+						await Page.delay(5000);
 						const newValue = await extractValue(rangePicker);
 						expect(newValue).toBe(5);
 					});
@@ -25,11 +25,11 @@ describe('RangePicker', function () {
 					it('should change the value backward when decrementing the rangePicker', async function () {
 						expect(await rangePicker.incrementer().isFocused()).toBe(true);
 						await Page.spotlightSelect();
-						await Page.delay(200);
+						await Page.delay(300);
 						await Page.spotlightUp();
 						expect(await rangePicker.decrementer().isFocused()).toBe(true);
 						await Page.spotlightSelect();
-						await Page.delay(200);
+						await Page.delay(500);
 						const newValue = await extractValue(rangePicker);
 						expect(newValue).toBe(0);
 					});
@@ -38,17 +38,17 @@ describe('RangePicker', function () {
 				describe('pointer', function () {
 					it('should increase the value when incrementing the rangePicker', async function () {
 						await rangePicker.incrementer().click();
-						await Page.delay(200);
+						await Page.delay(500);
 						const newValue = await extractValue(rangePicker);
 						expect(newValue).toBe(5);
 					});
 
 					it('should decrease the value when decrementing the rangePicker', async function () {
 						await rangePicker.incrementer().click();
-						await Page.delay(200);
+						await Page.delay(300);
 						expect(await rangePicker.incrementer().isFocused()).toBe(true);
 						await rangePicker.decrementer().click();
-						await Page.delay(200);
+						await Page.delay(500);
 						const newValue = await extractValue(rangePicker);
 						expect(newValue).toBe(0);
 					});
@@ -62,7 +62,7 @@ describe('RangePicker', function () {
 					it('should not update on select', async function () {
 						const oldValue = await extractValue(rangePicker);
 						await Page.spotlightSelect();
-						await Page.delay(200);
+						await Page.delay(500);
 						await rangePicker.focus();
 						const newValue = await extractValue(rangePicker);
 						expect(newValue).toBe(oldValue);
@@ -73,7 +73,7 @@ describe('RangePicker', function () {
 					it('should not increase the value when clicking the incrementer', async function () {
 						const oldValue = await extractValue(rangePicker);
 						await rangePicker.incrementer().click();
-						await Page.delay(200);
+						await Page.delay(500);
 						const newValue = await extractValue(rangePicker);
 						expect(newValue).toBe(oldValue);
 					});
@@ -81,7 +81,7 @@ describe('RangePicker', function () {
 					it('should not decrease the value when clicking the decrementer', async function () {
 						const oldValue = await extractValue(rangePicker);
 						await rangePicker.decrementer().click();
-						await Page.delay(200);
+						await Page.delay(500);
 						const newValue = await extractValue(rangePicker);
 						expect(newValue).toBe(oldValue);
 					});
@@ -98,7 +98,7 @@ describe('RangePicker', function () {
 
 				it('should decrement to negative number', async function () {
 					await rangePicker.decrementer().click();
-					await Page.delay(200);
+					await Page.delay(500);
 					const newValue = await extractValue(rangePicker);
 					expect(newValue).toBe(-1);
 				});
@@ -111,7 +111,7 @@ describe('RangePicker', function () {
 					const oldValue = await extractValue(rangePicker);
 					expect(oldValue).toBe(0);
 					await rangePicker.decrementer().click();
-					await Page.delay(200);
+					await Page.delay(500);
 					const newValue = await extractValue(rangePicker);
 					expect(newValue).toBe(10);
 				});
@@ -119,12 +119,12 @@ describe('RangePicker', function () {
 				it('should increase to min value', async function () {
 					for (let i = 0; i < 10; i++) {
 						await rangePicker.incrementer().click();
-						await Page.delay(200);
+						await Page.delay(300);
 					}
 					const oldValue = await extractValue(rangePicker);
 					expect(oldValue).toBe(10);
 					await rangePicker.incrementer().click();
-					await Page.delay(200);
+					await Page.delay(300);
 					expect(await rangePicker.incrementer().isFocused()).toBe(true);
 					const newValue = extractValue(rangePicker);
 					expect(await newValue).toBe(0);
@@ -143,7 +143,7 @@ describe('RangePicker', function () {
 							await Page.spotlightDown();
 						}
 						await Page.spotlightSelect();
-						await Page.delay(200);
+						await Page.delay(500);
 						const newValue = await extractValue(rangePicker);
 						expect(newValue).toBe(5);
 					});
@@ -154,10 +154,10 @@ describe('RangePicker', function () {
 							await Page.spotlightDown();
 						}
 						await Page.spotlightSelect();
-						await Page.delay(200);
+						await Page.delay(500);
 						await Page.spotlightLeft();
 						await Page.spotlightSelect();
-						await Page.delay(200);
+						await Page.delay(500);
 						const newValue = await extractValue(rangePicker);
 						expect(newValue).toBe(0);
 					});
@@ -166,17 +166,17 @@ describe('RangePicker', function () {
 				describe('pointer', function () {
 					it('should increase the value when incrementing the range picker', async function () {
 						await rangePicker.incrementer().click();
-						await Page.delay(200);
+						await Page.delay(500);
 						const newValue = await extractValue(rangePicker);
 						expect(newValue).toBe(5);
 					});
 
 					it('should decrease the value when decrementing the range picker', async function () {
 						await rangePicker.incrementer().click();
-						await Page.delay(200);
+						await Page.delay(300);
 						expect(await rangePicker.incrementer().isFocused()).toBe(true);
 						await rangePicker.decrementer().click();
-						await Page.delay(200);
+						await Page.delay(500);
 						const newValue = await extractValue(rangePicker);
 						expect(newValue).toBe(0);
 					});
@@ -190,7 +190,7 @@ describe('RangePicker', function () {
 					it('should not update on select', async function () {
 						const oldValue = await extractValue(rangePicker);
 						await Page.spotlightSelect();
-						await Page.delay(200);
+						await Page.delay(500);
 						await rangePicker.focus();
 						const newValue = await extractValue(rangePicker);
 						expect(newValue).toBe(oldValue);
@@ -201,7 +201,7 @@ describe('RangePicker', function () {
 					it('should not increase the value when clicking the incrementer', async function () {
 						const oldValue = await extractValue(rangePicker);
 						await rangePicker.incrementer().click();
-						await Page.delay(200);
+						await Page.delay(500);
 						const newValue = await extractValue(rangePicker);
 						expect(newValue).toBe(oldValue);
 					});
@@ -209,7 +209,7 @@ describe('RangePicker', function () {
 					it('should not decrease the value when clicking the decrementer', async function () {
 						const oldValue = await extractValue(rangePicker);
 						await rangePicker.decrementer().click();
-						await Page.delay(200);
+						await Page.delay(500);
 						const newValue = await extractValue(rangePicker);
 						expect(newValue).toBe(oldValue);
 					});
@@ -226,7 +226,7 @@ describe('RangePicker', function () {
 
 				it('should decrement to negative number', async function () {
 					await rangePicker.decrementer().click();
-					await Page.delay(200);
+					await Page.delay(500);
 					const newValue = await extractValue(rangePicker);
 					expect(newValue).toBe(-1);
 				});
@@ -239,7 +239,7 @@ describe('RangePicker', function () {
 					const oldValue = await extractValue(rangePicker);
 					expect(oldValue).toBe(0);
 					await rangePicker.decrementer().click();
-					await Page.delay(200);
+					await Page.delay(500);
 					const newValue = await extractValue(rangePicker);
 					expect(newValue).toBe(10);
 				});
@@ -247,13 +247,13 @@ describe('RangePicker', function () {
 				it('should increase to min value', async function () {
 					for (let i = 0; i < 10; i++) {
 						await rangePicker.incrementer().click();
-						await Page.delay(200);
+						await Page.delay(300);
 					}
 					await Page.delay(500);
 					const oldValue = await extractValue(rangePicker);
 					expect(oldValue).toBe(10);
 					await rangePicker.incrementer().click();
-					await Page.delay(200);
+					await Page.delay(300);
 					expect(await rangePicker.incrementer().isFocused()).toBe(true);
 					const newValue = extractValue(rangePicker);
 					expect(await newValue).toBe(0);
@@ -274,7 +274,7 @@ describe('RangePicker', function () {
 				it('should change the value forward when incrementing the range picker', async function () {
 					expect(await rangePicker.incrementer().isFocused()).toBe(true);
 					await Page.spotlightSelect();
-					await Page.delay(200);
+					await Page.delay(500);
 					const newValue = await extractValue(rangePicker);
 					expect(newValue).toBe(5);
 				});
@@ -282,11 +282,11 @@ describe('RangePicker', function () {
 				it('should change the value backward when decrementing the range picker', async function () {
 					expect(await rangePicker.incrementer().isFocused()).toBe(true);
 					await Page.spotlightSelect();
-					await Page.delay(200);
+					await Page.delay(300);
 					await Page.spotlightUp();
 					expect(await rangePicker.decrementer().isFocused()).toBe(true);
 					await Page.spotlightSelect();
-					await Page.delay(200);
+					await Page.delay(500);
 					const newValue = await extractValue(rangePicker);
 					expect(newValue).toBe(0);
 				});
@@ -295,17 +295,17 @@ describe('RangePicker', function () {
 			describe('pointer', function () {
 				it('should increase the value when incrementing the range picker', async function () {
 					await rangePicker.incrementer().click();
-					await Page.delay(200);
+					await Page.delay(500);
 					const newValue = await extractValue(rangePicker);
 					expect(newValue).toBe(5);
 				});
 
 				it('should decrease the value when decrementing the range picker', async function () {
 					await rangePicker.incrementer().click();
-					await Page.delay(200);
+					await Page.delay(300);
 					expect(await rangePicker.incrementer().isFocused()).toBe(true);
 					await rangePicker.decrementer().click();
-					await Page.delay(200);
+					await Page.delay(500);
 					const newValue = await extractValue(rangePicker);
 					expect(newValue).toBe(0);
 				});
@@ -322,7 +322,7 @@ describe('RangePicker', function () {
 						await Page.spotlightDown();
 					}
 					await Page.spotlightSelect();
-					await Page.delay(200);
+					await Page.delay(300);
 					const newValue = await extractValue(rangePicker);
 					expect(newValue).toBe(5);
 				});
@@ -333,10 +333,10 @@ describe('RangePicker', function () {
 						await Page.spotlightDown();
 					}
 					await Page.spotlightSelect();
-					await Page.delay(200);
+					await Page.delay(300);
 					await Page.spotlightRight();
 					await Page.spotlightSelect();
-					await Page.delay(200);
+					await Page.delay(500);
 					const newValue = await extractValue(rangePicker);
 					expect(newValue).toBe(0);
 				});
@@ -345,17 +345,17 @@ describe('RangePicker', function () {
 			describe('pointer', async function () {
 				it('should increase the value when incrementing the range picker', async function () {
 					await rangePicker.incrementer().click();
-					await Page.delay(200);
+					await Page.delay(500);
 					const newValue = await extractValue(rangePicker);
 					expect(newValue).toBe(5);
 				});
 
 				it('should decrease the value when decrementing the range picker', async function () {
 					await rangePicker.incrementer().click();
-					await Page.delay(200);
+					await Page.delay(300);
 					expect(await rangePicker.incrementer().isFocused()).toBe(true);
 					await rangePicker.decrementer().click();
-					await Page.delay(200);
+					await Page.delay(500);
 					const newValue = await extractValue(rangePicker);
 					expect(newValue).toBe(0);
 				});

--- a/tests/ui/specs/RangePicker/RangePicker-specs.js
+++ b/tests/ui/specs/RangePicker/RangePicker-specs.js
@@ -14,7 +14,7 @@ describe('RangePicker', function () {
 
 				describe('5-way', function () {
 					it('should change the value forward when incrementing the rangePicker', async function () {
-						await rangePicker.incrementer().focus();
+						await rangePicker.focusIncrementer();
 						expect(await rangePicker.incrementer().isFocused()).toBe(true);
 						await Page.spotlightSelect();
 						await Page.delay(200);

--- a/tests/ui/specs/RangePicker/RangePickerPage.js
+++ b/tests/ui/specs/RangePicker/RangePickerPage.js
@@ -10,6 +10,10 @@ class RangePickerInterface {
 		return browser.execute((el) => el.focus(), await $(`#${this.id}>div`));
 	}
 
+	async focusIncrementer () {
+		return browser.execute((el) => el.focus(), await this.incrementer());
+	}
+
 	get self () {
 		return $(`#${this.id}`, browser);
 	}

--- a/tests/ui/specs/TimePicker/TimePicker-specs.js
+++ b/tests/ui/specs/TimePicker/TimePicker-specs.js
@@ -118,7 +118,7 @@ describe('TimePicker', function () {
 			describe('pointer', function () {
 				it('should select hour when opened', async function () {
 					(await timePicker.decrementer('hour')).click();
-					await Page.delay(500);
+					await Page.delay(300);
 					await browser.waitUntil(async () => await timePicker.decrementer('hour').isFocused(), {timeout: 1500,  interval: 100});
 				});
 
@@ -126,7 +126,7 @@ describe('TimePicker', function () {
 				it('should increase the hour when incrementing the picker', async function () {
 					const {hour} = await extractValues(timePicker);
 					(await timePicker.incrementer('hour')).click();
-					await Page.delay(300);
+					await Page.delay(500);
 					const {hour: value} = await extractValues(timePicker);
 					const expected = hour < 12 ? hour + 1 : 1;
 					expect(value).toBe(expected);

--- a/tests/ui/specs/TimePicker/TimePicker-specs.js
+++ b/tests/ui/specs/TimePicker/TimePicker-specs.js
@@ -34,7 +34,7 @@ describe('TimePicker', function () {
 					const {hour} = await extractValues(timePicker);
 					await browser.waitUntil(async () => (await timePicker.decrementer('hour')).isFocused(), {timeout: 1500,  interval: 100});
 					await Page.spotlightSelect();
-					await Page.delay(200);
+					await Page.delay(300);
 					const {hour: value} = await extractValues(timePicker);
 					const expected = hour > 1 ? hour - 1 : 12;
 					expect(value).toBe(expected);
@@ -45,7 +45,7 @@ describe('TimePicker', function () {
 					await Page.spotlightDown();
 					await browser.waitUntil(async () => (await timePicker.incrementer('hour')).isFocused(), {timeout: 1500,  interval: 100});
 					await Page.spotlightSelect();
-					await Page.delay(200);
+					await Page.delay(300);
 					const {hour: value} = await extractValues(timePicker);
 					const expected = hour < 12 ? hour + 1 : 1;
 					expect(value).toBe(expected);
@@ -56,7 +56,7 @@ describe('TimePicker', function () {
 					await Page.spotlightRight();
 					await browser.waitUntil(async () => (await timePicker.decrementer('minute')).isFocused(), {timeout: 1500,  interval: 100});
 					await Page.spotlightSelect();
-					await Page.delay(200);
+					await Page.delay(300);
 					const {minute: value} = await extractValues(timePicker);
 					const expected = minute !== 0 ? minute - 1 : 59;
 					expect(value).toBe(expected);
@@ -69,7 +69,7 @@ describe('TimePicker', function () {
 					await Page.spotlightDown();
 					await browser.waitUntil(async () => (await timePicker.incrementer('minute')).isFocused(), {timeout: 1500,  interval: 100});
 					await Page.spotlightSelect();
-					await Page.delay(200);
+					await Page.delay(300);
 					const {minute: value} = await extractValues(timePicker);
 					const expected = minute !== 59 ? minute + 1 : 0;
 					expect(value).toBe(expected);
@@ -90,7 +90,7 @@ describe('TimePicker', function () {
 						await browser.waitUntil(async () => (await timePicker.decrementer('meridiem')).isFocused(), {timeout: 1500,  interval: 100});
 					}
 					await Page.spotlightSelect();
-					await Page.delay(200);
+					await Page.delay(300);
 
 					const {hour: value} = await extractValues(timePicker);
 					expect(value).toBe(hour);
@@ -107,7 +107,7 @@ describe('TimePicker', function () {
 					// 12 hours ought to change the value text if meridiem changes
 					for (let i = 12; i; i -= 1) {
 						await Page.spotlightSelect();
-						await Page.delay(200);
+						await Page.delay(300);
 					}
 
 					const {meridiem: value} = await extractValues(timePicker);
@@ -118,7 +118,7 @@ describe('TimePicker', function () {
 			describe('pointer', function () {
 				it('should select hour when opened', async function () {
 					(await timePicker.decrementer('hour')).click();
-					await Page.delay(200);
+					await Page.delay(500);
 					await browser.waitUntil(async () => await timePicker.decrementer('hour').isFocused(), {timeout: 1500,  interval: 100});
 				});
 
@@ -126,7 +126,7 @@ describe('TimePicker', function () {
 				it('should increase the hour when incrementing the picker', async function () {
 					const {hour} = await extractValues(timePicker);
 					(await timePicker.incrementer('hour')).click();
-					await Page.delay(200);
+					await Page.delay(300);
 					const {hour: value} = await extractValues(timePicker);
 					const expected = hour < 12 ? hour + 1 : 1;
 					expect(value).toBe(expected);
@@ -135,7 +135,7 @@ describe('TimePicker', function () {
 				it('should decrease the hour when decrementing the picker', async function () {
 					const {hour} = await extractValues(timePicker);
 					(await timePicker.decrementer('hour')).click();
-					await Page.delay(200);
+					await Page.delay(300);
 					const {hour: value} = await extractValues(timePicker);
 					const expected = hour > 1 ? hour - 1 : 12;
 					expect(value).toBe(expected);
@@ -144,7 +144,7 @@ describe('TimePicker', function () {
 				it('should increase the minute when incrementing the picker', async function () {
 					const {minute} = await extractValues(timePicker);
 					(await timePicker.incrementer('minute')).click();
-					await Page.delay(200);
+					await Page.delay(300);
 					await browser.waitUntil( async () => (await timePicker.incrementer('minute')).isFocused(), {timeout: 1500,  interval: 100});
 					const {minute: value} = await extractValues(timePicker);
 					const expected = minute !== 59 ? minute + 1 : 0;
@@ -154,7 +154,7 @@ describe('TimePicker', function () {
 				it('should decrease the minute when decrementing the picker', async function () {
 					const {minute} = await extractValues(timePicker);
 					(await timePicker.decrementer('minute')).click();
-					await Page.delay(200);
+					await Page.delay(300);
 					await browser.waitUntil(async () => (await timePicker.decrementer('minute')).isFocused(), {timeout: 1500,  interval: 100});
 					const {minute: value} = await extractValues(timePicker);
 					const expected = minute !== 0 ? minute - 1 : 59;
@@ -167,13 +167,13 @@ describe('TimePicker', function () {
 						// 12 hours ought to change the value text if meridiem changes
 						for (let i = 12; i; i -= 1) {
 							(await timePicker.incrementer('hour')).click();
-							await Page.delay(200);
+							await Page.delay(300);
 						}
 					} else {
 						// 12 hours ought to change the value text if meridiem changes
 						for (let i = 12; i; i -= 1) {
 							(await timePicker.decrementer('hour')).click();
-							await Page.delay(200);
+							await Page.delay(300);
 						}
 					}
 
@@ -192,7 +192,7 @@ describe('TimePicker', function () {
 				it('should not update on select', async function () {
 					await timePicker.focus();
 					await Page.spotlightSelect();
-					await Page.delay(200);
+					await Page.delay(300);
 
 					const {hour, minute, meridiem} = await extractValues(timePicker);
 
@@ -209,7 +209,7 @@ describe('TimePicker', function () {
 			describe('5-way', function () {
 				it('should not update on select', async function () {
 					await Page.spotlightSelect();
-					await Page.delay(200);
+					await Page.delay(300);
 					await timePicker.focus();
 				});
 			});
@@ -218,7 +218,7 @@ describe('TimePicker', function () {
 				it('should not update hour on click', async function () {
 					const {hour} = await extractValues(timePicker);
 					await timePicker.decrementer('hour').click();
-					await Page.delay(200);
+					await Page.delay(500);
 					expect(await (await timePicker.decrementer('hour')).isFocused()).toBe(true);
 					const {hour: value} = await extractValues(timePicker);
 					expect(value).toBe(hour);
@@ -232,20 +232,20 @@ describe('TimePicker', function () {
 				const {hour, minute, meridiem} = await extractValues(timePicker);
 
 				(await timePicker.decrementer('minute')).click();
-				await Page.delay(200);
+				await Page.delay(300);
 				expect(await timePicker.decrementer('minute').isFocused()).toBe(true);
 
 				(await timePicker.decrementer('hour')).click();
-				await Page.delay(200);
+				await Page.delay(300);
 				expect(await timePicker.decrementer('hour').isFocused()).toBe(true);
 
 				if (meridiem === 'AM') {
 					(await timePicker.incrementer('meridiem')).click();
-					await Page.delay(200);
+					await Page.delay(300);
 					expect(await timePicker.incrementer('meridiem').isFocused()).toBe(true);
 				} else {
 					(await timePicker.decrementer('meridiem')).click();
-					await Page.delay(200);
+					await Page.delay(300);
 					expect(await timePicker.decrementer('meridiem').isFocused()).toBe(true);
 				}
 
@@ -312,17 +312,17 @@ describe('TimePicker', function () {
 		it('should increment hours from 23 to 0', async function () {
 			// go to 23 first
 			(await timePicker.decrementer('hour')).click();
-			await Page.delay(200);
+			await Page.delay(500);
 			expect((await extractValues(timePicker)).hour).toBe(23);
 			// now increment
 			(await timePicker.incrementer('hour')).click();
-			await Page.delay(200);
+			await Page.delay(500);
 			expect((await extractValues(timePicker)).hour).toBe(0);
 		});
 
 		it('should decrement hours from 0 to 23', async function () {
 			(await timePicker.decrementer('hour')).click();
-			await Page.delay(200);
+			await Page.delay(300);
 			expect((await extractValues(timePicker)).hour).toBe(23);
 		});
 	});

--- a/tests/ui/specs/TimePicker/TimePicker-specs.js
+++ b/tests/ui/specs/TimePicker/TimePicker-specs.js
@@ -34,6 +34,7 @@ describe('TimePicker', function () {
 					const {hour} = await extractValues(timePicker);
 					await browser.waitUntil(async () => (await timePicker.decrementer('hour')).isFocused(), {timeout: 1500,  interval: 100});
 					await Page.spotlightSelect();
+					await Page.delay(200);
 					const {hour: value} = await extractValues(timePicker);
 					const expected = hour > 1 ? hour - 1 : 12;
 					expect(value).toBe(expected);
@@ -44,6 +45,7 @@ describe('TimePicker', function () {
 					await Page.spotlightDown();
 					await browser.waitUntil(async () => (await timePicker.incrementer('hour')).isFocused(), {timeout: 1500,  interval: 100});
 					await Page.spotlightSelect();
+					await Page.delay(200);
 					const {hour: value} = await extractValues(timePicker);
 					const expected = hour < 12 ? hour + 1 : 1;
 					expect(value).toBe(expected);
@@ -54,6 +56,7 @@ describe('TimePicker', function () {
 					await Page.spotlightRight();
 					await browser.waitUntil(async () => (await timePicker.decrementer('minute')).isFocused(), {timeout: 1500,  interval: 100});
 					await Page.spotlightSelect();
+					await Page.delay(200);
 					const {minute: value} = await extractValues(timePicker);
 					const expected = minute !== 0 ? minute - 1 : 59;
 					expect(value).toBe(expected);
@@ -66,6 +69,7 @@ describe('TimePicker', function () {
 					await Page.spotlightDown();
 					await browser.waitUntil(async () => (await timePicker.incrementer('minute')).isFocused(), {timeout: 1500,  interval: 100});
 					await Page.spotlightSelect();
+					await Page.delay(200);
 					const {minute: value} = await extractValues(timePicker);
 					const expected = minute !== 59 ? minute + 1 : 0;
 					expect(value).toBe(expected);
@@ -86,6 +90,7 @@ describe('TimePicker', function () {
 						await browser.waitUntil(async () => (await timePicker.decrementer('meridiem')).isFocused(), {timeout: 1500,  interval: 100});
 					}
 					await Page.spotlightSelect();
+					await Page.delay(200);
 
 					const {hour: value} = await extractValues(timePicker);
 					expect(value).toBe(hour);
@@ -102,6 +107,7 @@ describe('TimePicker', function () {
 					// 12 hours ought to change the value text if meridiem changes
 					for (let i = 12; i; i -= 1) {
 						await Page.spotlightSelect();
+						await Page.delay(200);
 					}
 
 					const {meridiem: value} = await extractValues(timePicker);
@@ -112,6 +118,7 @@ describe('TimePicker', function () {
 			describe('pointer', function () {
 				it('should select hour when opened', async function () {
 					(await timePicker.decrementer('hour')).click();
+					await Page.delay(200);
 					await browser.waitUntil(async () => await timePicker.decrementer('hour').isFocused(), {timeout: 1500,  interval: 100});
 				});
 
@@ -119,7 +126,7 @@ describe('TimePicker', function () {
 				it('should increase the hour when incrementing the picker', async function () {
 					const {hour} = await extractValues(timePicker);
 					(await timePicker.incrementer('hour')).click();
-					await browser.pause(500);
+					await Page.delay(200);
 					const {hour: value} = await extractValues(timePicker);
 					const expected = hour < 12 ? hour + 1 : 1;
 					expect(value).toBe(expected);
@@ -128,6 +135,7 @@ describe('TimePicker', function () {
 				it('should decrease the hour when decrementing the picker', async function () {
 					const {hour} = await extractValues(timePicker);
 					(await timePicker.decrementer('hour')).click();
+					await Page.delay(200);
 					const {hour: value} = await extractValues(timePicker);
 					const expected = hour > 1 ? hour - 1 : 12;
 					expect(value).toBe(expected);
@@ -136,6 +144,7 @@ describe('TimePicker', function () {
 				it('should increase the minute when incrementing the picker', async function () {
 					const {minute} = await extractValues(timePicker);
 					(await timePicker.incrementer('minute')).click();
+					await Page.delay(200);
 					await browser.waitUntil( async () => (await timePicker.incrementer('minute')).isFocused(), {timeout: 1500,  interval: 100});
 					const {minute: value} = await extractValues(timePicker);
 					const expected = minute !== 59 ? minute + 1 : 0;
@@ -145,6 +154,7 @@ describe('TimePicker', function () {
 				it('should decrease the minute when decrementing the picker', async function () {
 					const {minute} = await extractValues(timePicker);
 					(await timePicker.decrementer('minute')).click();
+					await Page.delay(200);
 					await browser.waitUntil(async () => (await timePicker.decrementer('minute')).isFocused(), {timeout: 1500,  interval: 100});
 					const {minute: value} = await extractValues(timePicker);
 					const expected = minute !== 0 ? minute - 1 : 59;
@@ -157,15 +167,17 @@ describe('TimePicker', function () {
 						// 12 hours ought to change the value text if meridiem changes
 						for (let i = 12; i; i -= 1) {
 							(await timePicker.incrementer('hour')).click();
+							await Page.delay(200);
 						}
 					} else {
 						// 12 hours ought to change the value text if meridiem changes
 						for (let i = 12; i; i -= 1) {
 							(await timePicker.decrementer('hour')).click();
+							await Page.delay(200);
 						}
 					}
 
-					await browser.pause(500);
+					await Page.delay(500);
 					const {meridiem: value} = await extractValues(timePicker);
 					expect(value !== meridiem).toBe(true);
 				});
@@ -180,6 +192,7 @@ describe('TimePicker', function () {
 				it('should not update on select', async function () {
 					await timePicker.focus();
 					await Page.spotlightSelect();
+					await Page.delay(200);
 
 					const {hour, minute, meridiem} = await extractValues(timePicker);
 
@@ -196,6 +209,7 @@ describe('TimePicker', function () {
 			describe('5-way', function () {
 				it('should not update on select', async function () {
 					await Page.spotlightSelect();
+					await Page.delay(200);
 					await timePicker.focus();
 				});
 			});
@@ -204,8 +218,8 @@ describe('TimePicker', function () {
 				it('should not update hour on click', async function () {
 					const {hour} = await extractValues(timePicker);
 					await timePicker.decrementer('hour').click();
+					await Page.delay(200);
 					expect(await (await timePicker.decrementer('hour')).isFocused()).toBe(true);
-					await browser.pause(500);
 					const {hour: value} = await extractValues(timePicker);
 					expect(value).toBe(hour);
 				});
@@ -218,20 +232,24 @@ describe('TimePicker', function () {
 				const {hour, minute, meridiem} = await extractValues(timePicker);
 
 				(await timePicker.decrementer('minute')).click();
+				await Page.delay(200);
 				expect(await timePicker.decrementer('minute').isFocused()).toBe(true);
 
 				(await timePicker.decrementer('hour')).click();
+				await Page.delay(200);
 				expect(await timePicker.decrementer('hour').isFocused()).toBe(true);
 
 				if (meridiem === 'AM') {
 					(await timePicker.incrementer('meridiem')).click();
+					await Page.delay(200);
 					expect(await timePicker.incrementer('meridiem').isFocused()).toBe(true);
 				} else {
 					(await timePicker.decrementer('meridiem')).click();
+					await Page.delay(200);
 					expect(await timePicker.decrementer('meridiem').isFocused()).toBe(true);
 				}
 
-				await browser.pause(500);
+				await Page.delay(500);
 				expect(hour).toBe(12);
 				expect(minute).toBe(0);
 				expect(meridiem).toBe('AM');
@@ -294,16 +312,17 @@ describe('TimePicker', function () {
 		it('should increment hours from 23 to 0', async function () {
 			// go to 23 first
 			(await timePicker.decrementer('hour')).click();
-			await browser.pause(500);
+			await Page.delay(200);
 			expect((await extractValues(timePicker)).hour).toBe(23);
 			// now increment
 			(await timePicker.incrementer('hour')).click();
-			await browser.pause(500);
+			await Page.delay(200);
 			expect((await extractValues(timePicker)).hour).toBe(0);
 		});
 
 		it('should decrement hours from 0 to 23', async function () {
 			(await timePicker.decrementer('hour')).click();
+			await Page.delay(200);
 			expect((await extractValues(timePicker)).hour).toBe(23);
 		});
 	});


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fixed failed `ui-test`

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Added `Page.delay` to wait for animation end after each `click` and `spotlightSelect` in `Picker` related components, because this is the moment when the value is changed, and the transition is triggered 
- Because the `transitionDuration` is `150ms`, a `300ms` delay was added (double of the transition time), and kept the same delay where it was already added

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
NXT-3374

### Comments

Enact-DCO-1.0-Signed-off-by: Ion Andrusciac ion.andrusciac@lgepartner.com