### PR TITLE
NXT-15800: Removed react-is override dependency

### DIFF
--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Clone and setup Enact CLI
         run: |
-          git clone --branch=feature/NXT-15800 --depth 1 https://github.com/enactjs/cli ../cli
+          git clone --branch=develop --depth 1 https://github.com/enactjs/cli ../cli
           pushd ../cli
           npm install
           npm link

--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Clone and setup Enact CLI
         run: |
-          git clone --branch=develop --depth 1 https://github.com/enactjs/cli ../cli
+          git clone --branch=feature/NXT-15800 --depth 1 https://github.com/enactjs/cli ../cli
           pushd ../cli
           npm install
           npm link

--- a/package.json
+++ b/package.json
@@ -63,9 +63,6 @@
   },
   "overrides": {
     "autolinker": "^4.1.5",
-    "prop-types": {
-      "react-is": "^19.2.3"
-    },
     "vue-template-compiler": "^3.0.0"
   }
 }

--- a/samples/sampler/.qa-storybook/main.js
+++ b/samples/sampler/.qa-storybook/main.js
@@ -53,11 +53,13 @@ export default {
 		// which causes "Cannot read properties of null (reading 'useEffect')"
 		const reactDir = dirname(moduleRequire.resolve('react/package.json'));
 		const reactDomDir = dirname(moduleRequire.resolve('react-dom/package.json'));
+		const reactIsDir = dirname(moduleRequire.resolve('react-is/package.json'));
 		webpackFinalConfig.resolve = webpackFinalConfig.resolve || {};
 		webpackFinalConfig.resolve.alias = {
 			...(webpackFinalConfig.resolve.alias || {}),
 			react: reactDir,
-			'react-dom': reactDomDir
+			'react-dom': reactDomDir,
+			'react-is': reactIsDir
 		};
 
 		return webpackFinalConfig;

--- a/samples/sampler/.storybook/main.js
+++ b/samples/sampler/.storybook/main.js
@@ -53,11 +53,13 @@ export default {
 		// which causes "Cannot read properties of null (reading 'useEffect')"
 		const reactDir = dirname(moduleRequire.resolve('react/package.json'));
 		const reactDomDir = dirname(moduleRequire.resolve('react-dom/package.json'));
+		const reactIsDir = dirname(moduleRequire.resolve('react-is/package.json'));
 		webpackFinalConfig.resolve = webpackFinalConfig.resolve || {};
 		webpackFinalConfig.resolve.alias = {
 			...(webpackFinalConfig.resolve.alias || {}),
 			react: reactDir,
-			'react-dom': reactDomDir
+			'react-dom': reactDomDir,
+			'react-is': reactIsDir
 		};
 
 		return webpackFinalConfig;

--- a/samples/sampler/npm-shrinkwrap.json
+++ b/samples/sampler/npm-shrinkwrap.json
@@ -22,6 +22,7 @@
         "prop-types": "^15.8.1",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
+        "react-is": "^19.2.6",
         "storybook": "^10.3.6"
       }
     },

--- a/samples/sampler/package.json
+++ b/samples/sampler/package.json
@@ -33,6 +33,7 @@
     "prop-types": "^15.8.1",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
+    "react-is": "^19.2.6",
     "storybook": "^10.3.6"
   }
 }


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Removed react-is override dependency from agate as it is handled in enact/cli

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Removed react-is dependency from agate sampler as storybook does not use enact cli

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
temmporary set feature branch of cli

### Links
[//]: # (Related issues, references)
NXT-15800

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian ([daniel.stoian@lgepartner.com](mailto:daniel.stoian@lgepartner.com))