### PR TITLE
NXT-12996: Added performance addon for storybook

### DIFF
--- a/samples/sampler/.qa-storybook/main.js
+++ b/samples/sampler/.qa-storybook/main.js
@@ -45,7 +45,7 @@ export default {
 	addons: [
 		'@enact/storybook-utils/addons/actions',
 		'@enact/storybook-utils/addons/controls',
-		'@github-ui/storybook-addon-performance-panel'
+		...(process.env.PERF_PANEL === 'true' ? ['@github-ui/storybook-addon-performance-panel'] : [])
 	],
 	managerEntries: [resolve(__dirname, '../custom-addon/manager.js')],
 	webpackFinal: async (config, {configType}) => {

--- a/samples/sampler/.qa-storybook/main.js
+++ b/samples/sampler/.qa-storybook/main.js
@@ -1,11 +1,15 @@
+/* eslint-disable no-shadow */
+
 import webpack from '@enact/storybook-utils/configs/webpack.js';
 import {readFileSync} from 'fs';
+import {createRequire} from 'module';
 import {dirname, resolve} from 'path';
 import {loadCsf} from 'storybook/internal/csf-tools';
 import {fileURLToPath} from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+const require = createRequire(import.meta.url);
 
 export default {
 	core: {
@@ -41,11 +45,24 @@ export default {
 	addons: [
 		'@enact/storybook-utils/addons/actions',
 		'@enact/storybook-utils/addons/controls',
-		'@storybook/addon-docs'
+		'@github-ui/storybook-addon-performance-panel'
 	],
 	managerEntries: [resolve(__dirname, '../custom-addon/manager.js')],
 	webpackFinal: async (config, {configType}) => {
-		return webpack(config, configType, __dirname);
+		const webpackFinalConfig = await webpack(config, configType, __dirname);
+
+		// Force a single React copy. Other enact packages might have different patch versions of React,
+		// which causes "Cannot read properties of null (reading 'useEffect')"
+		const reactDir = dirname(require.resolve('react/package.json'));
+		const reactDomDir = dirname(require.resolve('react-dom/package.json'));
+		webpackFinalConfig.resolve = webpackFinalConfig.resolve || {};
+		webpackFinalConfig.resolve.alias = {
+			...(webpackFinalConfig.resolve.alias || {}),
+			react: reactDir,
+			'react-dom': reactDomDir
+		};
+
+		return webpackFinalConfig;
 	},
 	typescript: {
 		reactDocgen: false

--- a/samples/sampler/.storybook/main.js
+++ b/samples/sampler/.storybook/main.js
@@ -45,7 +45,7 @@ export default {
 	addons: [
 		'@enact/storybook-utils/addons/actions',
 		'@enact/storybook-utils/addons/controls',
-		'@github-ui/storybook-addon-performance-panel'
+		...(process.env.PERF_PANEL === 'true' ? ['@github-ui/storybook-addon-performance-panel'] : [])
 	],
 	managerEntries: [resolve(__dirname, '../custom-addon/manager.js')],
 	webpackFinal: async (config, {configType}) => {

--- a/samples/sampler/.storybook/main.js
+++ b/samples/sampler/.storybook/main.js
@@ -1,11 +1,15 @@
+/* eslint-disable no-shadow */
+
 import webpack from '@enact/storybook-utils/configs/webpack.js';
 import {readFileSync} from 'fs';
+import {createRequire} from 'module';
 import {dirname, resolve} from 'path';
 import {loadCsf} from 'storybook/internal/csf-tools';
 import {fileURLToPath} from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+const require = createRequire(import.meta.url);
 
 export default {
 	core: {
@@ -41,11 +45,24 @@ export default {
 	addons: [
 		'@enact/storybook-utils/addons/actions',
 		'@enact/storybook-utils/addons/controls',
-		'@storybook/addon-docs'
+		'@github-ui/storybook-addon-performance-panel'
 	],
 	managerEntries: [resolve(__dirname, '../custom-addon/manager.js')],
 	webpackFinal: async (config, {configType}) => {
-		return webpack(config, configType, __dirname);
+		const webpackFinalConfig = await webpack(config, configType, __dirname);
+
+		// Force a single React copy. Other enact packages might have different patch versions of React,
+		// which causes "Cannot read properties of null (reading 'useEffect')"
+		const reactDir = dirname(require.resolve('react/package.json'));
+		const reactDomDir = dirname(require.resolve('react-dom/package.json'));
+		webpackFinalConfig.resolve = webpackFinalConfig.resolve || {};
+		webpackFinalConfig.resolve.alias = {
+			...(webpackFinalConfig.resolve.alias || {}),
+			react: reactDir,
+			'react-dom': reactDomDir
+		};
+
+		return webpackFinalConfig;
 	},
 	typescript: {
 		reactDocgen: false

--- a/samples/sampler/README.md
+++ b/samples/sampler/README.md
@@ -1,0 +1,54 @@
+# Agate Sampler
+
+> A sampler showing off Agate components
+
+It uses [React Storybook](https://getstorybook.io/). Component properties can be adjusted using the
+`Knobs` tab. Click the `?` in the upper right to see more information on each sample.
+
+## Usage
+
+To launch the sampler using its built-in web server (on http://localhost:8080/):
+```
+npm run serve
+```
+
+To package the sampler applications as a stand-alone app:
+```
+npm run pack
+```
+
+### Performance Panel addon
+
+The `@github-ui/storybook-addon-performance-panel` addon is disabled by default. To enable it, set the `PERF_PANEL` environment variable to `true` when launching or packaging the sampler. The flag applies to both `npm run serve` and `npm run pack`.
+
+PowerShell:
+```
+$env:PERF_PANEL='true'; npm run serve
+$env:PERF_PANEL='true'; npm run pack
+```
+
+Windows CMD:
+```
+set "PERF_PANEL=true" && npm run serve
+set "PERF_PANEL=true" && npm run pack
+```
+
+Bash:
+```
+PERF_PANEL=true npm run serve
+PERF_PANEL=true npm run pack
+```
+
+Without the flag, both commands run normally and the addon is excluded.
+
+## Copyright and License Information
+
+Unless otherwise specified, all content, including all source code files and documentation files in this repository are:
+
+Copyright (c) 2016-2026 LG Electronics
+
+Unless otherwise specified or set forth in the NOTICE file, all content, including all source code files and documentation files in this repository are: Licensed under the Apache License, Version 2.0 (the "License"); you may not use this content except in compliance with the License. You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/samples/sampler/npm-shrinkwrap.json
+++ b/samples/sampler/npm-shrinkwrap.json
@@ -1,53 +1,53 @@
 {
   "name": "agate-sampler",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agate-sampler",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@enact/agate": "../../",
-        "@enact/core": "^5.4.2",
-        "@enact/i18n": "^5.4.2",
-        "@enact/spotlight": "^5.4.2",
+        "@enact/core": "^5.5.0",
+        "@enact/i18n": "^5.5.0",
+        "@enact/spotlight": "^5.5.0",
         "@enact/storybook-utils": "^8.0.0",
-        "@enact/ui": "^5.4.2",
+        "@enact/ui": "^5.5.0",
         "@github-ui/storybook-addon-performance-panel": "^1.1.4",
-        "@storybook/react-webpack5": "^10.3.5",
+        "@storybook/react-webpack5": "^10.3.6",
         "dotenv": "^16.5.0",
-        "ilib": "^14.21.2",
+        "ilib": "^14.21.3",
         "prop-types": "^15.8.1",
-        "react": "^19.2.4",
-        "react-dom": "^19.2.4",
-        "storybook": "^10.3.5"
+        "react": "^19.2.6",
+        "react-dom": "^19.2.6",
+        "storybook": "^10.3.6"
       }
     },
     "../..": {
       "name": "@enact/agate",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@enact/core": "^5.4.2",
-        "@enact/i18n": "^5.4.2",
-        "@enact/spotlight": "^5.4.2",
-        "@enact/ui": "^5.4.2",
+        "@enact/core": "^5.5.0",
+        "@enact/i18n": "^5.5.0",
+        "@enact/spotlight": "^5.5.0",
+        "@enact/ui": "^5.5.0",
         "classnames": "^2.5.1",
         "color-convert": "^2.0.1",
         "deep-freeze": "0.0.1",
         "eases": "^1.0.8",
-        "ilib": "^14.21.2",
+        "ilib": "^14.21.3",
         "invariant": "^2.2.4",
         "prop-types": "^15.8.1",
         "ramda": "^0.32.0",
-        "react": "^19.2.4",
-        "react-dom": "^19.2.4",
+        "react": "^19.2.6",
+        "react-dom": "^19.2.6",
         "warning": "^4.0.3"
       },
       "devDependencies": {
-        "@enact/docs-utils": "^0.4.16",
+        "@enact/docs-utils": "^0.4.17",
         "@enact/ui-test-utils": "^4.0.2",
         "eslint-config-enact-proxy": "^1.0.9"
       },
@@ -318,32 +318,32 @@
       "link": true
     },
     "node_modules/@enact/core": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/@enact/core/-/core-5.4.2.tgz",
-      "integrity": "sha512-dKVJZg23plRS/9P99WKmwXx5Tk+nD0G38+FIG/0PMmFHneYQc6B12TsH/qF0Ffmf8AynKcxRy7Yp3jwod8n9xw==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@enact/core/-/core-5.5.0.tgz",
+      "integrity": "sha512-BSzCTo5SAzbNkYIJQTKjG0P4MloNee0Rj1y/m82+ZleTqa3Fk/UV6FbEUKtN+b60e9Cb5uRDROUvfoYqPoMmOQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.5.1",
         "invariant": "^2.2.4",
         "prop-types": "^15.8.1",
         "ramda": "^0.32.0",
-        "react": "^19.2.3",
-        "react-dom": "^19.2.3",
-        "react-is": "^19.2.3",
+        "react": "^19.2.6",
+        "react-dom": "^19.2.6",
+        "react-is": "^19.2.6",
         "warning": "^4.0.3"
       }
     },
     "node_modules/@enact/i18n": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/@enact/i18n/-/i18n-5.4.2.tgz",
-      "integrity": "sha512-xqopx09ML6pXO0x9VbBRYQTuysMxWzAg7acA7554zz3oOMUau5hP9ZZg0LsY1MdwToOPOVeoQumNSwcEFQwljw==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@enact/i18n/-/i18n-5.5.0.tgz",
+      "integrity": "sha512-LwSNUXENDh/8KTZW/4CGNcQ6gljQHEuhiUT5WHboNxdQLYGnPwQPVJkzFb2NoXsQeoGfdAkCoeNzAB/3OprJcg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@enact/core": "^5.4.2",
+        "@enact/core": "^5.5.0",
         "prop-types": "^15.8.1",
         "ramda": "^0.32.0",
-        "react": "^19.2.3",
-        "react-dom": "^19.2.3",
+        "react": "^19.2.6",
+        "react-dom": "^19.2.6",
         "xhr": "^2.6.0"
       },
       "peerDependencies": {
@@ -351,17 +351,17 @@
       }
     },
     "node_modules/@enact/spotlight": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/@enact/spotlight/-/spotlight-5.4.2.tgz",
-      "integrity": "sha512-ujggO68Tzaubt/uo1h6Q2Z060UXqZqv2EfLKxk6lZy0BeHXEfwstl7pZpitfvk8OmflxM9hM9K0Mj95HonpIlg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@enact/spotlight/-/spotlight-5.5.0.tgz",
+      "integrity": "sha512-2Y3lu42lq7D4my+fqlxDOm8HyTvzTxla8BP9wlrOrnfWn+naLT4ETuVgoCMIMKU0HcIiExhFJdEPg7oEgkiQsg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@enact/core": "^5.4.2",
+        "@enact/core": "^5.5.0",
         "classnames": "^2.5.1",
         "prop-types": "^15.8.1",
         "ramda": "^0.32.0",
-        "react": "^19.2.3",
-        "react-dom": "^19.2.3",
+        "react": "^19.2.6",
+        "react-dom": "^19.2.6",
         "warning": "^4.0.3"
       }
     },
@@ -32464,21 +32464,21 @@
       }
     },
     "node_modules/@enact/ui": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/@enact/ui/-/ui-5.4.2.tgz",
-      "integrity": "sha512-ZT1fTpvGe3B+g5PW989HdYRhwc2tTlJX6zh95SYoLqqGRSnOpMvAh6L536XXLSesEmz1vLdw8p40D7pxO8vRdw==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@enact/ui/-/ui-5.5.0.tgz",
+      "integrity": "sha512-yyzJd12TTRPCSC0n3UXHL7OWyzRzHDGmBZwEZ2IEP8x9BK2/Fp7TEoEUqqS2sD16wnZJnnYH2JKSRwVmKs7Liw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@enact/core": "^5.4.2",
-        "@enact/i18n": "^5.4.2",
+        "@enact/core": "^5.5.0",
+        "@enact/i18n": "^5.5.0",
         "classnames": "^2.5.1",
-        "ilib": "^14.21.2",
+        "ilib": "^14.21.3",
         "invariant": "^2.2.4",
         "prop-types": "^15.8.1",
         "ramda": "^0.32.0",
-        "react": "^19.2.3",
-        "react-dom": "^19.2.3",
-        "react-is": "^19.2.3",
+        "react": "^19.2.6",
+        "react-dom": "^19.2.6",
+        "react-is": "^19.2.6",
         "warning": "^4.0.3"
       }
     },
@@ -34858,9 +34858,9 @@
       }
     },
     "node_modules/ilib": {
-      "version": "14.21.2",
-      "resolved": "https://registry.npmjs.org/ilib/-/ilib-14.21.2.tgz",
-      "integrity": "sha512-N9fRHde7I1SsFdGYn+uflPgANXDtbLe9mEZX21LXV1XWB1JfCWfKqPxzH5vbcN4yqk16EFzowt8c77cwwt1xFg==",
+      "version": "14.21.3",
+      "resolved": "https://registry.npmjs.org/ilib/-/ilib-14.21.3.tgz",
+      "integrity": "sha512-HQA76PAVwsjRxVUI7SzYaes4lOSEFkbED/klnWm/y3uOrLIJh1vZgMIlRp71AGq/rOQDdbtiF51hkxcnEHePlQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8 <25"
@@ -35794,9 +35794,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -35833,21 +35833,21 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.4"
+        "react": "^19.2.6"
       }
     },
     "node_modules/react-is": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
-      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
+      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
       "license": "MIT"
     },
     "node_modules/readdirp": {

--- a/samples/sampler/npm-shrinkwrap.json
+++ b/samples/sampler/npm-shrinkwrap.json
@@ -15,14 +15,14 @@
         "@enact/spotlight": "^5.4.2",
         "@enact/storybook-utils": "^8.0.0",
         "@enact/ui": "^5.4.2",
-        "@storybook/addon-docs": "^10.3.4",
-        "@storybook/react-webpack5": "^10.3.4",
+        "@github-ui/storybook-addon-performance-panel": "^1.1.4",
+        "@storybook/react-webpack5": "^10.3.5",
         "dotenv": "^16.5.0",
         "ilib": "^14.21.2",
         "prop-types": "^15.8.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "storybook": "^10.3.4"
+        "storybook": "^10.3.5"
       }
     },
     "../..": {
@@ -48,7 +48,7 @@
       },
       "devDependencies": {
         "@enact/docs-utils": "^0.4.16",
-        "@enact/ui-test-utils": "^4.0.1",
+        "@enact/ui-test-utils": "^4.0.2",
         "eslint-config-enact-proxy": "^1.0.9"
       },
       "peerDependencies": {
@@ -32898,6 +32898,26 @@
         "node": ">=18"
       }
     },
+    "node_modules/@github-ui/storybook-addon-performance-panel": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@github-ui/storybook-addon-performance-panel/-/storybook-addon-performance-panel-1.1.4.tgz",
+      "integrity": "sha512-clVeSoS1BM2z+nHffOXpnA1J034XALEDfJez6yg7TS7Clfn8eBjgw5FwLjfMvM+kWeG2nwfP6LujRMvJDqj+yg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@storybook/icons": "^2.0.0",
+        "@storybook/react": "^10.0.0",
+        "react": "^19",
+        "storybook": "^10"
+      },
+      "peerDependenciesMeta": {
+        "@storybook/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -32953,52 +32973,13 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@mdx-js/react": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
-      "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdx": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16",
-        "react": ">=16"
-      }
-    },
-    "node_modules/@storybook/addon-docs": {
-      "version": "10.3.4",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-10.3.4.tgz",
-      "integrity": "sha512-ohS8fX8UIP3LN6+mDZJLCDS4Qd2rsmGwes6V6fD0sbLOmIyCVY5y68r6NHMMGJKFRwadDQOmtOt8Vc6snExrIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/react": "^3.0.0",
-        "@storybook/csf-plugin": "10.3.4",
-        "@storybook/icons": "^2.0.1",
-        "@storybook/react-dom-shim": "10.3.4",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "ts-dedent": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^10.3.4"
-      }
-    },
     "node_modules/@storybook/builder-webpack5": {
-      "version": "10.3.4",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-webpack5/-/builder-webpack5-10.3.4.tgz",
-      "integrity": "sha512-ZFGw0bqVkLH9vFMMQcWTFUcvJ4cADHGk6yXs2MgvHX4/3ZZXIiGssb3PgewuxfXo4xto0flZMhIoC2dhrwK40A==",
+      "version": "10.3.6",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-webpack5/-/builder-webpack5-10.3.6.tgz",
+      "integrity": "sha512-PZ410NhxlOAMHESPDnr2y13QATCRV58VJ3yJBY+seJCk2R9gws5VbAtKASMD9EPjAhVsIfArEL866cp310rBJw==",
       "license": "MIT",
       "dependencies": {
-        "@storybook/core-webpack": "10.3.4",
+        "@storybook/core-webpack": "10.3.6",
         "case-sensitive-paths-webpack-plugin": "^2.4.0",
         "cjs-module-lexer": "^1.2.3",
         "css-loader": "^7.1.2",
@@ -33019,7 +33000,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^10.3.4"
+        "storybook": "^10.3.6"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -33028,9 +33009,9 @@
       }
     },
     "node_modules/@storybook/core-webpack": {
-      "version": "10.3.4",
-      "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-10.3.4.tgz",
-      "integrity": "sha512-y7TEIxd8melHWD6XvdoFWo2u0VUGIm2/LxOI2qWWfdT7hQL47WHsN52eKkOBaAEJ8HQYyT3ajRS9wGSnhu6KaQ==",
+      "version": "10.3.6",
+      "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-10.3.6.tgz",
+      "integrity": "sha512-qgKT6+L3uoIaphxidJUsz5Jxi1HEQvaG54cb4Au49YIdV8i9eYKB8MZzAo3jUwJWnPcIuf8OQDXs32gWovHX0w==",
       "license": "MIT",
       "dependencies": {
         "ts-dedent": "^2.0.0"
@@ -33040,41 +33021,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^10.3.4"
-      }
-    },
-    "node_modules/@storybook/csf-plugin": {
-      "version": "10.3.4",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.3.4.tgz",
-      "integrity": "sha512-WPP0Z39o82WiohPkhPOs6z+9yJ+bVvqPz4d+QUPfE6FMvOOBLojlwOcGx6Xmclyn5H/CKwywFrjuz4mBO/nHhA==",
-      "license": "MIT",
-      "dependencies": {
-        "unplugin": "^2.3.5"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "esbuild": "*",
-        "rollup": "*",
-        "storybook": "^10.3.4",
-        "vite": "*",
-        "webpack": "*"
-      },
-      "peerDependenciesMeta": {
-        "esbuild": {
-          "optional": true
-        },
-        "rollup": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        },
-        "webpack": {
-          "optional": true
-        }
+        "storybook": "^10.3.6"
       }
     },
     "node_modules/@storybook/global": {
@@ -33094,12 +33041,12 @@
       }
     },
     "node_modules/@storybook/preset-react-webpack": {
-      "version": "10.3.4",
-      "resolved": "https://registry.npmjs.org/@storybook/preset-react-webpack/-/preset-react-webpack-10.3.4.tgz",
-      "integrity": "sha512-3EK/aJtE0AK5nZh/k8jxS3y/ZGmOir06RIYY2KqOq55zD2iqS0tCwnhiKiLp8wQVsPAc7DuTCwG96kEkTrdU7g==",
+      "version": "10.3.6",
+      "resolved": "https://registry.npmjs.org/@storybook/preset-react-webpack/-/preset-react-webpack-10.3.6.tgz",
+      "integrity": "sha512-DpioH1j7zfztRmLCUV3K1R44rbmxhdEglzYZBfS7vYd6slME6+0W8Xx8eD+bzNEp4bk7gfmLexuXqmDghNiB8g==",
       "license": "MIT",
       "dependencies": {
-        "@storybook/core-webpack": "10.3.4",
+        "@storybook/core-webpack": "10.3.6",
         "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.0c3f3b7.0",
         "@types/semver": "^7.7.1",
         "magic-string": "^0.30.5",
@@ -33116,7 +33063,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.3.4"
+        "storybook": "^10.3.6"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -33125,13 +33072,13 @@
       }
     },
     "node_modules/@storybook/react": {
-      "version": "10.3.4",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-10.3.4.tgz",
-      "integrity": "sha512-I5ifYqjrqyuhOFjalpy47kMKMXX7QU/qmHj0h/547s9Bg6sEU7xRhJnneXx1RJsEJTySjC4SmGfEU+FJz4Foiw==",
+      "version": "10.3.6",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-10.3.6.tgz",
+      "integrity": "sha512-oZQZ6xayWe5IdHmFUTL0TL8rX/gpNNh9gWhT2vzW5eeUvlkVG/RBKdsja6Ndrk2s1D9vcnwiI6r6CNXy3IEEmg==",
       "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",
-        "@storybook/react-dom-shim": "10.3.4",
+        "@storybook/react-dom-shim": "10.3.6",
         "react-docgen": "^8.0.2",
         "react-docgen-typescript": "^2.2.2"
       },
@@ -33142,7 +33089,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.3.4",
+        "storybook": "^10.3.6",
         "typescript": ">= 4.9.x"
       },
       "peerDependenciesMeta": {
@@ -33170,30 +33117,15 @@
         "webpack": ">= 4"
       }
     },
-    "node_modules/@storybook/react-dom-shim": {
-      "version": "10.3.4",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.3.4.tgz",
-      "integrity": "sha512-VIm9YzreGubnOtQOZ6iqEfj6KncHvAkrCR/IilqnJq7DidPWuykrFszyajTASRMiY+p+TElOW+O1PGpv55qNGw==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.3.4"
-      }
-    },
     "node_modules/@storybook/react-webpack5": {
-      "version": "10.3.4",
-      "resolved": "https://registry.npmjs.org/@storybook/react-webpack5/-/react-webpack5-10.3.4.tgz",
-      "integrity": "sha512-Qf3weT1xGMBzJ10phyDVBOCva8kHnF6PQ8OvAdL9CUUoJivG5AmOb+EsLvHcSG9ypWCNhpd52tyX20yIohPZbg==",
+      "version": "10.3.6",
+      "resolved": "https://registry.npmjs.org/@storybook/react-webpack5/-/react-webpack5-10.3.6.tgz",
+      "integrity": "sha512-Z4a/tw3O1I5p4mo4ibmcWYt6CUF+b2DneDKbduqRzQ3QF1d8Sw+PBVd8ddTfFxeoFxyUB4dBsFk1X4HQZ3mfNg==",
       "license": "MIT",
       "dependencies": {
-        "@storybook/builder-webpack5": "10.3.4",
-        "@storybook/preset-react-webpack": "10.3.4",
-        "@storybook/react": "10.3.4"
+        "@storybook/builder-webpack5": "10.3.6",
+        "@storybook/preset-react-webpack": "10.3.6",
+        "@storybook/react": "10.3.6"
       },
       "funding": {
         "type": "opencollective",
@@ -33202,13 +33134,28 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.3.4",
+        "storybook": "^10.3.6",
         "typescript": ">= 4.9.x"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@storybook/react/node_modules/@storybook/react-dom-shim": {
+      "version": "10.3.6",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.3.6.tgz",
+      "integrity": "sha512-/Tu1gPu+Fw+zOnAGmxRmOD30FX3a04LxcTAKflEtdpmtIMVR5bA3qpjy+f5YhoyDCecbXyKmL1OeIU2FIIZHqQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.3.6"
       }
     },
     "node_modules/@storybook/react/node_modules/react-docgen": {
@@ -33398,12 +33345,6 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "license": "MIT"
     },
-    "node_modules/@types/mdx": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.13.tgz",
-      "integrity": "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==",
-      "license": "MIT"
-    },
     "node_modules/@types/node": {
       "version": "25.5.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
@@ -33411,16 +33352,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
-      }
-    },
-    "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/resolve": {
@@ -33678,9 +33609,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -33838,9 +33769,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -34207,13 +34138,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/csstype": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -34871,9 +34795,9 @@
       }
     },
     "node_modules/html-webpack-plugin": {
-      "version": "5.6.6",
-      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.6.tgz",
-      "integrity": "sha512-bLjW01UTrvoWTJQL5LsMRo1SypHW80FTm12OJRSnr3v6YHNhfe+1r0MYUZJMACxnCHURVnBWRwAsWs2yPU9Ezw==",
+      "version": "5.6.7",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.7.tgz",
+      "integrity": "sha512-md+vXtdCAe60s1k6AU3dUyMJnDxUyQAwfwPKoLisvgUF1IXjtlLsk2se54+qfL9Mdm26bbwvjJybpNx48NKRLw==",
       "license": "MIT",
       "dependencies": {
         "@types/html-minifier-terser": "^6.0.0",
@@ -35167,9 +35091,9 @@
       }
     },
     "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -35401,9 +35325,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -35665,9 +35589,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",
@@ -36133,9 +36057,9 @@
       }
     },
     "node_modules/storybook": {
-      "version": "10.3.4",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.3.4.tgz",
-      "integrity": "sha512-866YXZy9k59tLPl9SN3KZZOFeBC/swxkuBVtW8iQjJIzfCrvk7zXQd8RSQ4ignmCdArVvY4lGMCAT4yNaZSt1g==",
+      "version": "10.3.6",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.3.6.tgz",
+      "integrity": "sha512-vbSz7g/1rGMC1uAULqMZjALkIuLu2QABqfhRYhyr/11kzyesi+vAmwyJLukZP1FfecxGOgMwOh6GS0YsGpHAvQ==",
       "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",
@@ -36160,10 +36084,14 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "prettier": "^2 || ^3"
+        "prettier": "^2 || ^3",
+        "vite-plus": "^0.1.15"
       },
       "peerDependenciesMeta": {
         "prettier": {
+          "optional": true
+        },
+        "vite-plus": {
           "optional": true
         }
       }
@@ -36458,33 +36386,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/unplugin": {
-      "version": "2.3.11",
-      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
-      "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/remapping": "^2.3.5",
-        "acorn": "^8.15.0",
-        "picomatch": "^4.0.3",
-        "webpack-virtual-modules": "^0.6.2"
-      },
-      "engines": {
-        "node": ">=18.12.0"
-      }
-    },
-    "node_modules/unplugin/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -36644,9 +36545,9 @@
       }
     },
     "node_modules/webpack-dev-middleware/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",

--- a/samples/sampler/package.json
+++ b/samples/sampler/package.json
@@ -26,13 +26,13 @@
     "@enact/spotlight": "^5.4.2",
     "@enact/storybook-utils": "^8.0.0",
     "@enact/ui": "^5.4.2",
-    "@storybook/addon-docs": "^10.3.4",
-    "@storybook/react-webpack5": "^10.3.4",
+    "@github-ui/storybook-addon-performance-panel": "^1.1.4",
+    "@storybook/react-webpack5": "^10.3.5",
     "dotenv": "^16.5.0",
     "ilib": "^14.21.2",
     "prop-types": "^15.8.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "storybook": "^10.3.4"
+    "storybook": "^10.3.5"
   }
 }


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](https://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](https://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Added performance addon for storybook to have a live preview of major performance indicators. It can be enabled when setting a flag


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Removed storybook/addon-docs from sampler app as it was not directly used. This dependency was causing extra rerenders on each component update.
Removing this dependency was causing an error on story load "Cannot read properties of null (reading 'useEffect')", caused by the fact that storybook and other enact dependencies might have different React versions. This was solved by forcing a single React version in webpack configuration

### Links
[//]: # (Related issues, references)
NXT-12996

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian ([daniel.stoian@lgepartner.com](mailto:daniel.stoian@lgepartner.com))