### PR TITLE
NXT-12667: Set allowedHosts: true to fix 'Invalid host' error

### DIFF
--- a/samples/sampler/.qa-storybook/main.js
+++ b/samples/sampler/.qa-storybook/main.js
@@ -6,11 +6,11 @@ import {fileURLToPath} from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-		disableTelemetry: true,
-		allowedHosts: true
+
 export default {
 	core: {
-		disableTelemetry: true
+		disableTelemetry: true,
+		allowedHosts: true
 	},
 	features: {
 		backgrounds: false,

--- a/samples/sampler/.qa-storybook/main.js
+++ b/samples/sampler/.qa-storybook/main.js
@@ -6,7 +6,8 @@ import {fileURLToPath} from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-
+		disableTelemetry: true,
+		allowedHosts: true
 export default {
 	core: {
 		disableTelemetry: true

--- a/samples/sampler/.storybook/main.js
+++ b/samples/sampler/.storybook/main.js
@@ -6,11 +6,11 @@ import {fileURLToPath} from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-		disableTelemetry: true,
-		allowedHosts: true
+
 export default {
 	core: {
-		disableTelemetry: true
+		disableTelemetry: true,
+		allowedHosts: true
 	},
 	features: {
 		backgrounds: false,

--- a/samples/sampler/.storybook/main.js
+++ b/samples/sampler/.storybook/main.js
@@ -6,7 +6,8 @@ import {fileURLToPath} from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-
+		disableTelemetry: true,
+		allowedHosts: true
 export default {
 	core: {
 		disableTelemetry: true


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`Invalid host` error occurred while building sampler
```
// precondition: in cloud server, web server, or other external network server

$ npm i
$ npm run bootstrap
$ cd samples/sampler

$ npm i
$ npm run serve
```
<img width="1038" height="790" alt="image" src="https://github.com/user-attachments/assets/de34a4aa-ed2b-4cc1-93de-34015b535a92" />

Root causes:
Storybook's localhost and local network (or [--host](https://storybook.js.org/docs/api/cli-options#dev)) addresses are always allowed. But other reverse proxy(e.g. your webapp dev server) are not accessible cause of the secure reason.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Set allowedHosts: true to fix 'Invalid host' error
https://storybook.js.org/docs/api/main-config/main-config-core#allowedhosts
>[allowedHosts](https://storybook.js.org/docs/api/main-config/main-config-core#allowedhosts)
>Type: string[] | true

>Default: []
>Configures the allowed hosts for the Storybook dev server, used for Origin and Host header validation. Storybook's localhost and local network (or [--host](https://storybook.js.org/docs/api/cli-options#dev)) addresses are always allowed. Use this when accessing your local Storybook instance through a reverse proxy (e.g. your webapp dev server). Set to true to disable hostname validation (insecure). 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
NXT-12667

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)