### PR TITLE
NXT-9000: Added manual check for `propTypes`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
     - npm install
     - npm link
     - popd
-    - git clone --branch=feature/NXT-9000 --depth 1 https://github.com/enactjs/enact ../enact
+    - git clone --branch=develop --depth 1 https://github.com/enactjs/enact ../enact
     - pushd ../enact
     - npm uninstall @enact/ui-test-utils --prefix packages/i18n
     - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,12 @@ before_install:
 install:
     - npm config set prefer-offline false
     - npm install -g codecov
-    - git clone --branch=feature/NXT-9000 --depth 1 https://github.com/enactjs/cli ../cli
+    - git clone --branch=master --depth 1 https://github.com/enactjs/cli ../cli
     - pushd ../cli
     - npm install
     - npm link
     - popd
-    - git clone --branch=develop --depth 1 https://github.com/enactjs/enact ../enact
+    - git clone --branch=feature/NXT-9000 --depth 1 https://github.com/enactjs/enact ../enact
     - pushd ../enact
     - npm uninstall @enact/ui-test-utils --prefix packages/i18n
     - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 install:
     - npm config set prefer-offline false
     - npm install -g codecov
-    - git clone --branch=master --depth 1 https://github.com/enactjs/cli ../cli
+    - git clone --branch=feature/NXT-9000 --depth 1 https://github.com/enactjs/cli ../cli
     - pushd ../cli
     - npm install
     - npm link

--- a/ArcPicker/ArcPickerBehaviorDecorator.js
+++ b/ArcPicker/ArcPickerBehaviorDecorator.js
@@ -94,7 +94,7 @@ const ArcPickerBehaviorDecorator = hoc((config, Wrapped) => {
 			checkPropTypes(this, this.props);
 		}
 
-		componentDidUpdate(prevProps) {
+		componentDidUpdate (prevProps) {
 			checkPropTypes(this, this.props, prevProps);
 		}
 

--- a/ArcPicker/ArcPickerBehaviorDecorator.js
+++ b/ArcPicker/ArcPickerBehaviorDecorator.js
@@ -2,6 +2,7 @@ import {forward} from '@enact/core/handle';
 import {is} from '@enact/core/keymap';
 import hoc from '@enact/core/hoc';
 import platform from '@enact/core/platform';
+import {checkPropTypes} from '@enact/core/util';
 import {validateRangeOnce} from '@enact/ui/internal/validators';
 import PropTypes from 'prop-types';
 import {Component} from 'react';
@@ -89,6 +90,12 @@ const ArcPickerBehaviorDecorator = hoc((config, Wrapped) => {
 			this.state = {
 				isFocused: false
 			};
+
+			checkPropTypes(this, this.props);
+		}
+
+		componentDidUpdate(prevProps) {
+			checkPropTypes(this, this.props, prevProps);
 		}
 
 		handleClick = (value) => (ev) => {

--- a/ArcSlider/ArcSliderBehaviorDecorator.js
+++ b/ArcSlider/ArcSliderBehaviorDecorator.js
@@ -1,7 +1,7 @@
 import {forward} from '@enact/core/handle';
 import {is} from '@enact/core/keymap';
 import hoc from '@enact/core/hoc';
-import {clamp} from '@enact/core/util';
+import {checkPropTypes, clamp} from '@enact/core/util';
 import {validateRangeOnce, validateSteppedOnce} from '@enact/ui/internal/validators';
 import PropTypes from 'prop-types';
 import {createRef, Component} from 'react';
@@ -144,12 +144,16 @@ const ArcSliderBehaviorDecorator = hoc((config, Wrapped) => {
 				isFocused: false,
 				value: props.value ? props.value : props.min
 			};
+
+			checkPropTypes(this, this.props);
 		}
 
 		componentDidUpdate (prevProps) {
 			if ( this.props.max !== prevProps.max || this.props.min !== prevProps.min) {
 				this.handleChange(null, clamp(this.props.min, this.props.max, this.state.value));
 			}
+
+			checkPropTypes(this, this.props, prevProps);
 		}
 
 		handleDown = ({clientX, clientY}) => {

--- a/ColorPicker/ColorPicker.js
+++ b/ColorPicker/ColorPicker.js
@@ -15,6 +15,7 @@ import {adaptEvent, forward, handle} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import EnactPropTypes from '@enact/core/internal/prop-types';
 import kind from '@enact/core/kind';
+import {checkPropTypes} from '@enact/core/util';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import Changeable from '@enact/ui/Changeable';
 import Group from '@enact/ui/Group';
@@ -276,6 +277,8 @@ const ColorPickerExtended = hoc((config, Wrapped) => {
 			this.state = {
 				extended: props.defaultExtended || false
 			};
+
+			checkPropTypes(this, this.props);
 		}
 
 		componentDidMount () {
@@ -295,6 +298,8 @@ const ColorPickerExtended = hoc((config, Wrapped) => {
 			} else if (prevProps.open && !open) {
 				off('click', this.handleClick);
 			}
+
+			checkPropTypes(this, this.props, prevProps);
 		}
 
 		componentWillUnmount () {

--- a/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -12,7 +12,7 @@ import {handle, forProp, forKey, forward, stop} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import EnactPropTypes from '@enact/core/internal/prop-types';
 import {WithRef} from '@enact/core/internal/WithRef';
-import {extractAriaProps} from '@enact/core/util';
+import {checkPropTypes, extractAriaProps} from '@enact/core/util';
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import Spotlight, {getDirection} from '@enact/spotlight';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
@@ -283,6 +283,8 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 			if (props.setApiProvider) {
 				props.setApiProvider(this);
 			}
+
+			checkPropTypes(this, this.props);
 		}
 
 		componentDidMount () {
@@ -331,6 +333,8 @@ const Decorator = hoc(defaultConfig, (config, Wrapped) => {
 					this.spotActivator(prevState.activator);
 				}
 			}
+
+			checkPropTypes(this, this.props, prevProps);
 		}
 
 		componentWillUnmount () {

--- a/DropManager/DropManager.js
+++ b/DropManager/DropManager.js
@@ -145,18 +145,18 @@ const DropManager = hoc(defaultConfig, (configHoc, Wrapped) => {
 			arrangeable: false
 		};
 
-		state = {
-			dragging: false,
-			touchOverElement: null
-		};
-
-		constructor(props) {
+		constructor (props) {
 			super(props);
+
+			this.state = {
+				dragging: false,
+				touchOverElement: null
+			};
 
 			checkPropTypes(this, this.props);
 		}
 
-		componentDidUpdate(prevProps) {
+		componentDidUpdate (prevProps) {
 			checkPropTypes(this, this.props, prevProps);
 		}
 

--- a/DropManager/DropManager.js
+++ b/DropManager/DropManager.js
@@ -11,6 +11,7 @@
 
 import hoc from '@enact/core/hoc';
 import kind from '@enact/core/kind';
+import {checkPropTypes} from '@enact/core/util';
 import Changeable from '@enact/ui/Changeable';
 import Slottable from '@enact/ui/Slottable';
 import classnames from 'classnames';
@@ -148,6 +149,16 @@ const DropManager = hoc(defaultConfig, (configHoc, Wrapped) => {
 			dragging: false,
 			touchOverElement: null
 		};
+
+		constructor(props) {
+			super(props);
+
+			checkPropTypes(this, this.props);
+		}
+
+		componentDidUpdate(prevProps) {
+			checkPropTypes(this, this.props, prevProps);
+		}
 
 		addDropTarget = (target) => {
 			target.classList.add('dropTarget');

--- a/Dropdown/DropdownList.js
+++ b/Dropdown/DropdownList.js
@@ -3,6 +3,7 @@ import hoc from '@enact/core/hoc';
 import kind from '@enact/core/kind';
 import EnactPropTypes from '@enact/core/internal/prop-types';
 import {WithRef} from '@enact/core/internal/WithRef';
+import {checkPropTypes} from '@enact/core/util';
 import Spotlight from '@enact/spotlight';
 import ri from '@enact/ui/resolution';
 import PropTypes from 'prop-types';
@@ -216,9 +217,11 @@ const DropdownListSpotlightDecorator = hoc((config, Wrapped) => {
 			};
 
 			this.clientSiblingRef = createRef(null);
+
+			checkPropTypes(this, this.props);
 		}
 
-		componentDidUpdate () {
+		componentDidUpdate (prevProps) {
 			if (this.state.ready === ReadyState.INIT) {
 				this.scrollIntoView();
 			} else if (this.state.ready === ReadyState.SCROLLED) {
@@ -234,6 +237,8 @@ const DropdownListSpotlightDecorator = hoc((config, Wrapped) => {
 					this.resetFocus(keysDiffer);
 				}
 			}
+
+			checkPropTypes(this, this.props, prevProps);
 		}
 
 		setScrollTo = (scrollTo) => {

--- a/Image/Image.js
+++ b/Image/Image.js
@@ -12,6 +12,7 @@
 
 import kind from '@enact/core/kind';
 import hoc from '@enact/core/hoc';
+import {checkPropTypes} from '@enact/core/util';
 import UiImage from '@enact/ui/Image';
 import Pure from '@enact/ui/internal/Pure';
 import {selectSrc} from '@enact/ui/resolution';
@@ -108,10 +109,16 @@ const ResponsiveImageDecorator = hoc((config, Wrapped) => {
 			this.state = {
 				src: selectSrc(this.props.src)
 			};
+
+			checkPropTypes(this, this.props);
 		}
 
 		componentDidMount () {
 			window.addEventListener('resize', this.handleResize);
+		}
+
+		componentDidUpdate(prevProps) {
+			checkPropTypes(this, this.props, prevProps);
 		}
 
 		componentWillUnmount () {

--- a/Image/Image.js
+++ b/Image/Image.js
@@ -117,7 +117,7 @@ const ResponsiveImageDecorator = hoc((config, Wrapped) => {
 			window.addEventListener('resize', this.handleResize);
 		}
 
-		componentDidUpdate(prevProps) {
+		componentDidUpdate (prevProps) {
 			checkPropTypes(this, this.props, prevProps);
 		}
 

--- a/Input/InputSpotlightDecorator.js
+++ b/Input/InputSpotlightDecorator.js
@@ -1,6 +1,7 @@
 import {call, forward, forwardWithPrevent, handle, stopImmediate} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import {is} from '@enact/core/keymap';
+import {checkPropTypes} from '@enact/core/util';
 import {getDirection, Spotlight} from '@enact/spotlight';
 import Pause from '@enact/spotlight/Pause';
 import Spottable from '@enact/spotlight/Spottable';
@@ -139,10 +140,14 @@ const InputSpotlightDecorator = hoc(defaultConfig, (config, Wrapped) => {
 
 			this.paused = new Pause('InputSpotlightDecorator');
 			this.handleKeyDown = handleKeyDown.bind(this);
+
+			checkPropTypes(this, this.props);
 		}
 
-		componentDidUpdate (_, prevState) {
+		componentDidUpdate (prevProps, prevState) {
 			this.updateFocus(prevState);
+
+			checkPropTypes(this, this.props, prevProps);
 		}
 
 		componentWillUnmount () {

--- a/Keypad/Keypad.js
+++ b/Keypad/Keypad.js
@@ -269,7 +269,7 @@ const KeypadBehaviorDecorator = hoc((config, Wrapped) => {
 			checkPropTypes(this, this.props);
 		}
 
-		componentDidUpdate(prevProps) {
+		componentDidUpdate (prevProps) {
 			checkPropTypes(this, this.props, prevProps);
 		}
 

--- a/Keypad/Keypad.js
+++ b/Keypad/Keypad.js
@@ -15,6 +15,7 @@
 import {adaptEvent, forward, handle} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import kind from '@enact/core/kind';
+import {checkPropTypes} from '@enact/core/util';
 import {SpotlightContainerDecorator} from '@enact/spotlight/SpotlightContainerDecorator';
 import Layout, {Cell} from '@enact/ui/Layout';
 import PropTypes from 'prop-types';
@@ -264,6 +265,12 @@ const KeypadBehaviorDecorator = hoc((config, Wrapped) => {
 				charIndex: 0,
 				keypadValue: ''
 			};
+
+			checkPropTypes(this, this.props);
+		}
+
+		componentDidUpdate(prevProps) {
+			checkPropTypes(this, this.props, prevProps);
 		}
 
 		handleKeypadValue = (keyValue) => {

--- a/MediaPlayer/MediaPlayer.js
+++ b/MediaPlayer/MediaPlayer.js
@@ -464,6 +464,10 @@ const MediaPlayerBehaviorDecorator = hoc((config, Wrapped) => {
 			checkPropTypes(this, this.props);
 		}
 
+		componentDidUpdate (prevProps) {
+			checkPropTypes(this, this.props, prevProps);
+		}
+
 		handle = handle.bind(this);
 
 		handlePlay = this.handle(
@@ -475,10 +479,6 @@ const MediaPlayerBehaviorDecorator = hoc((config, Wrapped) => {
 			forwardPause,
 			() => this.pause()
 		);
-
-		componentDidUpdate(prevProps) {
-			checkPropTypes(this, this.props, prevProps);
-		}
 
 		//
 		// Handled Media events

--- a/MediaPlayer/MediaPlayer.js
+++ b/MediaPlayer/MediaPlayer.js
@@ -11,7 +11,7 @@ import {adaptEvent, call, forwardWithPrevent, handle} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import EnactPropTypes from '@enact/core/internal/prop-types';
 import kind from '@enact/core/kind';
-import {memoize} from '@enact/core/util';
+import {checkPropTypes, memoize} from '@enact/core/util';
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import {SpotlightContainerDecorator} from '@enact/spotlight/SpotlightContainerDecorator';
 import {useAnnounce} from '@enact/ui/AnnounceDecorator';
@@ -460,6 +460,8 @@ const MediaPlayerBehaviorDecorator = hoc((config, Wrapped) => {
 				shuffle: false,
 				sourceIndex: 0
 			};
+
+			checkPropTypes(this, this.props);
 		}
 
 		handle = handle.bind(this);
@@ -473,6 +475,10 @@ const MediaPlayerBehaviorDecorator = hoc((config, Wrapped) => {
 			forwardPause,
 			() => this.pause()
 		);
+
+		componentDidUpdate(prevProps) {
+			checkPropTypes(this, this.props, prevProps);
+		}
 
 		//
 		// Handled Media events

--- a/Panels/SharedStateDecorator.js
+++ b/Panels/SharedStateDecorator.js
@@ -1,4 +1,5 @@
 import hoc from '@enact/core/hoc';
+import {checkPropTypes} from '@enact/core/util';
 import PropTypes from 'prop-types';
 import {createContext, Component} from 'react';
 
@@ -66,6 +67,8 @@ const SharedStateDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			this.state = {
 				updateOnMount: false
 			};
+
+			checkPropTypes(this, this.props);
 		}
 
 		componentDidMount () {
@@ -78,6 +81,8 @@ const SharedStateDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			} else if (prevProps.noSharedState && !this.props.noSharedState) {
 				this.loadFromContext();
 			}
+
+			checkPropTypes(this, this.props, prevProps);
 		}
 
 		isUpdateable () {

--- a/Panels/Viewport.js
+++ b/Panels/Viewport.js
@@ -1,4 +1,5 @@
 import {forward, handle} from '@enact/core/handle';
+import {checkPropTypes} from '@enact/core/util';
 import Spotlight from '@enact/spotlight';
 import Pause from '@enact/spotlight/Pause';
 import ViewManager, {shape, SlideBottomArranger as VerticalArranger, SlideRightArranger as HorizontalArranger} from '@enact/ui/ViewManager';
@@ -96,8 +97,8 @@ const ViewportBase = class extends Component {
 		noAnimation: false
 	};
 
-	constructor () {
-		super();
+	constructor (props) {
+		super(props);
 
 		this.nodeRef = createRef();
 		this.paused = new Pause('Viewport');
@@ -105,6 +106,8 @@ const ViewportBase = class extends Component {
 			prevIndex: -1,
 			direction: 'forward'
 		};
+
+		checkPropTypes(this, this.props);
 	}
 
 	static getDerivedStateFromProps (props, state) {
@@ -122,6 +125,8 @@ const ViewportBase = class extends Component {
 		for (let i = prevProps.index; this.context && i > this.props.index; i--) {
 			this.context.delete(i);
 		}
+
+		checkPropTypes(this, this.props, prevProps);
 	}
 
 	componentWillUnmount () {

--- a/Popup/PopupState.js
+++ b/Popup/PopupState.js
@@ -2,6 +2,7 @@ import {on, off} from '@enact/core/dispatcher';
 import {forward} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import {is} from '@enact/core/keymap';
+import {checkPropTypes} from '@enact/core/util';
 import Spotlight, {getDirection} from '@enact/spotlight';
 import Pause from '@enact/spotlight/Pause';
 import FloatingLayer from '@enact/ui/FloatingLayer';
@@ -225,6 +226,8 @@ const PopupState = hoc((config, Wrapped) => {
 				activator: null
 			};
 			checkScrimNone(this.props);
+
+			checkPropTypes(this, this.props);
 		}
 
 		// Spot the content after it's mounted.
@@ -261,6 +264,8 @@ const PopupState = hoc((config, Wrapped) => {
 			}
 
 			checkScrimNone(this.props);
+
+			checkPropTypes(this, this.props, prevProps);
 		}
 
 		componentWillUnmount () {

--- a/Scroller/Scroller.js
+++ b/Scroller/Scroller.js
@@ -16,7 +16,7 @@
  * @exports Scroller
  */
 
-import {setDefaultProps} from '@enact/core/util';
+import {checkPropTypes, setDefaultProps} from '@enact/core/util';
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import {ResizeContext} from '@enact/ui/Resizable';
@@ -62,6 +62,7 @@ const scrollerDefaultProps = {
  */
 let Scroller = (props) => {
 	const scrollerProps = setDefaultProps(props, scrollerDefaultProps);
+	checkPropTypes(Scroller, scrollerProps);
 
 	// Hooks
 	const {

--- a/Slider/SliderBehaviorDecorator.js
+++ b/Slider/SliderBehaviorDecorator.js
@@ -1,6 +1,7 @@
 import {forward} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
 import platform from '@enact/core/platform';
+import {checkPropTypes} from '@enact/core/util';
 import Pause from '@enact/spotlight/Pause';
 import PropTypes from 'prop-types';
 import {Component, createRef} from 'react';
@@ -82,6 +83,8 @@ const SliderBehaviorDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				useHintText: false,
 				prevValue: props.value
 			};
+
+			checkPropTypes(this, this.props);
 		}
 
 		static getDerivedStateFromProps (props, state) {
@@ -92,6 +95,10 @@ const SliderBehaviorDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				};
 			}
 			return null;
+		}
+
+		componentDidUpdate(prevProps) {
+			checkPropTypes(this, this.props, prevProps);
 		}
 
 		componentWillUnmount () {

--- a/Slider/SliderBehaviorDecorator.js
+++ b/Slider/SliderBehaviorDecorator.js
@@ -97,7 +97,7 @@ const SliderBehaviorDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			return null;
 		}
 
-		componentDidUpdate(prevProps) {
+		componentDidUpdate (prevProps) {
 			checkPropTypes(this, this.props, prevProps);
 		}
 

--- a/SliderButton/SliderButtonBehaviorDecorator.js
+++ b/SliderButton/SliderButtonBehaviorDecorator.js
@@ -1,6 +1,7 @@
 import {forward} from '@enact/core/handle';
 import {is} from '@enact/core/keymap';
 import platform from '@enact/core/platform';
+import {checkPropTypes} from '@enact/core/util';
 import PropTypes from 'prop-types';
 import {useCallback, useState, useRef} from 'react';
 
@@ -17,6 +18,7 @@ const isRight = is('right');
 const SliderButtonBehaviorDecorator = (Wrapped) => {
 	// eslint-disable-next-line no-shadow
 	function SliderButtonBehaviorDecorator (props) {
+		checkPropTypes(SliderButtonBehaviorDecorator, props);
 		const {children} = props;
 		const [valueText, setValueText] = useState(children ? children[0] : null);
 		const ref = useRef();

--- a/ThemeDecorator/ThemeDecorator.js
+++ b/ThemeDecorator/ThemeDecorator.js
@@ -10,6 +10,7 @@ import {setDefaultTargetById} from '@enact/core/dispatcher';
 import hoc from '@enact/core/hoc';
 import {addAll} from '@enact/core/keymap';
 import kind from '@enact/core/kind';
+import {checkPropTypes} from '@enact/core/util';
 import I18nDecorator from '@enact/i18n/I18nDecorator';
 import SpotlightRootDecorator from '@enact/spotlight/SpotlightRootDecorator';
 import {ResolutionDecorator} from '@enact/ui/resolution';
@@ -317,6 +318,16 @@ const ThemeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			 */
 			skin: PropTypes.string
 		};
+
+		constructor(props) {
+			super(props);
+
+			checkPropTypes(this, this.props);
+		}
+
+		componentDidUpdate(prevProps) {
+			checkPropTypes(this, this.props, prevProps);
+		}
 
 		render () {
 			const currentSkin = this.props.skin || defaultSkin;

--- a/ThemeDecorator/ThemeDecorator.js
+++ b/ThemeDecorator/ThemeDecorator.js
@@ -319,13 +319,13 @@ const ThemeDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			skin: PropTypes.string
 		};
 
-		constructor(props) {
+		constructor (props) {
 			super(props);
 
 			checkPropTypes(this, this.props);
 		}
 
-		componentDidUpdate(prevProps) {
+		componentDidUpdate (prevProps) {
 			checkPropTypes(this, this.props, prevProps);
 		}
 

--- a/TimePicker/TimePickerBase.js
+++ b/TimePicker/TimePickerBase.js
@@ -1,4 +1,5 @@
 import kind from '@enact/core/kind';
+import {checkPropTypes} from '@enact/core/util';
 import {Component, Fragment} from 'react';
 import PropTypes from 'prop-types';
 
@@ -41,6 +42,8 @@ class HourPicker extends Component {
 			noAnimation: false,
 			prevValue: props.value
 		};
+
+		checkPropTypes(this, this.props);
 	}
 
 	static getDerivedStateFromProps (props, state) {
@@ -54,6 +57,10 @@ class HourPicker extends Component {
 		}
 
 		return null;
+	}
+
+	componentDidUpdate(prevProps) {
+		checkPropTypes(this, this.props, prevProps);
 	}
 
 	render () {

--- a/TimePicker/TimePickerBase.js
+++ b/TimePicker/TimePickerBase.js
@@ -59,7 +59,7 @@ class HourPicker extends Component {
 		return null;
 	}
 
-	componentDidUpdate(prevProps) {
+	componentDidUpdate (prevProps) {
 		checkPropTypes(this, this.props, prevProps);
 	}
 

--- a/TooltipDecorator/TooltipDecorator.js
+++ b/TooltipDecorator/TooltipDecorator.js
@@ -11,7 +11,7 @@
 
 import {forward, handle, forProp} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
-import {Job} from '@enact/core/util';
+import {checkPropTypes, Job} from '@enact/core/util';
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import {FloatingLayerBase} from '@enact/ui/FloatingLayer';
 import ri from '@enact/ui/resolution';
@@ -239,6 +239,8 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 				arrowAnchor: null,
 				position: {top: 0, left: 0}
 			};
+
+			checkPropTypes(this, this.props);
 		}
 
 		componentDidMount () {
@@ -259,6 +261,8 @@ const TooltipDecorator = hoc(defaultConfig, (config, Wrapped) => {
 			)) {
 				this.setTooltipLayout();
 			}
+
+			checkPropTypes(this, this.props, prevProps);
 		}
 
 		componentWillUnmount () {

--- a/TooltipDecorator/tests/TooltipDecorator-specs.js
+++ b/TooltipDecorator/tests/TooltipDecorator-specs.js
@@ -327,11 +327,11 @@ describe('TooltipDecorator Specs', () => {
 				});
 			});
 
-			test('should have `above centerArrow` className when tooltipPosition is set to `left`', async () => {
+			test('should have `above centerArrow` className when tooltipPosition is not defined', async () => {
 				const tooltipText = 'Tooltip';
 				render(
 					<FloatingLayerController>
-						<TooltipButton tooltipDelay={0} tooltipPosition="left" tooltipText={tooltipText}>Label</TooltipButton>
+						<TooltipButton tooltipDelay={0} tooltipText={tooltipText}>Label</TooltipButton>
 					</FloatingLayerController>
 				);
 

--- a/VirtualList/VirtualList.js
+++ b/VirtualList/VirtualList.js
@@ -6,7 +6,7 @@
  * @exports VirtualList
  */
 
-import {setDefaultProps} from '@enact/core/util';
+import {checkPropTypes, setDefaultProps} from '@enact/core/util';
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import {ResizeContext} from '@enact/ui/Resizable';
@@ -50,6 +50,7 @@ const virtualListDefaultProps = {
  * @public
  */
 let VirtualList = (props) => {
+	checkPropTypes(VirtualList, props);
 	const virtualListProps = setDefaultProps(props, virtualListDefaultProps);
 	const {itemSize, role, ...rest} = virtualListProps;
 
@@ -505,6 +506,7 @@ const virtualGridListDefaultProps = {
  * @public
  */
 let VirtualGridList = (props) => {
+	checkPropTypes(VirtualGridList, props);
 	const virtualGridListProps = setDefaultProps(props, virtualGridListDefaultProps);
 	const {role, ...rest} = virtualGridListProps;
 

--- a/internal/DateTime/DateTimeDecorator.js
+++ b/internal/DateTime/DateTimeDecorator.js
@@ -121,7 +121,7 @@ const DateTimeDecorator = hoc((config, Wrapped) => {
 			return null;
 		}
 
-		componentDidUpdate(prevProps) {
+		componentDidUpdate (prevProps) {
 			checkPropTypes(this, this.props, prevProps);
 		}
 

--- a/internal/DateTime/DateTimeDecorator.js
+++ b/internal/DateTime/DateTimeDecorator.js
@@ -7,7 +7,7 @@
 
 import {forward} from '@enact/core/handle';
 import hoc from '@enact/core/hoc';
-import {memoize} from '@enact/core/util';
+import {checkPropTypes, memoize} from '@enact/core/util';
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import Changeable from '@enact/ui/Changeable';
 import DateFactory from 'ilib/lib/DateFactory';
@@ -99,6 +99,8 @@ const DateTimeDecorator = hoc((config, Wrapped) => {
 					this.handlers[name] = this.handlePickerChange.bind(this, handlers[name]);
 				});
 			}
+
+			checkPropTypes(this, this.props);
 		}
 
 		static getDerivedStateFromProps (props, state) {
@@ -117,6 +119,10 @@ const DateTimeDecorator = hoc((config, Wrapped) => {
 			}
 
 			return null;
+		}
+
+		componentDidUpdate(prevProps) {
+			checkPropTypes(this, this.props, prevProps);
 		}
 
 		/**

--- a/package.json
+++ b/package.json
@@ -63,6 +63,9 @@
   },
   "overrides": {
     "autolinker": "^4.1.5",
+    "prop-types": {
+      "react-is": "^19.2.3"
+    },
     "vue-template-compiler": "^3.0.0"
   }
 }

--- a/samples/perf-virtuallist-native-with-different-item-size/src/views/HorizontalDifferentWidthItemList.js
+++ b/samples/perf-virtuallist-native-with-different-item-size/src/views/HorizontalDifferentWidthItemList.js
@@ -1,5 +1,6 @@
 import Item from '@enact/agate/Item';
 import {VirtualList} from '@enact/agate/VirtualList';
+import {checkPropTypes} from '@enact/core/util';
 import ri from '@enact/ui/resolution';
 import PropTypes from 'prop-types';
 import {useCallback, useEffect, useState} from 'react';
@@ -35,7 +36,9 @@ const innerItemStyleDefault = {
 	writingMode: 'vertical-rl'
 };
 
-const DifferenctWidthItem = ({index, items, style: itemStyleFromList, ...rest}) => {
+const DifferentWidthItem = (props) => {
+	checkPropTypes(DifferentWidthItem, props);
+	const {index, items, style: itemStyleFromList, ...rest} = props;
 	const
 		{title: children, width} = items[index],
 		itemStyle = {...itemStyleDefault, ...itemStyleFromList, width: width + 'px'};
@@ -49,12 +52,12 @@ const DifferenctWidthItem = ({index, items, style: itemStyleFromList, ...rest}) 
 	);
 };
 
-DifferenctWidthItem.propTypes = {
+DifferentWidthItem.propTypes = {
 	index: PropTypes.number,
 	items: PropTypes.array
 };
 
-const HorizontalDifferenctWidthItemList = (props) => {
+const HorizontalDifferentWidthItemList = (props) => {
 	const [items, setItems] = useState([]);
 	const [itemSize, setItemSize] = useState([]);
 
@@ -77,7 +80,7 @@ const HorizontalDifferenctWidthItemList = (props) => {
 	}, []);
 
 	const renderItem = useCallback((renderProps) => {
-		return <DifferenctWidthItem {...renderProps} />;
+		return <DifferentWidthItem {...renderProps} />;
 	}, []);
 
 	return (
@@ -100,4 +103,4 @@ const HorizontalDifferenctWidthItemList = (props) => {
 	);
 };
 
-export default HorizontalDifferenctWidthItemList;
+export default HorizontalDifferentWidthItemList;

--- a/samples/perf-virtuallist-native-with-different-item-size/src/views/VerticalDifferentHeightItemList.js
+++ b/samples/perf-virtuallist-native-with-different-item-size/src/views/VerticalDifferentHeightItemList.js
@@ -1,5 +1,6 @@
 import Item from '@enact/agate/Item';
 import {VirtualList} from '@enact/agate/VirtualList';
+import {checkPropTypes} from '@enact/core/util';
 import ri from '@enact/ui/resolution';
 import PropTypes from 'prop-types';
 import {useCallback, useEffect, useState} from 'react';
@@ -28,7 +29,9 @@ const itemStyleDefault = {
 	lineHeight
 };
 
-const DifferenctHeightItem = ({index, items, style: itemStyleFromList, ...rest}) => {
+const DifferentHeightItem = (props) => {
+	checkPropTypes(DifferentHeightItem, props);
+	const {index, items, style: itemStyleFromList, ...rest} = props;
 	const {title: children, height} = items[index],
 		itemStyle = {...itemStyleDefault, ...itemStyleFromList, height};
 
@@ -39,7 +42,7 @@ const DifferenctHeightItem = ({index, items, style: itemStyleFromList, ...rest})
 	);
 };
 
-DifferenctHeightItem.propTypes = {
+DifferentHeightItem.propTypes = {
 	index: PropTypes.number,
 	items: PropTypes.array
 };
@@ -68,7 +71,7 @@ const VerticalDifferentHeightItemList = (props) => {
 	}, []);
 
 	const renderItem = useCallback((renderProps) => {
-		return <DifferenctHeightItem {...renderProps} />;
+		return <DifferentHeightItem {...renderProps} />;
 	}, []);
 
 	return (

--- a/samples/perf-virtuallist-native-with-different-item-size/src/views/VerticalExpandableDifferentHeightItemList.js
+++ b/samples/perf-virtuallist-native-with-different-item-size/src/views/VerticalExpandableDifferentHeightItemList.js
@@ -1,6 +1,7 @@
 import Button from '@enact/agate/Button';
 import Icon from '@enact/agate/Icon';
 import {VirtualList} from '@enact/agate/VirtualList';
+import {checkPropTypes} from '@enact/core/util';
 import ri from '@enact/ui/resolution';
 import PropTypes from 'prop-types';
 import {useCallback, useEffect, useRef, useState} from 'react';
@@ -53,7 +54,9 @@ const iconButtonStyleDefault = {
 	right: 0
 };
 
-const ExpandableDifferentHeightItem = ({index, 'data-index': dataIndex, items, ref, style: itemStyleFromList, updateItemStatus, ...rest}) => {
+const ExpandableDifferentHeightItem = (props) => {
+	checkPropTypes(ExpandableDifferentHeightItem, props);
+	const {index, 'data-index': dataIndex, items, ref, style: itemStyleFromList, updateItemStatus, ...rest} = props;
 	const {title: children, numOfLines, open} = items[index],
 		itemStyle = {...itemStyleDefault, ...itemStyleFromList};
 
@@ -106,7 +109,9 @@ ExpandableDifferentHeightItem.propTypes = {
 	updateItemStatus: PropTypes.func
 };
 
-const ResizableItem = ({updateItemSize, ...rest}) => {
+const ResizableItem = (props) => {
+	checkPropTypes(ResizableItem, props);
+	const {updateItemSize, ...rest} = props;
 	const indexRef = useRef(0);
 	const domRef = useRef({});
 

--- a/samples/qa-a11y/src/App/App.js
+++ b/samples/qa-a11y/src/App/App.js
@@ -1,3 +1,4 @@
+import {checkPropTypes} from '@enact/core/util';
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import Item from '@enact/agate/Item';
 import Scroller from '@enact/agate/Scroller';
@@ -112,7 +113,9 @@ const views = [
 	{title: 'WindDirectionControl', view: WindDirectionControl}
 ];
 
-const AppBase = ({className, rtl, updateLocale, ...rest}) => {
+const AppBase = (props) => {
+	checkPropTypes(AppBase, props);
+	const {className, rtl, updateLocale, ...rest} = props;
 	const [isDebugMode, setIsDebugMode] = useState(false);
 	const [jumpToView, setJumpToView] = useState('');
 	const [selected, setSelected] = useState(0);

--- a/samples/qa-a11y/src/App/View.js
+++ b/samples/qa-a11y/src/App/View.js
@@ -1,20 +1,23 @@
 import Header from '@enact/agate/Header';
 import {Panel} from '@enact/agate/Panels';
 import Scroller from '@enact/agate/Scroller';
+import {checkPropTypes} from '@enact/core/util';
 import Layout, {Cell} from '@enact/ui/Layout';
 import PropTypes from 'prop-types';
 
-const View = ({debugProps = false, handleDebug, isAriaHidden = false, isDebugMode = false, isHeader = true, title, view: ComponentView}) => {
+const View = (props) => {
+	checkPropTypes(View, props);
+	const {debugProps = false, handleDebug, isAriaHidden = false, isDebugMode = false, isHeader = true, title, view: ComponentView} = props;
 	const
 		header = isHeader ? <Header aria-hidden={isAriaHidden} title={title} /> : null,
-		props = debugProps ? {handleDebug, isDebugMode} : null;
+		viewProps = debugProps ? {handleDebug, isDebugMode} : null;
 
 	return (
 		<Panel aria-owns="floatLayer" style={{padding: 0}}>
 			{header}
 			<Layout orientation="vertical">
 				<Cell component={Scroller} direction="vertical">
-					<ComponentView {...props} />
+					<ComponentView {...viewProps} />
 				</Cell>
 			</Layout>
 		</Panel>

--- a/samples/qa-a11y/src/components/AriaValueTextDecorator.js
+++ b/samples/qa-a11y/src/components/AriaValueTextDecorator.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/jsx-no-bind */
 
 import hoc from '@enact/core/hoc';
+import {checkPropTypes} from '@enact/core/util';
 import PropTypes from 'prop-types';
 import {useState} from 'react';
 
@@ -13,7 +14,9 @@ const AriaValueTextDecorator  = hoc((config, Wrapped) => {
 	}
 
 	// eslint-disable-next-line no-shadow
-	function AriaValueTextDecorator ({'aria-valuetext': ariaValueText, ...rest}) {
+	function AriaValueTextDecorator (props) {
+		checkPropTypes(AriaValueTextDecorator, props);
+		const {'aria-valuetext': ariaValueText, ...rest} = props;
 		const [value, setValue] = useState(defaultValue);
 		const valueText = `${ariaValueText} ${value}`;
 

--- a/samples/qa-a11y/src/views/IncrementSlider.js
+++ b/samples/qa-a11y/src/views/IncrementSlider.js
@@ -2,12 +2,15 @@
 
 import Button from '@enact/agate/Button';
 import IncrementSlider from '@enact/agate/IncrementSlider';
+import {checkPropTypes} from '@enact/core/util';
 import PropTypes from 'prop-types';
 import {useState} from 'react';
 
 import Section from '../components/Section';
 
-const CustomIncrementSlider = ({customText, ...rest}) => {
+const CustomIncrementSlider = (props) => {
+	checkPropTypes(CustomIncrementSlider, props);
+	const {customText, ...rest} = props;
 	const [value, setValue] = useState(0);
 	const valueText = `${customText} ${value}`;
 

--- a/samples/qa-a11y/src/views/Option.js
+++ b/samples/qa-a11y/src/views/Option.js
@@ -1,3 +1,4 @@
+import {checkPropTypes} from '@enact/core/util';
 import {useI18nContext} from '@enact/i18n/I18nDecorator';
 import Checkbox from '@enact/agate/CheckboxItem';
 import PropTypes from 'prop-types';
@@ -8,6 +9,7 @@ import Section from '../components/Section';
 import appCss from '../App/App.module.less';
 
 const Option = (props) => {
+	checkPropTypes(Option, props);
 	const {handleDebug, isDebugMode} = props;
 	const {rtl, updateLocale} = useI18nContext();
 	const handleClick = useCallback(() => {

--- a/samples/qa-a11y/src/views/Slider.js
+++ b/samples/qa-a11y/src/views/Slider.js
@@ -2,12 +2,15 @@
 
 import Button from '@enact/agate/Button';
 import Slider from '@enact/agate/Slider';
+import {checkPropTypes} from '@enact/core/util';
 import PropTypes from 'prop-types';
 import {useState} from 'react';
 
 import Section from '../components/Section';
 
-const CustomSlider = ({customText, ...rest}) => {
+const CustomSlider = (props) => {
+	checkPropTypes(CustomSlider, props);
+	const {customText, ...rest} = props;
 	const [value, setValue] = useState(0);
 	const valueText = `${customText} ${value}`;
 

--- a/samples/qa-i18n-async/src/App/App.js
+++ b/samples/qa-i18n-async/src/App/App.js
@@ -1,6 +1,7 @@
 import Button from '@enact/agate/Button';
 import Dropdown from '@enact/agate/Dropdown';
 import ThemeDecorator from '@enact/agate/ThemeDecorator';
+import {checkPropTypes} from '@enact/core/util';
 import {I18nContextDecorator} from '@enact/i18n/I18nDecorator';
 import Text, {TextDecorator} from '@enact/i18n/Text';
 import $L from '@enact/i18n/$L';
@@ -11,7 +12,9 @@ const TextButton = TextDecorator(Button);
 
 const locales = ['en-US', 'ko-KR'];
 
-const Decorator = ({locale, updateLocale, ...rest}) => {
+const Decorator = (props) => {
+	checkPropTypes(Decorator, props);
+	const {locale, updateLocale, ...rest} = props;
 	const onSelect = useCallback(({data: selLocale}) => updateLocale(selLocale), [updateLocale]);
 	return (
 		<div {...rest}>

--- a/samples/qa-scroller/src/components/Controls/Controls.js
+++ b/samples/qa-scroller/src/components/Controls/Controls.js
@@ -1,5 +1,6 @@
 import CheckboxItem from '@enact/agate/CheckboxItem';
 import Input from '@enact/agate/Input';
+import {checkPropTypes} from '@enact/core/util';
 import {Cell, Row} from '@enact/ui/Layout';
 import ri from '@enact/ui/resolution';
 import PropTypes from 'prop-types';
@@ -7,7 +8,9 @@ import PropTypes from 'prop-types';
 import LocaleSwitch from '../LocaleSwitch';
 import ScrollModeSwitch from '../ScrollModeSwitch';
 
-const Controls = ({handleFocusableScrollbar, handleHeight, handleScrollMode, handleWidth, height, nativeScroll, width}) => {
+const Controls = (props) => {
+	checkPropTypes(Controls, props);
+	const {handleFocusableScrollbar, handleHeight, handleScrollMode, handleWidth, height, nativeScroll, width} = props;
 	const inputWidth = {width: '5em'};
 	const rowWidth = typeof window !== 'undefined' ? `${ri.scaleToRem(window.innerWidth)}` : `${ri.scaleToRem(1920)}`;
 

--- a/samples/qa-virtualgridlist/src/components/ImageList/ImageList.js
+++ b/samples/qa-virtualgridlist/src/components/ImageList/ImageList.js
@@ -1,4 +1,5 @@
 import {VirtualGridList} from '@enact/agate/VirtualList';
+import {checkPropTypes} from '@enact/core/util';
 import ri from '@enact/ui/resolution';
 import PropTypes from 'prop-types';
 import {useCallback} from 'react';
@@ -8,7 +9,9 @@ import ImageItem from '../ImageItem';
 
 import css from './ImageList.module.less';
 
-const ImageList = ({imageItems, minHeight, minWidth, spacing, selectedItems, ...rest}) => {
+const ImageList = (props) => {
+	checkPropTypes(ImageList, props);
+	const {imageItems, minHeight, minWidth, spacing, selectedItems, ...rest} = props;
 	const calculateOfSize = (size) => ri.scale(parseInt(size) || 0);
 
 	const renderItem = useCallback(({...renderRest}) => {

--- a/samples/qa-virtualgridlistnative-preserve-focus/src/components/SampleVirtualGridList.js
+++ b/samples/qa-virtualgridlistnative-preserve-focus/src/components/SampleVirtualGridList.js
@@ -1,12 +1,15 @@
 import ImageItem from '@enact/agate/ImageItem';
 import {VirtualGridList} from '@enact/agate/VirtualList';
+import {checkPropTypes} from '@enact/core/util';
 import ri from '@enact/ui/resolution';
 import PropTypes from 'prop-types';
 import {useCallback} from 'react';
 
 import css from './SampleVirtualGridList.module.less';
 
-const SampleVirtualGridList = ({index, onClick, ...rest}) => {
+const SampleVirtualGridList = (props) => {
+	checkPropTypes(SampleVirtualGridList, props);
+	const {index, onClick, ...rest} = props;
 	const renderItem = useCallback(({index, ...rest}) => { // eslint-disable-line no-shadow
 		const
 			color = Math.floor((Math.random() * (0x1000000 - 0x101010)) + 0x101010).toString(16),

--- a/samples/qa-virtuallist/src/views/MainPanel.js
+++ b/samples/qa-virtuallist/src/views/MainPanel.js
@@ -4,6 +4,7 @@ import Header from '@enact/agate/Header';
 import Input from '@enact/agate/Input';
 import {Panel} from '@enact/agate/Panels';
 import VirtualList from '@enact/agate/VirtualList';
+import {checkPropTypes} from '@enact/core/util';
 import {Cell, Layout, Row} from '@enact/ui/Layout';
 import ri from '@enact/ui/resolution';
 import PropTypes from 'prop-types';
@@ -19,7 +20,9 @@ import css from './MainPanel.module.less';
 
 const childProps = {text: ' child props'};
 
-const MainPanel = ({...rest}) => {
+const MainPanel = (props) => {
+	checkPropTypes(MainPanel, props);
+	const {...rest} = props;
 	const dispatch = useDispatch();
 	const [hasChildProps, setHasChildProps] = useState(false);
 	const [isDisabled, setIsDisabled] = useState(false);

--- a/samples/sampler/custom-addon/ColorPicker.js
+++ b/samples/sampler/custom-addon/ColorPicker.js
@@ -11,7 +11,7 @@ const getDefaultColor = (colorPickerType) => {
 };
 
 const ColorPicker = ({colorPickerType}) => {
-	checkPropTypes(ColorPicker, {colorPickerType})
+	checkPropTypes(ColorPicker, {colorPickerType});
 	const [globals, updateGlobals] = useGlobals();
 	const handleChange = useCallback((ev) => {
 		updateGlobals({[colorPickerType]: ev.target.value});

--- a/samples/sampler/custom-addon/ColorPicker.js
+++ b/samples/sampler/custom-addon/ColorPicker.js
@@ -1,3 +1,4 @@
+import {checkPropTypes} from '@enact/core/util';
 import {useGlobals} from 'storybook/manager-api';
 import PropTypes from 'prop-types';
 import React, {useCallback, useEffect} from 'react'; // eslint-disable-line
@@ -10,6 +11,7 @@ const getDefaultColor = (colorPickerType) => {
 };
 
 const ColorPicker = ({colorPickerType}) => {
+	checkPropTypes(ColorPicker, {colorPickerType})
 	const [globals, updateGlobals] = useGlobals();
 	const handleChange = useCallback((ev) => {
 		updateGlobals({[colorPickerType]: ev.target.value});

--- a/samples/sampler/custom-addon/DefaultSkinToolbarTab.js
+++ b/samples/sampler/custom-addon/DefaultSkinToolbarTab.js
@@ -1,3 +1,4 @@
+import {checkPropTypes} from '@enact/core/util';
 import {useGlobals} from 'storybook/manager-api';
 import PropTypes from 'prop-types';
 import React from 'react'; // eslint-disable-line
@@ -5,6 +6,7 @@ import React from 'react'; // eslint-disable-line
 import ToolbarTab from './ToolbarTab';
 
 const DefaultSkinToolbarTab = ({toolbarParamKey}) => {
+	checkPropTypes(DefaultSkinToolbarTab, {toolbarParamKey});
 	const [globals, updateGlobals] = useGlobals();
 	const isActive = globals[toolbarParamKey] || false;
 

--- a/samples/sampler/custom-addon/ToolbarTab.js
+++ b/samples/sampler/custom-addon/ToolbarTab.js
@@ -1,8 +1,11 @@
+import {checkPropTypes} from '@enact/core/util';
 import {IconButton} from 'storybook/internal/components';
 import PropTypes from 'prop-types';
 import React from 'react'; // eslint-disable-line
 
-const ToolbarTab = ({isActive, toggleState, toolbarParamKey}) => {
+const ToolbarTab = (props) => {
+	checkPropTypes(props);
+	const {isActive, toggleState, toolbarParamKey} = props;
 	return (
 		<IconButton
 			active={isActive}

--- a/samples/sampler/stories/default/Panels.js
+++ b/samples/sampler/stories/default/Panels.js
@@ -9,7 +9,7 @@ import Button from '@enact/agate/Button';
 import Header from '@enact/agate/Header';
 import {Panels, Panel} from '@enact/agate/Panels';
 import kind from '@enact/core/kind';
-import {clamp} from '@enact/core/util';
+import {checkPropTypes, clamp} from '@enact/core/util';
 import ri from '@enact/ui/resolution';
 
 Panels.displayName = 'Panels';
@@ -46,6 +46,7 @@ const SecondPanel = kind({
 });
 
 const BasicPanels = ({...rest}) => {
+	checkPropTypes(BasicPanels, rest);
 	const [index, setIndex] = useState(0);
 	const goNext = () => setIndex(clamp(0, 2, index + 1));
 	const goPrevious = () => setIndex(clamp(0, 2, index - 1));

--- a/samples/sampler/stories/default/TabbedPanels.js
+++ b/samples/sampler/stories/default/TabbedPanels.js
@@ -1,3 +1,4 @@
+import {checkPropTypes} from '@enact/core/util';
 import {action} from '@enact/storybook-utils/addons/actions';
 import {mergeComponentMetadata} from '@enact/storybook-utils';
 import {boolean, number, select} from '@enact/storybook-utils/addons/controls';
@@ -16,7 +17,9 @@ TabbedPanels.displayName = 'TabbedPanels';
 const Config = mergeComponentMetadata('TabbedPanels', TabbedPanelsBase);
 // `paddingBottom: '56.25%'` is a trick to impose 16:9 aspect ratio on the component, since padding percentage is based on the width, not the height.
 
-const I18nTabbedPanelsBase = ({orientation, rtl, ...rest}) => {
+const I18nTabbedPanelsBase = (props) => {
+	checkPropTypes(I18nTabbedPanelsBase, props);
+	const {orientation, rtl, ...rest} = props;
 	const [panelIndex, setIndex] = useState(Config.defaultProps.index || 0);
 	const onSelect = (e) => {
 		setIndex(e.index);

--- a/tests/ui/apps/VirtualList/VirtualList/VirtualList-View.js
+++ b/tests/ui/apps/VirtualList/VirtualList/VirtualList-View.js
@@ -1,3 +1,4 @@
+import {checkPropTypes} from '@enact/core/util';
 import spotlight from '@enact/spotlight';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import {Row, Column, Cell} from '@enact/ui/Layout';
@@ -57,6 +58,7 @@ class StatefulSwitchItem extends Component {
 			prevIndex: props.index,
 			selected: items[props.index].selected
 		};
+		checkPropTypes(this, this.props);
 	}
 
 	static getDerivedStateFromProps (props, state) {
@@ -68,6 +70,10 @@ class StatefulSwitchItem extends Component {
 		}
 
 		return null;
+	}
+
+	componentDidUpdate(prevProps) {
+		checkPropTypes(this, this.props, prevProps);
 	}
 
 	onToggle = () => {

--- a/tests/ui/apps/VirtualList/VirtualList/VirtualList-View.js
+++ b/tests/ui/apps/VirtualList/VirtualList/VirtualList-View.js
@@ -72,7 +72,7 @@ class StatefulSwitchItem extends Component {
 		return null;
 	}
 
-	componentDidUpdate(prevProps) {
+	componentDidUpdate (prevProps) {
 		checkPropTypes(this, this.props, prevProps);
 	}
 

--- a/useScroll/Scrollbar.js
+++ b/useScroll/Scrollbar.js
@@ -1,3 +1,4 @@
+import {checkPropTypes} from '@enact/core/util';
 import {useScrollbar as useScrollbarBase} from '@enact/ui/useScroll/Scrollbar';
 import PropTypes from 'prop-types';
 import {memo, useLayoutEffect} from 'react';
@@ -69,6 +70,7 @@ const ScrollbarBase = memo(({css = componentCss, minThumbSize = 18, vertical = t
 		vertical,
 		...rest
 	};
+	checkPropTypes(ScrollbarBase, props);
 
 	const {
 		restProps,

--- a/useScroll/ScrollbarTrack.js
+++ b/useScroll/ScrollbarTrack.js
@@ -1,3 +1,4 @@
+import {checkPropTypes} from '@enact/core/util';
 import {ScrollbarTrack as UiScrollbarTrack} from '@enact/ui/useScroll/Scrollbar';
 import PropTypes from 'prop-types';
 import {useEffect, memo} from 'react';
@@ -12,7 +13,9 @@ const nop = () => {};
  * @ui
  * @private
  */
-const ScrollbarTrack = ({cbAlertScrollbarTrack = nop, ref, ...rest}) => {
+const ScrollbarTrack = (props) => {
+	checkPropTypes(ScrollbarTrack, props);
+	const {cbAlertScrollbarTrack = nop, ref, ...rest} = props;
 	useEffect (() => {
 		cbAlertScrollbarTrack();
 	}, []); // eslint-disable-line react-hooks/exhaustive-deps


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
React 19 removed `propTypes`, so we decided to add a manual check.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Fixed unit test for TooltipDecorator as it contained unpermitted prop value
Forced reac-is subdependecy to match react version to avoid false positive prop-types errors

### Links
[//]: # (Related issues, references)
NXT-9000

### Comments

Enact-DCO-1.0-Signed-off-by: Ion Andrusciac ion.andrusciac@lgepartner.com